### PR TITLE
Fix for batteries dropping copies of themselves

### DIFF
--- a/objects/power/isn_battery.lua
+++ b/objects/power/isn_battery.lua
@@ -1,6 +1,6 @@
 function init(virtual)
 	if virtual == true then return end
-	
+
 	if storage.currentstoredpower == nil then storage.currentstoredpower = 0 end
 	if storage.powercapacity == nil then storage.powercapacity = config.getParameter("isn_batteryCapacity") end
 	if storage.voltage == nil then storage.voltage = config.getParameter("isn_batteryVoltage") end
@@ -26,7 +26,7 @@ function update(dt)
 		powerlevel = isn_numericRange(powerlevel,0,10)
 		animator.setAnimationState("meter", tostring(math.floor(powerlevel)))
 	end
-	
+
 	local powerinput = isn_getCurrentPowerInput(false)  -- set this to (true) to enable batteries losing power (divisor)
 	if powerinput and powerinput >= 1 then
 		storage.currentstoredpower = storage.currentstoredpower + powerinput
@@ -46,7 +46,7 @@ function update(dt)
 	else
 		animator.setAnimationState("status", "off")
 	end
-	
+
 	storage.currentstoredpower = math.min(storage.currentstoredpower, storage.powercapacity)
 	--object.setConfigParameter('isnStoredPower', storage.currentstoredpower)
 	object.setConfigParameter('description', isn_makeBatteryDescription())
@@ -69,7 +69,7 @@ function isn_getCurrentPowerOutput(divide)
 	if not isn_hasStoredPower() or storage.excessCurrent then return 0 end
 
 	local divisor = isn_countPowerDevicesConnectedOnOutboundNode(0)
-	
+
 	-- if divisor < 1 then return 0 end
 	if divide and divisor > 0 then return storage.voltage / divisor
 	else return storage.voltage end
@@ -110,7 +110,9 @@ function die()
 		end
 
 		world.spawnItem(object.name(), entity.position(), 1, newObject)
-		object.smash(true)
+		-- object.smash(true)
+	else
+		world.spawnItem(object.name(), entity.position())
 	end
 end
 

--- a/objects/power/isn_battery_t1/isn_battery_t1.object
+++ b/objects/power/isn_battery_t1/isn_battery_t1.object
@@ -21,6 +21,8 @@
     }
   ],
 
+  "breakDropOptions" : [],
+
   "animation" : "isn_battery_t1.animation",
   "animationParts" : {
     "meter" : "isn_battery_t1_meter.png",
@@ -28,15 +30,15 @@
     "base" : "isn_battery_t1_base.png"
   },
   "animationPosition" : [0, 0],
-  
+
   "scripts" : [ "/objects/power/isn_battery.lua",
                 "/objects/power/isn_sharedpowerscripts.lua",
 		"/objects/isn_sharedobjectscripts.lua"],
   "scriptDelta" : 50,
-  
+
   "outputNodes" : [ [1, 3] ],
   "inputNodes" : [ [0, 1], [2, 1] ],
-  
+
   "isn_powerSupplier" : true,
   "isn_powerReciever" : true,
   "isn_batteryCapacity" : 1000,

--- a/objects/power/isn_battery_t2/isn_battery_t2.object
+++ b/objects/power/isn_battery_t2/isn_battery_t2.object
@@ -21,6 +21,8 @@
     }
   ],
 
+  "breakDropOptions" : [],
+
   "animation" : "isn_battery_t2.animation",
   "animationParts" : {
     "meter" : "isn_battery_t2_meter.png",
@@ -28,15 +30,15 @@
     "base" : "isn_battery_t2_base.png"
   },
   "animationPosition" : [0, 0],
-  
+
   "scripts" : [ "/objects/power/isn_battery.lua",
                 "/objects/power/isn_sharedpowerscripts.lua",
 		"/objects/isn_sharedobjectscripts.lua"],
   "scriptDelta" : 50,
-  
+
   "outputNodes" : [ [1, 3] ],
   "inputNodes" : [ [0, 1], [2, 1] ],
-  
+
   "isn_powerSupplier" : true,
   "isn_powerReciever" : true,
   "isn_batteryCapacity" : 2500,

--- a/objects/power/isn_battery_t3_ceru/isn_battery_t3_ceru.object
+++ b/objects/power/isn_battery_t3_ceru/isn_battery_t3_ceru.object
@@ -21,6 +21,8 @@
     }
   ],
 
+  "breakDropOptions" : [],
+
   "animation" : "isn_battery_t3_ceru.animation",
   "animationParts" : {
     "meter" : "isn_battery_t3_ceru_meter.png",
@@ -28,15 +30,15 @@
     "base" : "isn_battery_t3_ceru_base.png"
   },
   "animationPosition" : [0, 0],
-  
+
   "scripts" : [ "/objects/power/isn_battery.lua",
                 "/objects/power/isn_sharedpowerscripts.lua",
 		"/objects/isn_sharedobjectscripts.lua"],
   "scriptDelta" : 50,
-  
+
   "outputNodes" : [ [1, 3] ],
   "inputNodes" : [ [0, 1], [2, 1] ],
-  
+
   "isn_powerSupplier" : true,
   "isn_powerReciever" : true,
   "isn_batteryCapacity" : 4000,

--- a/objects/power/isn_battery_t3_fero/isn_battery_t3_fero.object
+++ b/objects/power/isn_battery_t3_fero/isn_battery_t3_fero.object
@@ -20,6 +20,8 @@
     }
   ],
 
+  "breakDropOptions" : [],
+
   "animation" : "isn_battery_t3_fero.animation",
   "animationParts" : {
     "meter" : "isn_battery_t3_fero_meter.png",
@@ -27,15 +29,15 @@
     "base" : "isn_battery_t3_fero_base.png"
   },
   "animationPosition" : [0, 0],
-  
+
   "scripts" : [ "/objects/power/isn_battery.lua",
                 "/objects/power/isn_sharedpowerscripts.lua",
 		"/objects/isn_sharedobjectscripts.lua"],
   "scriptDelta" : 50,
-  
+
   "outputNodes" : [ [1, 3] ],
   "inputNodes" : [ [0, 1], [2, 1] ],
-  
+
   "isn_powerSupplier" : true,
   "isn_powerReciever" : true,
   "isn_batteryCapacity" : 8000,

--- a/objects/power/isn_battery_t4_fero/isn_battery_t4_fero.object
+++ b/objects/power/isn_battery_t4_fero/isn_battery_t4_fero.object
@@ -20,6 +20,8 @@
     }
   ],
 
+  "breakDropOptions" : [],
+
   "animation" : "isn_battery_t4_fero.animation",
   "animationParts" : {
     "meter" : "isn_battery_t4_fero_meter.png",
@@ -27,15 +29,15 @@
     "base" : "isn_battery_t4_fero_base.png"
   },
   "animationPosition" : [0, 0],
-  
+
   "scripts" : [ "/objects/power/isn_battery.lua",
                 "/objects/power/isn_sharedpowerscripts.lua",
 		"/objects/isn_sharedobjectscripts.lua"],
   "scriptDelta" : 50,
-  
+
   "outputNodes" : [ [1, 3] ],
   "inputNodes" : [ [0, 1], [2, 1] ],
-  
+
   "isn_powerSupplier" : true,
   "isn_powerReciever" : true,
   "isn_batteryCapacity" : 16000,


### PR DESCRIPTION
As per metadept's suggestion, replaced object.smash() with a null breakOptions in the object file, and manually drop a generic battery in die() when there's no power to store.