### PR TITLE
Fix displaying the description for inspected tiles.

### DIFF
--- a/tiles/mods/algaeore.matmod
+++ b/tiles/mods/algaeore.matmod
@@ -2,7 +2,7 @@
   "modId" : 6700,
   "modName" : "algaeore",
   "itemDrop" : "algaegreen",
-  "Description" : "algae",
+  "description" : "algae",
   "health" : 2,
   "harvestLevel" : 2,
   "breaksWithTile" : true,

--- a/tiles/mods/berlinite.matmod
+++ b/tiles/mods/berlinite.matmod
@@ -2,7 +2,7 @@
   "modId" : 6701,
   "modName" : "berlinite",
   "itemDrop" : "berliniteore",
-  "Description" : "Berlinite.",
+  "description" : "Berlinite.",
   "health" : 3,
   "harvestLevel" : 5,
   "breaksWithTile" : true,

--- a/tiles/mods/blackslimegrass.matmod
+++ b/tiles/mods/blackslimegrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6703,
   "modName" : "blackslimegrass",
-  "Description" : "Black slime",
+  "description" : "Black slime",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/bloodstonegrass.matmod
+++ b/tiles/mods/bloodstonegrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6704,
   "modName" : "bloodstonegrass",
-  "Description" : "bloodstone grass",
+  "description" : "bloodstone grass",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/cinnabar.matmod
+++ b/tiles/mods/cinnabar.matmod
@@ -2,7 +2,7 @@
   "modId" : 6705,
   "modName" : "cinnabar",
   "itemDrop" : "cinnabarore",
-  "Description" : "Cinnabar",
+  "description" : "Cinnabar",
   "health" : 12,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/clay.matmod
+++ b/tiles/mods/clay.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6706,
   "modName" : "clay",
-  "Description" : "A light layer of clay.",
+  "description" : "A light layer of clay.",
   "footstepSound" : "/sfx/blocks/footstep_mud.ogg",
   "health" : 0,
   

--- a/tiles/mods/claygrass2.matmod
+++ b/tiles/mods/claygrass2.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6707,
   "modName" : "claygrass2",
-  "Description" : "Clay",
+  "description" : "Clay",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/corruption.matmod
+++ b/tiles/mods/corruption.matmod
@@ -2,7 +2,7 @@
   "modId" : 6709,
   "modName" : "corruption",
   "itemDrop" : "corruptionore",
-  "Description" : "corruption",
+  "description" : "corruption",
   "health" : 8.5,
   "harvestLevel" : 3,
   "breaksWithTile" : true,

--- a/tiles/mods/darkgrass.matmod
+++ b/tiles/mods/darkgrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6710,
   "modName" : "darkgrass",
-  "Description" : "strange solid-darkness grass...",
+  "description" : "strange solid-darkness grass...",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/deadleaves.matmod
+++ b/tiles/mods/deadleaves.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6711,
   "modName" : "deadleaves",
-  "Description" : "dead leaves",
+  "description" : "dead leaves",
   "footstepSound" : "/sfx/blocks/footstep_grass.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/effigium.matmod
+++ b/tiles/mods/effigium.matmod
@@ -2,7 +2,7 @@
   "modId" : 6762,
   "modName" : "effigium",
   "itemDrop" : "effigiumore",
-  "Description" : "Effigium",
+  "description" : "Effigium",
   "health" : 5,
   "breaksWithTile" : true,
   "harvestLevel" : 4,

--- a/tiles/mods/fleshgrass2.matmod
+++ b/tiles/mods/fleshgrass2.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6713,
   "modName" : "fleshgrass2",
-  "Description" : "flesh grass",
+  "description" : "flesh grass",
   "footstepSound" : "/sfx/blocks/footstep_mud.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/fualiengrass.matmod
+++ b/tiles/mods/fualiengrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6715,
   "modName" : "fualiengrass",
-  "Description" : "alien grass",
+  "description" : "alien grass",
   "footstepSound" : "/sfx/blocks/footstep_grass.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/fualiengrass2.matmod
+++ b/tiles/mods/fualiengrass2.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6716,
   "modName" : "fualiengrass2",
-  "Description" : "alien grass",
+  "description" : "alien grass",
   "footstepSound" : "/sfx/blocks/footstep_grass.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/fublooddiamond.matmod
+++ b/tiles/mods/fublooddiamond.matmod
@@ -2,7 +2,7 @@
   "modId" : 6754,
   "modName" : "fublooddiamond",
   "itemDrop" : "blooddiamond",
-  "Description" : "Blood Diamond",
+  "description" : "Blood Diamond",
   "health" : 18,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/fuhivegrass.matmod
+++ b/tiles/mods/fuhivegrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6760,
   "modName" : "fuhivegrass",
-  "Description" : "hive grass",
+  "description" : "hive grass",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/glowsandgrass.matmod
+++ b/tiles/mods/glowsandgrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6717,
   "modName" : "glowsandgrass",
-  "Description" : "glowing sand",
+  "description" : "glowing sand",
   "footstepSound" : "/sfx/blocks/footstep_sand.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/greenslimegrass.matmod
+++ b/tiles/mods/greenslimegrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6718,
   "modName" : "greenslimegrass",
-  "Description" : "Green slime",
+  "description" : "Green slime",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/hydrotilled.matmod
+++ b/tiles/mods/hydrotilled.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6719,
   "modName" : "hydrotilled",
-  "Description" : "hydroponically specialized soil",
+  "description" : "hydroponically specialized soil",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "tilled" : true,
   "health" : 0,

--- a/tiles/mods/hydrotilleddry.matmod
+++ b/tiles/mods/hydrotilleddry.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6720,
   "modName" : "hydrotilleddry",
-  "Description" : "hydroponically specialized soil",
+  "description" : "hydroponically specialized soil",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "tilled" : true,
   "health" : 0,

--- a/tiles/mods/icegrass1.matmod
+++ b/tiles/mods/icegrass1.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6721,
   "modName" : "icegrass1",
-  "Description" : "ice",
+  "description" : "ice",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "health" : 0,
 

--- a/tiles/mods/icegrass2.matmod
+++ b/tiles/mods/icegrass2.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6722,
   "modName" : "icegrass2",
-  "Description" : "ice",
+  "description" : "ice",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "health" : 0,
 

--- a/tiles/mods/irradium.matmod
+++ b/tiles/mods/irradium.matmod
@@ -2,7 +2,7 @@
   "modId" : 6723,
   "modName" : "irradium",
   "itemDrop" : "irradiumore",
-  "Description" : "Irradium",
+  "description" : "Irradium",
   "health" : 11.5,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/isogen.matmod
+++ b/tiles/mods/isogen.matmod
@@ -2,7 +2,7 @@
   "modId" : 6763,
   "modName" : "isogen",
   "itemDrop" : "isogenore",
-  "Description" : "Isogen",
+  "description" : "Isogen",
   "health" : 8.5,
   "harvestLevel" : 6,
   "breaksWithTile" : true,

--- a/tiles/mods/junkmod.matmod
+++ b/tiles/mods/junkmod.matmod
@@ -2,7 +2,7 @@
   "modId" : 6758,
   "modName" : "junkmod",
   "itemDrop" : "ff_spareparts",
-  "Description" : "algae",
+  "description" : "algae",
   "health" : 3.5,
   "harvestLevel" : 2,
   "breaksWithTile" : true,

--- a/tiles/mods/lazulite.matmod
+++ b/tiles/mods/lazulite.matmod
@@ -2,7 +2,7 @@
   "modId" : 6724,
   "modName" : "lazulite",
   "itemDrop" : "lazuliteore",
-  "Description" : "Lazulite.",
+  "description" : "Lazulite.",
   "health" : 3,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/lunariore.matmod
+++ b/tiles/mods/lunariore.matmod
@@ -2,7 +2,7 @@
   "modId" : 6725,
   "modName" : "lunariore",
   "itemDrop" : "solarishard",
-  "Description" : "lunari crystal",
+  "description" : "lunari crystal",
   "health" : 3.5,
   "harvestLevel" : 2,
   "breaksWithTile" : true,

--- a/tiles/mods/magnesium.matmod
+++ b/tiles/mods/magnesium.matmod
@@ -2,7 +2,7 @@
   "modId" : 6726,
   "modName" : "magnesium",
   "itemDrop" : "magnesiumore",
-  "Description" : "Magnesium.",
+  "description" : "Magnesium.",
   "health" : 3,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/mascagnite.matmod
+++ b/tiles/mods/mascagnite.matmod
@@ -2,7 +2,7 @@
   "modId" : 6727,
   "modName" : "mascagnite",
   "itemDrop" : "mascagniteore",
-  "Description" : "Mascagnite.",
+  "description" : "Mascagnite.",
   "health" : 3,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/metalgrass.matmod
+++ b/tiles/mods/metalgrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6757,
   "modName" : "metalgrass",
-  "Description" : "Metal Debris",
+  "description" : "Metal Debris",
   "footstepSound" : "/sfx/blocks/footstep_metallic.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/mossgrass1.matmod
+++ b/tiles/mods/mossgrass1.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6728,
   "modName" : "mossgrass1",
-  "Description" : "Mossy ground",
+  "description" : "Mossy ground",
   "footstepSound" : "/sfx/blocks/footstep_grass.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/mossgrass2.matmod
+++ b/tiles/mods/mossgrass2.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6729,
   "modName" : "mossgrass2",
-  "Description" : "Mossy grass",
+  "description" : "Mossy grass",
   "footstepSound" : "/sfx/blocks/footstep_grass.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/neptunium.matmod
+++ b/tiles/mods/neptunium.matmod
@@ -2,7 +2,7 @@
   "modId" : 6755,
   "modName" : "neptunium",
   "itemDrop" : "neptuniumore",
-  "Description" : "Neptunium",
+  "description" : "Neptunium",
   "health" : 6,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/penumbragrass.matmod
+++ b/tiles/mods/penumbragrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6730,
   "modName" : "penumbragrass",
-  "Description" : "Umbral grass",
+  "description" : "Umbral grass",
   "footstepSound" : "/sfx/blocks/footstep_grass.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/penumbrite.matmod
+++ b/tiles/mods/penumbrite.matmod
@@ -2,7 +2,7 @@
   "modId" : 6731,
   "modName" : "penumbrite",
   "itemDrop" : "penumbriteore",
-  "Description" : "Penumbrite",
+  "description" : "Penumbrite",
   "health" : 18,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/protocite.matmod
+++ b/tiles/mods/protocite.matmod
@@ -2,7 +2,7 @@
   "modId" : 6732,
   "modName" : "protocite",
   "itemDrop" : "protociteore",
-  "Description" : "Protocite",
+  "description" : "Protocite",
   "health" : 11,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/protograss.matmod
+++ b/tiles/mods/protograss.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6733,
   "modName" : "protograss",
-  "Description" : "Thick purple grass.",
+  "description" : "Thick purple grass.",
   "footstepSound" : "/sfx/blocks/footstep_grass.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/purplecrystalgrass.matmod
+++ b/tiles/mods/purplecrystalgrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6734,
   "modName" : "purplecrystalgrass",
-  "Description" : "Crystals",
+  "description" : "Crystals",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/pyreite.matmod
+++ b/tiles/mods/pyreite.matmod
@@ -2,7 +2,7 @@
   "modId" : 6764,
   "modName" : "pyreite",
   "itemDrop" : "pyreiteore",
-  "Description" : "Pyreite",
+  "description" : "Pyreite",
   "health" : 8.5,
   "harvestLevel" : 6,
   "breaksWithTile" : true,

--- a/tiles/mods/quietus.matmod
+++ b/tiles/mods/quietus.matmod
@@ -2,7 +2,7 @@
   "modId" : 6753,
   "modName" : "quietus",
   "itemDrop" : "quietusore",
-  "Description" : "Quietus",
+  "description" : "Quietus",
   "health" : 12,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/redsand.matmod
+++ b/tiles/mods/redsand.matmod
@@ -3,7 +3,7 @@
   "modName" : "redsand",
   "frames" : "redsand.png",
   "variants" : 5,
-  "Description" : "Scattered sand.",
+  "description" : "Scattered sand.",
   "footstepSound" : "/sfx/blocks/footstep_sand.ogg",
   "health" : 0
 }

--- a/tiles/mods/sulphuricgrass.matmod
+++ b/tiles/mods/sulphuricgrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6737,
   "modName" : "sulphuricgrass",
-  "Description" : "Sulphuric Stone",
+  "description" : "Sulphuric Stone",
   "footstepSound" : "/sfx/blocks/footstep_stone2.ogg",
   "health" : 0,
 

--- a/tiles/mods/thickjunglegrass.matmod
+++ b/tiles/mods/thickjunglegrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6738,
   "modName" : "thickjunglegrass",
-  "Description" : "Jungle grasses",
+  "description" : "Jungle grasses",
   "footstepSound" : "/sfx/blocks/footstep_grass.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/thorium.matmod
+++ b/tiles/mods/thorium.matmod
@@ -2,7 +2,7 @@
   "modId" : 6756,
   "modName" : "thorium",
   "itemDrop" : "thoriumore",
-  "Description" : "Thorium",
+  "description" : "Thorium",
   "health" : 8,
   "breaksWithTile" : true,
   "harvestLevel" : 2,

--- a/tiles/mods/wagnergrass.matmod
+++ b/tiles/mods/wagnergrass.matmod
@@ -1,7 +1,7 @@
 {
   "modId" : 6761,
   "modName" : "wagnergrass",
-  "Description" : "Some sort of nasty people-goop.",
+  "description" : "Some sort of nasty people-goop.",
   "footstepSound" : "/sfx/blocks/footstep_brains.ogg",
   "grass" : true,
   "health" : 0,

--- a/tiles/mods/xithricite.matmod
+++ b/tiles/mods/xithricite.matmod
@@ -2,7 +2,7 @@
   "modId" : 6765,
   "modName" : "xithricite",
   "itemDrop" : "xithriciteore",
-  "Description" : "Xithricite",
+  "description" : "Xithricite",
   "health" : 8.5,
   "harvestLevel" : 6,
   "breaksWithTile" : true,

--- a/tiles/mods/zerchesium.matmod
+++ b/tiles/mods/zerchesium.matmod
@@ -2,7 +2,7 @@
   "modId" : 6751,
   "modName" : "zerchesium",
   "itemDrop" : "zerchesiumore",
-  "Description" : "Zerchesium",
+  "description" : "Zerchesium",
   "health" : 5,
   "breaksWithTile" : true,
   "harvestLevel" : 3,


### PR DESCRIPTION
When the key isn't all lowercase, going into inspection mode causes a
blank window to be displayed when trying to identify one of the FU tiles
such as the new ores (at least on Linux).