### PR TITLE
Dragon Trophy Category Fix

### DIFF
--- a/recipes/furniture1/dragontrophy.recipe
+++ b/recipes/furniture1/dragontrophy.recipe
@@ -7,5 +7,5 @@
     "item" : "fudragontrophy",
     "count" : 1
   },
-  "groups" : [ "craftingfurniture", "storage", "all" ]
+  "groups" : [ "craftingfurniture", "decoration", "all" ]
 }


### PR DESCRIPTION
It was in storage instead of decoration.
Fixed now.