### PR TITLE
The Big Bee Patch

### DIFF
--- a/interface/windowconfig/beestation.config
+++ b/interface/windowconfig/beestation.config
@@ -1,5 +1,5 @@
 {
-"requiresBlueprint" : false,
+"requiresBlueprint" : true,
   "paneLayout" : {
     "background" : {
       "type" : "background",
@@ -232,7 +232,7 @@
           "baseImage" : "/interface/crafting/objects.png",
           "baseImageChecked" : "/interface/crafting/objectsSelected.png",
           "data" : {
-            "filter" : [ "objects" ]
+            "filter" : [ "objects" , "furniture" ]
           }
         },
         {
@@ -242,7 +242,7 @@
           "data" : {
             "filter" : [ "other" ]
           }
-        }        
+        }
       ]
     },
     "rarities" : {
@@ -253,13 +253,3 @@
     }
   }
 }
-
-
-
-
-
-
-
-
-
-

--- a/items/active/shields/fubeeshield.activeitem
+++ b/items/active/shields/fubeeshield.activeitem
@@ -2,9 +2,9 @@
   "itemName" : "fubeeshield",
   "price" : 100,
   "maxStack" : 1,
-  "rarity" : "uncommon",
+  "rarity" : "legendary",
   "shortdescription" : "Queen's Shield",
-  "tooltipKind" : "shieldnew",  
+  "tooltipKind" : "shieldnew",
   "description" : "Represent for the Queen.",
   "twoHanded" : false,
   "itemTags" : ["shield"],
@@ -34,7 +34,7 @@
 
   "perfectBlockDirectives" : "?border=2;AACCFFFF;00000000",
   "perfectBlockTime" : 0.2,
-  
+
   "stances" : {
     "idle" : {
       "armRotation" : -90,

--- a/items/active/shields/fubeeshield2.activeitem
+++ b/items/active/shields/fubeeshield2.activeitem
@@ -2,18 +2,18 @@
   "itemName" : "fubeeshield2",
   "price" : 100,
   "maxStack" : 1,
-  "rarity" : "uncommon",
+  "rarity" : "rare",
   "shortdescription" : "Amber Shield",
-  "tooltipKind" : "shieldnew",  
+  "tooltipKind" : "shieldnew",
   "description" : "Chock full of dino-dna!",
   "twoHanded" : false,
   "itemTags" : ["shield"],
 
-  "inventoryIcon" : "images/fubeeshield.png:nearidle",
+  "inventoryIcon" : "images/fubeeshield2.png:nearidle",
 
   "animation" : "shield.animation",
   "animationParts" : {
-    "shield" : "images/fubeeshield.png"
+    "shield" : "images/fubeeshield2.png"
   },
   "animationCustom" : {
     "sounds" : {
@@ -34,7 +34,7 @@
 
   "perfectBlockDirectives" : "?border=2;AACCFFFF;00000000",
   "perfectBlockTime" : 0.2,
-  
+
   "stances" : {
     "idle" : {
       "armRotation" : -90,

--- a/items/active/weapons/melee/broadsword/fuambersword.activeitem
+++ b/items/active/weapons/melee/broadsword/fuambersword.activeitem
@@ -3,7 +3,7 @@
   "price" : 1500,
   "level" : 4,
   "maxStack" : 1,
-  "rarity" : "uncommon",
+  "rarity" : "rare",
   "description" : "Made from finely honed amber",
   "shortdescription" : "Amber Blade",
   "tooltipKind" : "sword",

--- a/items/active/weapons/melee/broadsword/fugoldenblade.activeitem
+++ b/items/active/weapons/melee/broadsword/fugoldenblade.activeitem
@@ -3,7 +3,7 @@
   "price" : 1500,
   "level" : 4,
   "maxStack" : 1,
-  "rarity" : "uncommon",
+  "rarity" : "rare",
   "description" : "Impossible. Weaponized honey.",
   "shortdescription" : "Golden Honey Blade",
   "tooltipKind" : "sword",

--- a/items/active/weapons/melee/broadsword/fupetalsword.activeitem
+++ b/items/active/weapons/melee/broadsword/fupetalsword.activeitem
@@ -3,7 +3,7 @@
   "price" : 1500,
   "level" : 4,
   "maxStack" : 1,
-  "rarity" : "uncommon",
+  "rarity" : "legendary",
   "description" : "The blade of a bee queen",
   "shortdescription" : "Queen Blade",
   "tooltipKind" : "sword",

--- a/items/active/weapons/melee/shortsword/redwaxsword.activeitem
+++ b/items/active/weapons/melee/shortsword/redwaxsword.activeitem
@@ -4,7 +4,7 @@
   "level" : 5,
   "maxStack" : 1,
   "rarity" : "uncommon",
-  "description" : "Useless",
+  "description" : "Still Useless",
   "shortdescription" : "Red Wax Sword",
   "tooltipKind" : "sword",
   "category" : "shortsword",
@@ -18,7 +18,7 @@
     "handle" : "",
     "blade" : "redwaxsword.png"
   },
-  
+
   "animationCustom" : { },
 
   "scripts" : ["/items/active/weapons/melee/meleeweapon.lua"],
@@ -30,7 +30,7 @@
     "fireTime" : 0.43,
     "baseDps" : 2.5
   },
-  
+
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
-  
+
 }

--- a/items/active/weapons/melee/shortsword/waxsword.activeitem
+++ b/items/active/weapons/melee/shortsword/waxsword.activeitem
@@ -18,19 +18,19 @@
     "handle" : "",
     "blade" : "waxsword.png"
   },
-  
+
   "animationCustom" : { },
 
   "scripts" : ["/items/active/weapons/melee/meleeweapon.lua"],
 
-  "elementalType" : "electric",
+  "elementalType" : "physical",
 
   "primaryAbilityType" : "shortswordcombo",
   "primaryAbility" : {
     "fireTime" : 0.25,
     "baseDps" : 2.5
   },
-  
+
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
-  
+
 }

--- a/items/bees/bees/adaptive/adaptivequeen.item
+++ b/items/bees/bees/adaptive/adaptivequeen.item
@@ -6,5 +6,5 @@
   "description" : "A queen bee with no preference for the heat or the cold.",
   "shortdescription" : "Adaptive Queen",
   "maxStack" : 1000,
-  "learnBlueprintsOnPickup" : [ "fuqueenhead", "fuqueenchest", "fuqueenlegs" ]
+  "learnBlueprintsOnPickup" : [ "fuqueenhead", "fuqueenchest", "fuqueenlegs" , "fubeeshield1"]
 }

--- a/items/bees/bees/flower/flowerqueen.item
+++ b/items/bees/bees/flower/flowerqueen.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "A flowery bee queen.",
   "shortdescription" : "Flower Queen",
-  "maxStack" : 1000
+  "maxStack" : 1000,
+  "learnBlueprintsOnPickup" : [ "scentedframe", "flowercandle", "scentedapiary"]
 }

--- a/items/bees/bees/forest/forestqueen.item
+++ b/items/bees/bees/forest/forestqueen.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "A forest queen, found in the depths of a forest.",
   "shortdescription" : "Forest Queen",
-  "maxStack" : 1000
+  "maxStack" : 1000,
+  "learnBlueprintsOnPickup" : [ "sweetframe" ]
 }

--- a/items/bees/bees/godly/godlyqueen.item
+++ b/items/bees/bees/godly/godlyqueen.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "A godly bee queen.",
   "shortdescription" : "Godly Queen",
-  "maxStack" : 1000
+  "maxStack" : 1000,
+  "learnBlueprintsOnPickup" : [ "godlyframe", "megahoneyhammer", "fusavethequeen", "fupetalsword"]
 }

--- a/items/bees/bees/jungle/junglequeen.item
+++ b/items/bees/bees/jungle/junglequeen.item
@@ -6,5 +6,5 @@
   "description" : "A jungle queen, a fine source of fiber!",
   "shortdescription" : "Jungle Queen",
   "maxStack" : 1000,
-  "learnBlueprintsOnPickup" : [ "fugoldenhead", "fugoldenchest", "fugoldenlegs" ]
+  "learnBlueprintsOnPickup" : [ "fugoldenhead", "fugoldenchest", "fugoldenlegs", "fubeeshield2" ]
 }

--- a/items/bees/bees/miner/minerqueen.item
+++ b/items/bees/bees/miner/minerqueen.item
@@ -5,5 +5,17 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "A variety of bee with an attraction to shiny objects.",
   "shortdescription" : "Miner Queen",
-  "maxStack" : 1000
+  "maxStack" : 1000,
+  "learnBlueprintsOnPickup" : [
+  "copperframe",
+  "silverframe",
+  "goldframe",
+  "diamondframe",
+  "ironframe",
+  "tungstenframe",
+  "titaniumframe",
+  "durasteelframe",
+  "feroziumframe",
+  "uraniumframe"
+  ]
 }

--- a/items/bees/bees/morbid/morbidqueen.item
+++ b/items/bees/bees/morbid/morbidqueen.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "A rather evil looking bee queen.",
   "shortdescription" : "Morbid Queen",
-  "maxStack" : 1000
+  "maxStack" : 1000,
+  "learnBlueprintsOnPickup" : [ "ghostcandle" ]
 }

--- a/items/bees/bees/nocturnal/nocturnalqueen.item
+++ b/items/bees/bees/nocturnal/nocturnalqueen.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "Dark and in charge.",
   "shortdescription" : "Nocturnal Queen",
-  "maxStack" : 1000
+  "maxStack" : 1000,
+  "learnBlueprintsOnPickup" : [ "eclipseframe"]
 }

--- a/items/bees/bees/normal/normalqueen.item
+++ b/items/bees/bees/normal/normalqueen.item
@@ -6,5 +6,5 @@
   "description" : "A bee queen.",
   "shortdescription" : "Honey Bee Queen",
   "maxStack" : 1000,
-  "learnBlueprintsOnPickup" : [ "fubeesuitchest", "fubeesuithead", "fubeesuitpants" ]
+  "learnBlueprintsOnPickup" : [ "fubeesuitchest", "fubeesuithead", "fubeesuitpants" , "waxsword" , "waxcandle", "provenframe"]
 }

--- a/items/bees/bees/plutonium/plutoniumqueen.item
+++ b/items/bees/bees/plutonium/plutoniumqueen.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "A plutonium queen. Just one sting could give you superpowers.. or kill you!",
   "shortdescription" : "Plutonium Queen",
-  "maxStack" : 1000
+  "maxStack" : 1000,
+  "learnBlueprintsOnPickup" : [ "plutoniumframe" ]
 }

--- a/items/bees/bees/red/redqueen.item
+++ b/items/bees/bees/red/redqueen.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "A bright red queen.",
   "shortdescription" : "Red Queen",
-  "maxStack" : 1000
+  "maxStack" : 1000,
+  "learnBlueprintsOnPickup" : [ "redwaxsword" , "redcandle" ]
 }

--- a/items/bees/bees/sun/sunqueen.item
+++ b/items/bees/bees/sun/sunqueen.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "A glowing queen from the sun itself.",
   "shortdescription" : "Sun Queen",
-  "maxStack" : 1000
+  "maxStack" : 1000,
+  "learnBlueprintsOnPickup" : [ "solarframe" ]
 }

--- a/items/generic/crafting/fissionfurnace/fuamberchunk.item
+++ b/items/generic/crafting/fissionfurnace/fuamberchunk.item
@@ -6,6 +6,10 @@
   "inventoryIcon" : "fuamberchunk.png",
   "description" : "A chunk of solid amber.",
   "shortdescription" : "Amber Chunk",
-  "learnBlueprintsOnPickup" : [ "fuamberchunk", "fulightpriestchest", "fulightpriesthead", "fulightpriestpants" ],
+  "learnBlueprintsOnPickup" : [ "fuamberchunk", "fulightpriestchest", "fulightpriesthead", "fulightpriestpants",
+  "ambersword",
+  "fugoldenblade",
+  "honeyhammer"
+  ],
   "itemTags" : [ "reagent" ]
 }

--- a/items/generic/crafting/ironbar.item.patch
+++ b/items/generic/crafting/ironbar.item.patch
@@ -1,18 +1,19 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [     
+	{"op":"add","path":"/learnBlueprintsOnPickup","value": [
     "tier1bed",
     "tier1chair",
     "tier1door",
     "tier1light",
     "tier1switch",
     "tier1table",
-    "beestation", 
-    "armoredsnowpants", 
+    "beestation",
+    "armoredsnowpants",
     "bonemealmaterial",
     "armory",
     "armoredsnowpants",
     "retexgreenhouse",
     "fucultaxe",
-    "stabfists"
+    "stabfists",
+		"bees_ironcentrifuge"
     ] }
 ]

--- a/items/generic/crafting/tungstenbar.item.patch
+++ b/items/generic/crafting/tungstenbar.item.patch
@@ -1,23 +1,25 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
+	{"op":"add","path":"/learnBlueprintsOnPickup","value": [
 	"mantizitier2pants",
 	"mantizitier2head",
 	"mantizitier2chest",
     "tungstenbow",
-    "hardenedsteelblade", 
-    "genecabinet", 
-    "genestorage", 
+    "hardenedsteelblade",
+    "genecabinet",
+    "genestorage",
     "fusteelgirdirmaterial",
     "microscope",
     "retexironblock",
-    "labfence", 
-    "isn_powersensor", 
-    "isn_solarpanel", 
-    "isn_hydroponicstray", 
+    "labfence",
+    "isn_powersensor",
+    "isn_solarpanel",
+    "isn_hydroponicstray",
     "isn_battery_t1",
  "fu_powersensorlarge",
  "isn_powersensor",
  "laspistol",
- "lasrifle"
+ "lasrifle",
+ "bees_industrialcentrifuge",
+ "honeyjarrer"
     ] }
 ]

--- a/items/liquids/fu_liquidhoney.liqitem
+++ b/items/liquids/fu_liquidhoney.liqitem
@@ -5,6 +5,6 @@
   "inventoryIcon" : "fu_liquidhoneyicon.png",
   "shortdescription" : "Pure Honey",
   "description" : "A measure of sweet, sweet honey.",
-  "learnBlueprintsOnPickup" : [ "honeycombmaterial", "fuhoneysilkbandage", "fuamberchunk", "fubeesuitchest", "fubeesuithead", "fubeesuitpants", "honeyham", "honeybread", "honeynutboltos", "orangehoneystraw", "neonhoneystraw", "honeystraw", "applehoneystraw", "grapehoneystraw" ],
+  "learnBlueprintsOnPickup" : [ "honeycombmaterial", "fuhoneysilkbandage", "fuamberchunk", "fubeesuitchest", "fubeesuithead", "fubeesuitpants", "honeyham", "honeybread", "honeynutboltos", "orangehoneystraw", "neonhoneystraw", "honeystraw", "applehoneystraw", "grapehoneystraw" , "833honeycrystalblock"],
   "liquid" : "fuhoney"
 }

--- a/objects/bees/beestation/beestation.object
+++ b/objects/bees/beestation/beestation.object
@@ -4,10 +4,10 @@
   "rarity" : "Common",
   "interactAction" : "OpenCraftingInterface",
   "interactData" : {
-    "config" : "/interface/windowconfig/beestation.config",  
+    "config" : "/interface/windowconfig/beestation.config",
     "filter" : [ "beestation" ]
   },
-  "learnBlueprintsOnPickup" : [ "normalalveary", "normalapiary", "beerefuge", "honeytable", "bees_industrialcentrifuge", "bees_ironcentrifuge", "bees_woodencentrifuge", "honeytable", "honeyextractor", "honeyjarrer", "scentedapiary" ],
+  "learnBlueprintsOnPickup" : [ "normalalveary", "normalapiary", "beerefuge", "honeytable", "bees_woodencentrifuge", "honeytable", "honeyextractor"],
   "printable" : false,
   "description" : "Craft all sorts of bee related items!",
   "shortdescription" : "^orange;Apiary Crafting Station^white;",

--- a/plants/flowers/Beeflower/beeflower.object
+++ b/plants/flowers/Beeflower/beeflower.object
@@ -36,5 +36,7 @@
       "harvestPool" : "beeflowerHarvest",
       "resetToStage" : 1
     }
-  ]
+  ],
+
+  "learnBlueprintOnPickup" : [ "amite" ]
 }

--- a/quests/bees/10industrialcentrifuge.questtemplate
+++ b/quests/bees/10industrialcentrifuge.questtemplate
@@ -2,12 +2,12 @@
   "id" : "10industrialcentrifuge",
   "prerequisites" : [ "9alveary" ],
   "title" : "^#1693d5;Industrial Edge",
-  "text" : "Now it's time to maximize your output. Build an ^orange;Industrial Centrifuge^reset;. You'll love it!",
+  "text" : "Now it's time to maximize your output. Build an ^orange;Industrial Centrifuge^reset;. You'll need to find some ^orange;arid bees^reset; to make the golden glass you need. Try the desert!",
   "completionText" : "Paired together with a Honey Jarrer, you'll get tons of honey.",
   "moneyRange" : [120, 220],
   "rewards" : [ ],
   "speaker" : "questGiver",
-  
+
   "updateDelta" : 10,
   "script" : "/quests/scripts/main.lua",
   "scriptConfig" : {
@@ -16,7 +16,7 @@
       "questStarted" : "questGiver",
       "questComplete" : "questGiver"
     },
-    
+
     "requireTurnIn" : true,
         "turnInDescription" : "Bring the ^orange;Industrial Centrifuge^reset; to the ^green;beekeeper^reset; at the ^orange;Science Outpost^reset;",
 

--- a/recipes/armor/bees/fubeeshield1.recipe
+++ b/recipes/armor/bees/fubeeshield1.recipe
@@ -2,11 +2,11 @@
   "input" : [
     { "item" : "fuamberchunk", "count" : 12 },
     { "item" : "fu_redhoneycombblock", "count" : 8 },
-    { "item" : "titaniumframe", "count" : 5 }
+    { "item" : "godlyframe", "count" : 5 }
   ],
   "output" : {
     "item" : "fubeeshield",
     "count" : 1
   },
-  "groups" : [ "beestation", "shield", "all" ]
+  "groups" : [ "beestation", "shield", "all", "armors" ]
 }

--- a/recipes/armor/bees/fubeeshield2.recipe
+++ b/recipes/armor/bees/fubeeshield2.recipe
@@ -2,11 +2,11 @@
   "input" : [
     { "item" : "fuamberchunk", "count" : 12 },
     { "item" : "fu_honeycombblock", "count" : 8 },
-    { "item" : "godlyframe", "count" : 5 }
+    { "item" : "titaniumframe", "count" : 5 }
   ],
   "output" : {
     "item" : "fubeeshield2",
     "count" : 1
   },
-  "groups" : [ "beestation", "shield", "all" ]
+  "groups" : [ "beestation", "shield", "all", "armors" ]
 }

--- a/recipes/bees/honeyjarrer.recipe
+++ b/recipes/bees/honeyjarrer.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
-   {"item" : "money", "count" : 500 }, 
-   { "item" : "tungstenbar", "count" : 35 },  
-   { "item" : "glass", "count" : 12 }
+   {"item" : "money", "count" : 500 },
+   { "item" : "tungstenbar", "count" : 35 },
+   { "item" : "goldenglass", "count" : 12 }
   ],
   "output" : {
     "item" : "honeyjarrer",

--- a/recipes/bees/industrialcentrifuge.recipe
+++ b/recipes/bees/industrialcentrifuge.recipe
@@ -1,9 +1,9 @@
 {
   "input" : [
-  { "item" : "money", "count" : 600 },   
-  { "item" : "tungstenbar", "count" : 46 }, 
-  { "item" : "glass", "count" : 24 },  
-  { "item" : "darkwoodmaterial", "count" : 8 }
+  { "item" : "money", "count" : 600 },
+  { "item" : "tungstenbar", "count" : 46 },
+  { "item" : "goldenglass", "count" : 24 },  
+  { "item" : "goldenplank", "count" : 8 }
   ],
   "output" : {
     "item" : "bees_industrialcentrifuge",

--- a/recipes/weapons/ambersword.recipe
+++ b/recipes/weapons/ambersword.recipe
@@ -8,5 +8,5 @@
     "item" : "fuambersword",
     "count" : 1
   },
-  "groups" : [ "beestation","melee", "all" ]
+  "groups" : [ "beestation","melee", "all", "weapons" ]
 }

--- a/recipes/weapons/fugoldenblade.recipe
+++ b/recipes/weapons/fugoldenblade.recipe
@@ -8,5 +8,5 @@
     "item" : "fugoldenblade",
     "count" : 1
   },
-  "groups" : [ "beestation","melee", "all" ]
+  "groups" : [ "beestation","melee", "all", "weapons" ]
 }

--- a/recipes/weapons/fupetalsword.recipe
+++ b/recipes/weapons/fupetalsword.recipe
@@ -2,11 +2,11 @@
   "input" : [
     { "item" : "fuamberchunk", "count" : 4 },
     { "item" : "petalblue", "count" : 10 },
-    { "item" : "ff_resin", "count" : 3 }
+    { "item" : "quietusbar", "count" : 3 }
   ],
   "output" : {
     "item" : "fupetalsword",
     "count" : 1
   },
-  "groups" : [ "beestation", "melee", "all" ]
+  "groups" : [ "beestation", "melee", "all", "weapons" ]
 }

--- a/recipes/weapons/fusavethequeen.recipe
+++ b/recipes/weapons/fusavethequeen.recipe
@@ -8,5 +8,5 @@
     "item" : "fusavethequeen",
     "count" : 1
   },
-  "groups" : [ "beestation","melee", "all" ]
+  "groups" : [ "beestation","melee", "all", "weapons" ]
 }

--- a/recipes/weapons/honeyhammer.recipe
+++ b/recipes/weapons/honeyhammer.recipe
@@ -8,5 +8,5 @@
     "item" : "fuhoneyhammer",
     "count" : 1
   },
-  "groups" : [ "beestation","melee", "all" ]
+  "groups" : [ "beestation","melee", "all", "weapons" ]
 }

--- a/recipes/weapons/megahoneyhammer.recipe
+++ b/recipes/weapons/megahoneyhammer.recipe
@@ -8,5 +8,5 @@
     "item" : "fumegahoneyhammer",
     "count" : 1
   },
-  "groups" : [ "beestation","melee", "all" ]
+  "groups" : [ "beestation","melee", "all", "weapons" ]
 }

--- a/tiles/materials/honey/fu_honeycombblock.matitem
+++ b/tiles/materials/honey/fu_honeycombblock.matitem
@@ -6,5 +6,12 @@
   "shortdescription" : "Honeycomb Block",
   "description" : "A block of honeycomb.",
   "materialId" : 6517,
-"learnBlueprintsOnPickup" : [ "honeyham", "fubeekeeperhead", "honeyplatform", "goldenplank", "honeystonebrick", "honeybread" ]
+"learnBlueprintsOnPickup" : [ "honeyham", "fubeekeeperhead", "honeyplatform", "goldenplank", "honeystonebrick", "honeybread" ,
+"fuhoneycombchest",
+"fuhoneycombchair",
+"fuhoneycombchair",
+"fuhoneycomblight",
+"fuhoneycombtable",
+"fuhoneycombcouch"
+]
 }

--- a/tiles/materials/honey/goldenplanks/goldenplank.matitem
+++ b/tiles/materials/honey/goldenplanks/goldenplank.matitem
@@ -7,6 +7,14 @@
   "shortdescription" : "Golden Planks",
   "glitchdescription" : "Statement. Wood.",
   "florandescription" : "Sssplintery wood.",
+  "learnBlueprintsOnPickup" : [
+  "fugoldenoakbed",
+  "fugoldenoakcabinet",
+  "fugoldenoakchest",
+  "fugoldenoakdoor",
+  "fuhoneybarrel",
+  "fuhoneybeesign"
+  ],
 
   "materialId" : 6514
 }


### PR DESCRIPTION
We're frackin golden guys just like the honey we make. Actually the majority of honey is not golden but that is neither here or there.

*Changelog
Catch and Crossbreed bees to get new Queens to Unlock More Recipes added to the Beestation!
The Industrial Centrifuge and Honey Jarrer now require Golden Glass as well as Golden Planks for the former. They are unlocked by tungstenbars.
The iron bar will unlock the iron centrifuge.
Amber Chunks unlock Mid Tier Weapons.
Godly Combs unlock High Tier Weapons.
Queens unlock the majority of recipes with the exception of the Tier 2-3 Centrifuge and Honey Jarrer which require bars to unlock.
.
*Bug Fixes
Bee Station Filtering Issue has been addressed.
Amber Shield is now uses correct images.

*Suggestion
1: Crystal bees that produce the Honey Crystal Block material for Honey Crystal Furniture.
