### PR TITLE
Adjustments

### DIFF
--- a/items/active/weapons/melee/axe/irradiumaxe.activeitem
+++ b/items/active/weapons/melee/axe/irradiumaxe.activeitem
@@ -2,7 +2,7 @@
   "itemName" : "irradiumaxe",
   "price" : 640,
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "Purified irradium weapon.",
   "shortdescription" : "Irradium Axe",
   "tooltipKind" : "sword",

--- a/items/active/weapons/melee/dagger/irradiumdagger.activeitem
+++ b/items/active/weapons/melee/dagger/irradiumdagger.activeitem
@@ -2,7 +2,7 @@
   "itemName" : "irradiumdagger",
   "price" : 640,
   "maxStack" : 1,
-  "rarity" : "Common",
+  "rarity" : "uncommon",
   "description" : "Swift and deadly.",
   "shortdescription" : "Irradium Dagger",
   "tooltipKind" : "sword",

--- a/items/active/weapons/melee/hammer/irradiumhammer.activeitem
+++ b/items/active/weapons/melee/hammer/irradiumhammer.activeitem
@@ -2,7 +2,7 @@
   "itemName" : "banehammer",
   "price" : 900,
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "uncommon",
   "description" : "Forged from carbon and irradium. Quite dangerous.",
   "shortdescription" : "Irradium Hammer",
   "tooltipKind" : "sword",

--- a/items/active/weapons/ranged/unique/peglaci/cripplermachinegun/chargemachinegun.activeitem
+++ b/items/active/weapons/ranged/unique/peglaci/cripplermachinegun/chargemachinegun.activeitem
@@ -3,7 +3,7 @@
   "price" : 160,
   "inventoryIcon" : "chargemachinegun.png",
   "maxStack" : 1,
-  "rarity" : "legendary",
+  "rarity" : "rare",
   "description" : "Depleted uranium rounds take down enemy armor.",
   "shortdescription" : "Crippler Machinegun",
   "category" : "Energy Gun",

--- a/items/generic/crafting/starbooze/emptybottle2.item
+++ b/items/generic/crafting/starbooze/emptybottle2.item
@@ -5,5 +5,6 @@
   "category" : "craftingMaterial",
   "inventoryIcon" : "emptybottle2.png",
   "description" : "Just an empty glass bottle.",
-  "shortdescription" : "Empty Glass Bottle"
+  "shortdescription" : "Empty Glass Bottle",
+  "itemTags" : [ "reagent" ]
 }

--- a/items/generic/crafting/starbooze/grainwater.item
+++ b/items/generic/crafting/starbooze/grainwater.item
@@ -5,6 +5,5 @@
   "category" : "cookingIngredient",
   "inventoryIcon" : "grainwater.png",
   "description" : "A bottle filled with the basis of yeast.",
-  "shortdescription" : "Grain Water",
-  "itemTags" : [ "reagent" ]
+  "shortdescription" : "Grain Water"
 }


### PR DESCRIPTION
Irradium Set is now uncommon, one tier below enriched uranium.
Crippler Machine Gun is now rare to match other enriched uranium weapons.
Also fixed itemTags on emptybottle2 and grainwater