### PR TITLE
Couple bee fixes + Quantum Generator unlock

### DIFF
--- a/items/bees/other/beesilk.item
+++ b/items/bees/other/beesilk.item
@@ -5,5 +5,6 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "Strands of sticky silk! Craft with them!",
   "shortdescription" : "Bee Silk",
-  "learnBlueprintsOnPickup" : [ "fuhoneysilkbandage", "goldenfleece" ]
+  "learnBlueprintsOnPickup" : [ "fuhoneysilkbandage", "goldenfleece" ],
+  "itemTags" : [ "reagent" ]
 }

--- a/items/generic/crafting/fissionfurnace/fuamberchunk.item
+++ b/items/generic/crafting/fissionfurnace/fuamberchunk.item
@@ -1,15 +1,19 @@
 {
   "itemName" : "fuamberchunk",
   "rarity" : "rare",
-    "price" : 110,
+  "price" : 110,
   "category" : "craftingMaterial",
   "inventoryIcon" : "fuamberchunk.png",
   "description" : "A chunk of solid amber.",
   "shortdescription" : "Amber Chunk",
-  "learnBlueprintsOnPickup" : [ "fuamberchunk", "fulightpriestchest", "fulightpriesthead", "fulightpriestpants",
-  "ambersword",
-  "fugoldenblade",
-  "honeyhammer"
+  "learnBlueprintsOnPickup" : [
+	"fuamberchunk",
+	"fulightpriestchest",
+	"fulightpriesthead",
+	"fulightpriestpants",
+	"fuambersword",
+	"fugoldenblade",
+	"fuhoneyhammer"
   ],
   "itemTags" : [ "reagent" ]
 }

--- a/recipes/ff_stations/prototyper/fu_quantumgenerator.recipe
+++ b/recipes/ff_stations/prototyper/fu_quantumgenerator.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "isn_fissionreactor", "count" : 1 },
+    { "item" : "isn_fissionreactornew", "count" : 1 },
     { "item" : "nuclearcore", "count" : 2 },
     { "item" : "morphitebar", "count" : 6 },
     { "item" : "pyreitebar", "count" : 6 },


### PR DESCRIPTION
Fix unlocks for amber chunk. It was unlocking PGIs.
Add itemTag for bee silk to properly use the crafting ingredient tab.
Correct Quantum Generator unlock to use isn_fissionreactor**new**