### PR TITLE
Beekeeper's Hat fixes, atmosphere regulator fix

### DIFF
--- a/items/bees/other/waxchunk.item
+++ b/items/bees/other/waxchunk.item
@@ -6,5 +6,6 @@
   "description" : "A chunk of beeswax.",
   "handPosition" : [0.0, 0],
   "shortdescription" : "Beeswax",
+  "learnBlueprintsOnPickup" : [ "fubeekeeperhead" ],
   "itemTags" : [ "reagent" ]
 }

--- a/items/bees/vmite/beeflowerhead.item
+++ b/items/bees/vmite/beeflowerhead.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "The head of a Beeflower. Contains traces of anti-mite poison!",
   "shortdescription" : "Flower Head",
-  "maxStack" : 600
+  "maxStack" : 600,
+  "itemTags" : [ "reagent" ]
 }

--- a/objects/power/isn_atmosregulator/isn_atmosprotection.lua
+++ b/objects/power/isn_atmosregulator/isn_atmosprotection.lua
@@ -1,5 +1,5 @@
 function init()
-  status.setPersistentEffects("fu_protoprotection", {{stat = "protoImmunity", amount = 1}}
+  status.setPersistentEffects("fu_protoprotection", {{stat = "protoImmunity", amount = 1}})
   status.setPersistentEffects("isn_airprotection2", {{stat = "waterbreathProtection", amount = 1}})
   status.setPersistentEffects("isn_airprotection", {{stat = "breathProtection", amount = 1}})
   status.setPersistentEffects("isn_radsprotection", {{stat = "biomeradiationImmunity", amount = 1}})

--- a/recipes/armor/fubeekeeper.recipe
+++ b/recipes/armor/fubeekeeper.recipe
@@ -1,11 +1,12 @@
 {
   "input" : [
     { "item" : "fabric", "count" : 4 },
-    { "item" : "polymer", "count" : 2 }
+    { "item" : "polymer", "count" : 2 },
+	{ "item" : "flowercomb", "count" : 1 }
   ],
   "output" : {
     "item" : "fubeekeeperhead",
     "count" : 1
   },
-  "groups" : [ "armory", "armor", "other" ]
+  "groups" : [ "clothingfabricator", "beestation", "armors", "other" ]
 }


### PR DESCRIPTION
The beekeeper's hat (fubeekeeperhead) is a cut-price version of the beekeeper's armor. No bonuses, but immune to stings. Was already in, but inactive.

Fix for typo in atmosphere regulator projectile Lua.