### PR TITLE
Power supply: small optimisations and battery drainage improvement

### DIFF
--- a/objects/power/fu_conduit/fu_conduit.lua
+++ b/objects/power/fu_conduit/fu_conduit.lua
@@ -10,7 +10,7 @@ end
 function isn_getCurrentPowerOutput(divide)
 	local divisor = isn_countPowerDevicesConnectedOnOutboundNode(0)
 	local voltage = isn_getCurrentPowerInput(true)
-	if divide and divisor > 0 then return voltage / divisor
+	if voltage and divide and divisor > 0 then return voltage / divisor
 	else return voltage end
 end
 

--- a/objects/power/isn_battery.lua
+++ b/objects/power/isn_battery.lua
@@ -47,9 +47,14 @@ function isn_getCurrentPowerStorage()
 	return isn_getXPercentageOfY(storage.currentstoredpower,storage.powercapacity)
 end
 
+function isn_hasStoredPower()
+	if not storage.active then return false end  -- This might be pointless. Need to think about it. -r
+	return storage.currentstoredpower > 0
+end
+
 function isn_getCurrentPowerOutput(divide)
-	if not storage.active then return 0 end  -- This might be pointless. Need to think about it. -r
-	if storage.currentstoredpower <= 0 then return 0 end
+	if not isn_hasStoredPower() then return 0 end
+
 	local divisor = isn_countPowerDevicesConnectedOnOutboundNode(0)
 	
 	-- if divisor < 1 then return 0 end

--- a/objects/power/isn_battery.lua
+++ b/objects/power/isn_battery.lua
@@ -25,7 +25,7 @@ function update(dt)
 	end
 	
 	local powerinput = isn_getCurrentPowerInput(true)
-	if powerinput >= 1 then
+	if powerinput and powerinput >= 1 then
 		storage.currentstoredpower = storage.currentstoredpower + powerinput
 		-- sb.logInfo(string.format("Storing %.2fu, now at %.2fu", powerinput, storage.currentstoredpower))
 	end

--- a/objects/power/isn_sharedpowerscripts.lua
+++ b/objects/power/isn_sharedpowerscripts.lua
@@ -2,14 +2,12 @@ function isn_getCurrentPowerInput(divide)
 	-- sb.logInfo("POWER INPUT DEBUG aka PID")
 	-- sb.logInfo("called by " .. world.entityName(entity.id()))
 	local totalInput = 0
-	local iterator = 0
 	local connectedDevices
 	local output = 0
 	
-	local nodecount = object.inputNodeCount() 
-	-- sb.logInfo("PID: nodecount is " .. nodecount)
+	-- sb.logInfo("PID: nodecount is " .. object.inputNodeCount())
 	
-	while iterator < nodecount do
+	for iterator = 0, object.inputNodeCount() - 1 do
 		-- sb.logInfo("PID: Iteration " .. iterator)
 		if object.getInputNodeLevel(iterator) then
 			connectedDevices = isn_getAllDevicesConnectedOnNode(iterator,"input")
@@ -27,7 +25,6 @@ function isn_getCurrentPowerInput(divide)
 			end
 		end
 		-- sb.logInfo("PID: total input now at " .. totalInput)
-		iterator = iterator + 1
 	end
 	
 	-- sb.logInfo("GENERAL POWER INPUT DEBUG END")
@@ -92,11 +89,8 @@ end
 
 function isn_activeConsumption()
 	if config.getParameter("isn_powerPassthrough") then -- It's a conduit (or similar device), better check what downstream says -r
-		local nodecount = object.outputNodeCount()
-		local iterator = 0
-		while iterator < nodecount do
+		for iterator = 0, object.outputNodeCount() - 1 do
 			if isn_areActivePowerDevicesConnectedOnOutboundNode(iterator) then return true end
-			iterator = iterator + 1
 		end
 		return false
 	end

--- a/objects/power/isn_sharedpowerscripts.lua
+++ b/objects/power/isn_sharedpowerscripts.lua
@@ -1,9 +1,14 @@
 function isn_getCurrentPowerInput(divide)
+	--- If this is not a battery and a passthrough is connected, there must only be one and no PSUs except those connected via it
+	--- If that condition is not met, this function returns nil
 	-- sb.logInfo("POWER INPUT DEBUG aka PID")
 	-- sb.logInfo("called by " .. world.entityName(entity.id()))
 	local totalInput = 0
 	local connectedDevices
 	local output = 0
+	local hasPSU = false
+	local hasPassthrough = false
+	local isBattery = isn_isBattery()
 	
 	-- sb.logInfo("PID: nodecount is " .. object.inputNodeCount())
 	
@@ -16,6 +21,17 @@ function isn_getCurrentPowerInput(divide)
 				-- sb.logInfo("PID: value is " .. value)
 				-- sb.logInfo("PID: value ID check resolves to " .. world.entityName(value))
 				if world.callScriptedEntity(value,"isn_canSupplyPower") then
+					if not isBattery then
+						local isPassthrough = world.callScriptedEntity(value,"isn_isPowerPassthrough")
+						if isPassthrough then
+							if hasPSU or hasPassthrough then return nil end --ERROR (passthrough; already found a PSU or passthrough)
+							hasPassthrough = true
+						else
+							if hasPassthrough then return nil end --ERROR (PSU; already found a passthrough)
+							hasPSU = true
+						end
+					end
+
 					output = world.callScriptedEntity(value,"isn_getCurrentPowerOutput",divide)
 					-- sb.logInfo("PID: Power supplier detected with output of " .. output)
 					if output ~= nil then totalInput = totalInput + output end
@@ -31,6 +47,24 @@ function isn_getCurrentPowerInput(divide)
 	return totalInput
 end
 
+function isn_countCurrentPowerInputs()
+	local connectedDevices
+	local psus = 0
+	local totalInput = 0
+
+	for iterator = 0, object.inputNodeCount() - 1 do
+		if object.getInputNodeLevel(iterator) then
+			connectedDevices = isn_getAllDevicesConnectedOnNode(iterator,"input")
+			for key, value in pairs (connectedDevices) do
+				if world.callScriptedEntity(value, "isn_hasStoredPower") or world.callScriptedEntity(value, "isn_isPowerPassthrough")  then
+					psus = psus + 1
+				end
+			end
+		end
+	end
+	return psus
+end
+
 function isn_hasRequiredPower()
 	local power = isn_getCurrentPowerInput(true)
 	local requirement = config.getParameter("isn_requiredPower")
@@ -41,13 +75,23 @@ function isn_hasRequiredPower()
 	else return false end
 end
 
-function isn_requiredPowerValue()
+function isn_requiredPowerValue(persupply)
+	local req
+	local conduit = false
+
 	if config.getParameter("isn_powerPassthrough") then
 		-- It's a conduit, or a similar device. Check what downstream says.
-		return isn_sumPowerActiveDevicesConnectedOnOutboundNode(0)
+		req = isn_sumPowerActiveDevicesConnectedOnOutboundNode(0)
+		conduit = true
 	else
-		return config.getParameter("isn_requiredPower")
+		req = config.getParameter("isn_requiredPower")
 	end
+
+	-- If requested, get the number of connected active power supplies and split the power requirement equally across them
+	-- (mainly because we don't know which PSU is calling us)
+	local psus = persupply and isn_countCurrentPowerInputs() or 0
+
+	return psus > 0 and req / psus or req
 end
 
 function isn_canSupplyPower()
@@ -62,6 +106,11 @@ end
 
 function isn_doesNotConsumePower()
 	if config.getParameter("isn_freePower") then return true
+	else return false end
+end
+
+function isn_isPowerPassthrough()
+	if config.getParameter("isn_powerPassthrough") then return true
 	else return false end
 end
 
@@ -142,8 +191,9 @@ function isn_sumPowerActiveDevicesConnectedOnOutboundNode(node)
 		if world.callScriptedEntity(value,"isn_canRecievePower") then
 			if not world.callScriptedEntity(value,"isn_doesNotConsumePower") then
 				if world.callScriptedEntity(value,"isn_activeConsumption") then
-					voltagecount = voltagecount + world.callScriptedEntity(value,"isn_requiredPowerValue")
-					-- sb.logInfo("Found a consumer, " .. value .. ", total increased to " .. voltagecount)
+					-- allow for the consumer's power requirement being spread across several supplies
+					voltagecount = voltagecount + world.callScriptedEntity(value,"isn_requiredPowerValue", true)
+					-- sb.logInfo(entity.id() .. ": Found a consumer, " .. value .. ", requiring " .. world.callScriptedEntity(value,"isn_requiredPowerValue", true) .. "; total increased to " .. voltagecount)
 				end
 			end
 		end


### PR DESCRIPTION
Powering a device from more than one battery now properly spreads the load, rather than draining as if it were n devices each connected to a different one of n batteries.

However, for accurate calculation (given the current state of the code), there is a limitation:
- you may connect any number of direct power supplies (batteries and/or generators); or
- you may connect one indirect power supply (wire relay) only..

Power sensors will, when misconnected, indicate ‘invalid’.

`isn_getCurrentPowerInput()` may return `nil`.