### PR TITLE
recipe tweak - fixes #69

### DIFF
--- a/recipes/augments/augment_regen1.recipe
+++ b/recipes/augments/augment_regen1.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "microchip", "count" : 2 },
+    { "item" : "advcircuit", "count" : 2 },
     { "item" : "ff_plastic", "count" : 2 },
     { "item" : "miraclegrass", "count" : 5 }
   ],


### PR DESCRIPTION
replace microchip (deprecated) recipe input with advcircuit as current with the other tier1 augments. 