### PR TITLE
Gemglow, Lumivine, Gold Shroom Spore corrections

### DIFF
--- a/items/generic/produce/gemglow.consumable
+++ b/items/generic/produce/gemglow.consumable
@@ -5,6 +5,14 @@
   "inventoryIcon" : "gemglow.png",
   "description" : "Rocksalt in fruit form. A hylotl favorite. Increases your energy by 20%.",
   "shortdescription" : "Gemglow",
+  "category" : "food",
+  "eventCategory" : "eventCrop",
+  "foodValue" : 7,
+  "tooltipKind" : "food",
+  "builder" : "/items/buildscripts/buildfood.lua",
+  "maxStack" : 1000,
+  "itemAgingScripts" : ["/scripts/items/rotting.lua"],
+  "rottingMultiplier" : 20.0,
   "effects" : [ [
     {
         "effect" : "maxenergyscalingboostfood",

--- a/items/generic/produce/lumivine.consumable
+++ b/items/generic/produce/lumivine.consumable
@@ -1,13 +1,13 @@
 {
   "itemName" : "lumivine",
   "rarity" : "rare",
-  "price" : 10,
+  "price" : 100,
   "inventoryIcon" : "lumivine.png",
   "description" : "They have a faintly eggy taste. Makes you immune to extreme pressure for 5 minutes.",
   "shortdescription" : "Lumivine",
   "category" : "food",
   "eventCategory" : "eventCrop",
-  "foodValue" : 7,
+  "foodValue" : 0,
   "tooltipKind" : "food",
   "builder" : "/items/buildscripts/buildfood.lua",
   "maxStack" : 1000,
@@ -15,5 +15,6 @@
   "rottingMultiplier" : 20.0,
   "effects" : [ [
       "pressureimmunity"
-    ] ]  
+    ] ],
+  "learnBlueprintsOnPickup" : [ "lumivineseed" ]
 }

--- a/objects/farmables/a_professionboundplants/goldshroom/goldshroomseed.object
+++ b/objects/farmables/a_professionboundplants/goldshroom/goldshroomseed.object
@@ -2,7 +2,7 @@
   "objectName" : "goldshroomseed",
     "colonyTags" : [ "nature" ],
   "rarity" : "common",
-  "category" : "Farmable Herb",
+  "category" : "seed",
   "description" : "Glow in the dark.",
   "shortdescription" : "Gold Shroom Spore",
   "objectType" : "farmable",

--- a/objects/farmables/gemglow/wildgemglowseed.object
+++ b/objects/farmables/gemglow/wildgemglowseed.object
@@ -66,5 +66,8 @@
   ],
   "learnBlueprintsOnPickup" : [ "gemglowseed" ],
 
-  "maxImmersion" : 2.0
+  "maxImmersion" : 2.0,
+  "breakDropOptions" : [
+    [ [ "gemglowseed", 1, { } ] ]
+  ]
 }

--- a/objects/farmables/lumivine/wildlumivineseed.object
+++ b/objects/farmables/lumivine/wildlumivineseed.object
@@ -22,20 +22,20 @@
   "orientations" : [
     {
       "imageLayers" : [ { "image" : "lumivineseed.png:<color>.<stage>.<alt>", "fullbright" : true }, { "image" : "lumivineseedlit.png:<color>.<stage>.<alt>" } ],
-	  "direction" : "left",
-	  "flipImages" : true,
+  	  "direction" : "left",
+  	  "flipImages" : true,
       "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 
       "spaces" : [ [1, 0], [0, 0], [1, 1], [0, 1], [1, 2], [0, 2], [1, 3], [0, 3] ],
-      "requireTilledAnchors" : true,
+      "requireTilledAnchors" : false,
       "anchors" : [ "top" ]
 
     },
 	{
       "imageLayers" : [ { "image" : "lumivineseed.png:<color>.<stage>.<alt>", "fullbright" : true }, { "image" : "lumivineseedlit.png:<color>.<stage>.<alt>" } ],
-	  "direction" : "right",
+      "direction" : "right",
       "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
@@ -64,6 +64,9 @@
       "resetToStage" : 0
     }
   ],
-"maxImmersion" : 2.0,
-"consumeSoilMoisture" : false
+  "maxImmersion" : 2.0,
+  "consumeSoilMoisture" : false,
+  "breakDropOptions" : [
+    [ [ "lumivineseed", 1, { } ] ]
+  ]
 }


### PR DESCRIPTION
Normalizes gemglow and lumivine to SB 1.0 standards.
Corrects gold shroom spore inventory tab.
Also, experimenting setting foodValue to 0 on lumivine consumable.