### PR TITLE
fix #65 - adds Frackin' Universe's ores to vanilla ore detector

### DIFF
--- a/items/active/unsorted/oredetector/oredetector.activeitem.patch
+++ b/items/active/unsorted/oredetector/oredetector.activeitem.patch
@@ -1,0 +1,14 @@
+[
+    { "op": "remove", "path": "/pingDetectConfig/colors/none",       "value": [120, 160, 120,  50] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/berlinite",  "value": [141, 117, 113, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/lazulite",   "value": [ 94, 103, 147, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/lead",       "value": [102, 102, 102, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/magnesium",  "value": [120, 125, 117, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/mascagnite", "value": [185, 165, 148, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/moonstone",  "value": [223, 219,  97, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/neptunium",  "value": [173, 129, 192, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/plutonium",  "value": [211,  69, 195, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/sulphur",    "value": [165, 159, 106, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/thorium",    "value": [128, 172, 193, 255] },
+    { "op": "add",    "path": "/pingDetectConfig/colors/none",       "value": [120, 160, 120,  50] }
+]


### PR DESCRIPTION
Does what it says on the tin. Patch in color assignments to the ore detector to support ores added by Frackin' Universe. Colors chosen with a sampled average color of the tile graphics for respective ores.

I couldn't find a way to add a line "second to last" so instead am first removing the last item (none) and placing it back in after the new additions.