### PR TITLE
organic soup fix + misc

### DIFF
--- a/dungeons/microdungeons/randomencounter/asteroidfield/asteroidencounter.dungeon
+++ b/dungeons/microdungeons/randomencounter/asteroidfield/asteroidencounter.dungeon
@@ -201,7 +201,7 @@
           "type" : "questlocation",
           "parameters" : {
             "broadcastArea" : [-8, -16, 8, 16],
-            "locationType" : "asteroidunderground.mine"
+            "locationType" : "asteroidencounter"
           }
         }
       ] ]

--- a/items/materials/honeycombmaterial.matitem
+++ b/items/materials/honeycombmaterial.matitem
@@ -6,7 +6,7 @@
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "shortdescription" : "Honey Material",
   "description" : "Waxy!",
-  "learnBlueprintsOnPickup" : [ "honeycombmaterial", "honeycombblockmaterial", "honeyplatform" ],
+  "learnBlueprintsOnPickup" : [ "honeycombmaterial", "fu_honeycombblock", "honeyplatform" ],
 
   "materialId" : 6566
 }

--- a/stats/effects/fu_tileeffects/organicsoupeffect/organicsoupeffect.lua
+++ b/stats/effects/fu_tileeffects/organicsoupeffect/organicsoupeffect.lua
@@ -1,15 +1,18 @@
 function init()
+  if status.isResource("food") then
+    hungerMax = { pcall(status.resourceMax, "food") }
+    hungerMax = hungerMax[1] and hungerMax[2]
+    hungerLevel = status.resource("food")
+    baseValue = config.getParameter("healthDown",0)*(status.resourceMax("food"))
 
-  hungerMax = { pcall(status.resourceMax, "food") }
-  hungerMax = hungerMax[1] and hungerMax[2]
-  hungerLevel = status.resource("food")
-  baseValue = config.getParameter("healthDown",0)*(status.resourceMax("food"))
-  
-  effect.setParentDirectives("border=1;cc005500;00000000")
-  self.tickDamagePercentage = 0.0
-  self.tickTime = 3.0
-  self.tickTimer = self.tickTime  
-  script.setUpdateDelta(3)
+    effect.setParentDirectives("border=1;cc005500;00000000")
+    self.tickDamagePercentage = 0.0
+    self.tickTime = 3.0
+    self.tickTimer = self.tickTime
+    script.setUpdateDelta(3)
+  else
+    script.setUpdateDelta(0)
+  end
 end
 
 
@@ -20,14 +23,14 @@ function update(dt)
   hungerMax = hungerMax[1] and hungerMax[2]
   hungerLevel = status.resource("food")
   baseValue = config.getParameter("healthDown",0)*(status.resourceMax("food"))
-  
+
   self.tickTimer = self.tickTimer - dt
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime
 	  if (hungerLevel < hungerMax) then
 	    adjustedHunger = hungerLevel + (hungerLevel * 0.011)
 	    status.setResource("food", adjustedHunger)
-	  end    
+	  end
   end
 
   effect.setParentDirectives("fade=aa00cc="..self.tickTimer * 0.4)
@@ -35,5 +38,5 @@ function update(dt)
 end
 
 function uninit()
-  
+
 end


### PR DESCRIPTION
Organic Soup no longer tries to affect NPCs and monsters (no food resource to adjust).
asteroidencounter no longer looks for a non-existent location.
honeycombmaterial no longer unlocks a PGI on pickup.