### PR TITLE
Gene Sequencer Window Config HotFix

### DIFF
--- a/interface/windowconfig/genesequencer.config
+++ b/interface/windowconfig/genesequencer.config
@@ -59,7 +59,7 @@
     "imgAmountInput" : {
       "type" : "image",
       "file" : "/interface/crafting/amount.png",
-      "position" : [226, 45],
+      "position" : [243, 61],
       "zlevel" : -3
     },
     "btnCraft" : {


### PR DESCRIPTION
Fixes incorrect "imgAmountInput" position missing from last hotfix.