### PR TITLE
Update patch files to make them friendlier to mods loaded before Frackin' Universe

### DIFF
--- a/items/generic/crafting/bone.item.patch
+++ b/items/generic/crafting/bone.item.patch
@@ -1,13 +1,18 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [
-    "whitedye",
-    "bonemealmaterial",
-    "bonematerial",
-    "throwingbones", "fuflamewand"
-    ] },
-    
-  {"op":"add","path":"/pickupQuestTemplates","value": [ "fuquest_bonespear" ] }    
-]  
-
-
-
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op": "test", "path": "/pickupQuestTemplates", "inverse" : true },
+    { "op": "add", "path": "/pickupQuestTemplates", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "whitedye" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "bonemealmaterial" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "bonematerial" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "throwingbones" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuflamewand" },
+    {"op":"add", "path":"/pickupQuestTemplates/-", "value": "fuquest_bonespear" }  
+  ]
+]

--- a/items/generic/crafting/bugshell.item.patch
+++ b/items/generic/crafting/bugshell.item.patch
@@ -1,7 +1,11 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-        "fudesertwalkerhead", 
-        "fudesertwalkerchest", 
-        "fudesertwalkerpants"	
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudesertwalkerhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudesertwalkerchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudesertwalkerpants" }
+  ]
 ]

--- a/items/generic/crafting/canvas.item.patch
+++ b/items/generic/crafting/canvas.item.patch
@@ -1,9 +1,13 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	"mantiziruffianchest",
-	"mantiziruffianlegs",
-	"fudarkrobeshelmet",
-	"fudarkrobeschest",
-	"fudarkrobespants"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantiziruffianchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantiziruffianlegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudarkrobeshelmet" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudarkrobeschest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudarkrobespants" }
+  ]
 ]

--- a/items/generic/crafting/cellmatter.item.patch
+++ b/items/generic/crafting/cellmatter.item.patch
@@ -1,4 +1,13 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "fucellgun", "fu_lasereyestaff", "fumonsterclaw", "fucellsword" ] },
-        {"op":"replace","path":"/price","value": 20 }	
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucellgun" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fu_lasereyestaff" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fumonsterclaw" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucellsword" },
+    {"op":"replace","path":"/price","value": 20 }
+  ]
 ]

--- a/items/generic/crafting/ceruliumcompound.item.patch
+++ b/items/generic/crafting/ceruliumcompound.item.patch
@@ -1,12 +1,17 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-    "tier7bed",
-    "tier7chair",
-    "tier7door",
-    "tier7light",
-    "tier7switch",
-    "tier7table",  
-  "furavagerhead", 
-  "furavagerchest", 
-  "furavagerpants" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier7bed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier7chair" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier7door" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier7light" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier7switch" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier7table" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "furavagerhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "furavagerchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "furavagerpants" }
+  ]
 ]

--- a/items/generic/crafting/copperbar.item.patch
+++ b/items/generic/crafting/copperbar.item.patch
@@ -1,5 +1,12 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-    "kirhostier1chest", "kirhostier1head", "kirhostier1pants", "heavypipe"
-    ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "kirhostier1chest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "kirhostier1head" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "kirhostier1pants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "heavypipe" }
+  ]
 ]

--- a/items/generic/crafting/copperore.item.patch
+++ b/items/generic/crafting/copperore.item.patch
@@ -1,6 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-    "copperbar", 
-    "polymer"
-    ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "copperbar" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "polymer" }
+  ]
 ]

--- a/items/generic/crafting/coralfragment.item.patch
+++ b/items/generic/crafting/coralfragment.item.patch
@@ -1,3 +1,11 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "coralstinger", "coraldullblade", "fucoralcleaver"  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "coralstinger" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "coraldullblade" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucoralcleaver" }
+  ]
 ]

--- a/items/generic/crafting/corefragmentore.item.patch
+++ b/items/generic/crafting/corefragmentore.item.patch
@@ -1,3 +1,11 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "fuflamewand", "fucopperbomb", "fuironbomb" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuflamewand" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucopperbomb" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuironbomb" }
+  ]
 ]

--- a/items/generic/crafting/cotton.item.patch
+++ b/items/generic/crafting/cotton.item.patch
@@ -1,6 +1,10 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	"mantizidrapedchest", 
-	"mantizidrapedlegs"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizidrapedchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizidrapedlegs" }
+  ]
 ]

--- a/items/generic/crafting/cottonwool.item.patch
+++ b/items/generic/crafting/cottonwool.item.patch
@@ -1,9 +1,13 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	"mantizidrapedchest", 
-	"mantizidrapedlegs",
-	"cannoneerchest",
-	"cannoneerhead",
-	"cannoneerlegs"	
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizidrapedchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizidrapedlegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "cannoneerchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "cannoneerhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "cannoneerlegs" }
+  ]
 ]

--- a/items/generic/crafting/crystal.item.patch
+++ b/items/generic/crafting/crystal.item.patch
@@ -1,10 +1,14 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	"crystalblock", 
-	"liquidcrystal", 
-	"crystallineblade",
-        "fucrystalspear",
-        "fuicewand",
-        "crystallight"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "crystalblock" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "liquidcrystal" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "crystallineblade" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucrystalspear" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuicewand" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "crystallight" }
+  ]
 ]

--- a/items/generic/crafting/diamond.item.patch
+++ b/items/generic/crafting/diamond.item.patch
@@ -1,8 +1,12 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	"diamondlantern", 
-	"diamondblockmaterial", 
-	"ff_focusingarray", 
-	"diamondshield"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "diamondlantern" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "diamondblockmaterial" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ff_focusingarray" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "diamondshield" }
+  ]
 ]

--- a/items/generic/crafting/durasteelbar.item.patch
+++ b/items/generic/crafting/durasteelbar.item.patch
@@ -1,15 +1,19 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [
-	"energyblade",
-	"fuexplorerchest",
-	"fuexplorerhead",
-	"fuexplorerlegs",
-	"durasteelshield",
-	"durasteelassaultrifle",
-	"durasteelrevolver",
-	"mantizitier4pants",
-	"mantizitier4head",
-	"mantizitier4chest",
-	"sprinklerroof"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "energyblade" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuexplorerchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuexplorerhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuexplorerlegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "durasteelshield" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "durasteelassaultrifle" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "durasteelrevolver" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier4pants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier4head" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier4chest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "sprinklerroof" }
+  ]
 ]

--- a/items/generic/crafting/fabric.item.patch
+++ b/items/generic/crafting/fabric.item.patch
@@ -1,7 +1,11 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 	
-	"mantizihoodhead",
-	"mantizipleblegs",
-	"mantiziplebchest"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizihoodhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizipleblegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantiziplebchest" }
+  ]
 ]

--- a/items/generic/crafting/fleshstrand.item.patch
+++ b/items/generic/crafting/fleshstrand.item.patch
@@ -1,23 +1,27 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	"fuunderworldtable2",
-	"fuunderworldtable3",
-	"fuunderworldtable4",
-	"fuunderworldeyestatue1",
-	"fuunderworldeyestatue2",
-	"fuunderworldeyestatue3",	
-	"fuunderworldcandles", 
-	"fuunderworldcandles2", 
-	"fuunderworldchair", 
-	"fuunderworldchair2", 
-	"fuunderworlddoor",
-	"fuunderworlddoor2",
-	"fuunderworldfountain",
-	"fuunderworldfountain2",
-	"fuunderworldlamp",
-	"fuunderworldbed",
-	"fuunderworldtable1",
-	"fleshblock", 
-	"bloodypuss"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldtable2" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldtable3" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldtable4" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldeyestatue1" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldeyestatue2" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldeyestatue3" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldcandles" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldcandles2" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldchair" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldchair2" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworlddoor" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworlddoor2" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldfountain" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldfountain2" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldlamp" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldbed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuunderworldtable1" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fleshblock" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "bloodypuss" }
+  ]
 ]

--- a/items/generic/crafting/goldbar.item.patch
+++ b/items/generic/crafting/goldbar.item.patch
@@ -1,7 +1,11 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [
-        "zeroburst_tech",
-	"pumpoutfu",
-	"pumpoutpressurefu"
-    ] }
-]  
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "zeroburst_tech" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "pumpoutfu" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "pumpoutpressurefu" }
+  ]
+]

--- a/items/generic/crafting/graphene.item.patch
+++ b/items/generic/crafting/graphene.item.patch
@@ -1,104 +1,107 @@
- [
- {
-    "op": "add",
-    "path": "/price",
-    "value": 100
-  },
-  {
-    "op": "add",
-    "path": "/category",
-    "value": "craftingMaterial"
-  },
-  {
-    "op": "add",
-    "path": "/radioMessagesOnPickup",
-    "value": [
-      "pickupGraphene"
-    ]
-  },
-  {
-    "op": "replace",
-    "path": "/rarity",
-    "value": "uncommon"
-  },
-  {
-    "op": "replace",
-    "path": "/description",
-    "value": "Durable, flexible and conductive. A near-magical material."
-  },
-  {
-    "op": "replace",
-    "path": "/shortdescription",
-    "value": "^#77acc3;Graphene^white;"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup",
-    "value": []
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "teleportercore"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "hylotlgreatscion"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "hylotllesserscion"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "graphenechest"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "graphenehead"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "graphenelegs"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "morphiteore"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "fugaussmachinegun"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "fugausspistol"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "fugaussrifle"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "fu_gaussturret"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "fureinforcedglass"
-  },
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup/-",
-    "value": "tethersnap"
-  }
+[
+  [
+    { "op": "test", "path": "/radioMessagesOnPickup", "inverse" : true },
+    { "op": "add", "path": "/radioMessagesOnPickup", "value": [] }
+  ],
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    {
+      "op": "add",
+      "path": "/price",
+      "value": 100
+    },
+    {
+      "op": "replace",
+      "path": "/rarity",
+      "value": "uncommon"
+    },
+    {
+      "op": "replace",
+      "path": "/description",
+      "value": "Durable, flexible and conductive. A near-magical material."
+    },
+    {
+      "op": "replace",
+      "path": "/shortdescription",
+      "value": "^#77acc3;Graphene^white;"
+    },
+    {
+      "op": "add",
+      "path": "/category",
+      "value": "craftingMaterial"
+    },
+    {
+      "op": "add",
+      "path": "/radioMessagesOnPickup/-",
+      "value": "pickupGraphene"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "teleportercore"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "hylotlgreatscion"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "hylotllesserscion"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "graphenechest"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "graphenehead"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "graphenelegs"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "morphiteore"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "fugaussmachinegun"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "fugausspistol"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "fugaussrifle"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "fu_gaussturret"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "fureinforcedglass"
+    },
+    {
+      "op": "add",
+      "path": "/learnBlueprintsOnPickup/-",
+      "value": "tethersnap"
+    }
   ]
+]

--- a/items/generic/crafting/greenslime.item.patch
+++ b/items/generic/crafting/greenslime.item.patch
@@ -1,9 +1,13 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	"slimeplantseed", 
-	"ff_slimehead", 
-	"ff_slimechest", 
-	"ff_slimelegs",
-	"magnorbslime"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "slimeplantseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ff_slimehead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ff_slimechest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ff_slimelegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "magnorbslime" }
+  ]
 ]

--- a/items/generic/crafting/icecrystal.item.patch
+++ b/items/generic/crafting/icecrystal.item.patch
@@ -1,8 +1,12 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-        "magnorbfrost",
-        "sciencefulegs",
-        "sciencefuhead",
-        "sciencefuchest"
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "magnorbfrost" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "sciencefulegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "sciencefuhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "sciencefuchest" }
+  ]
 ]

--- a/items/generic/crafting/ironbar.item.patch
+++ b/items/generic/crafting/ironbar.item.patch
@@ -1,15 +1,19 @@
 [
-    {"op":"add","path":"/learnBlueprintsOnPickup","value": [
-    "armoredsnowpants",
-    "tier1bed",
-    "tier1chair",
-    "tier1door",
-    "tier1light",
-    "tier1switch",
-    "tier1table",
-    "mininghathead",
-    "beestation",
-    "wiretoolfu",
-    "irongrating"
-    ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "armoredsnowpants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1bed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1chair" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1door" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1light" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1switch" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1table" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mininghathead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "beestation" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "wiretoolfu" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "irongrating" }
+  ]
 ]

--- a/items/generic/crafting/ironore.item.patch
+++ b/items/generic/crafting/ironore.item.patch
@@ -1,3 +1,10 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "ironbar", "medievalworkstation" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ironbar" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "medievalworkstation" }
+  ]
 ]

--- a/items/generic/crafting/leather.item.patch
+++ b/items/generic/crafting/leather.item.patch
@@ -1,15 +1,19 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-        "deckardchest", 
-        "deckardpants",
-        "deckardhead",
-	"mantizitier1pants",
-	"mantizitier1head",
-	"mantizitier1chest",
-	"leatherpants",
-	"leatherhead",
-	"leatherchest",	
-	"leathershield",
-	"ropewhip"
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "deckardchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "deckardpants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "deckardhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier1pants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier1head" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier1chest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "leatherpants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "leatherhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "leatherchest" },	
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "leathershield" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ropewhip" }
+  ]
 ]

--- a/items/generic/crafting/matteritem.item.patch
+++ b/items/generic/crafting/matteritem.item.patch
@@ -1,7 +1,11 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-    "fubonusarmorhead", 
-    "fubonusarmorchest", 
-    "fubonusarmorpants" 
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fubonusarmorhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fubonusarmorchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fubonusarmorpants" }
+  ]
 ]

--- a/items/generic/crafting/monsterdrops/cryonicextract.item.patch
+++ b/items/generic/crafting/monsterdrops/cryonicextract.item.patch
@@ -1,5 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-  "fucoldaugment1",
-  "fucryogenicbed"] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucoldaugment1" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucryogenicbed" }
+  ]
 ]

--- a/items/generic/crafting/monsterdrops/livingroot.item.patch
+++ b/items/generic/crafting/monsterdrops/livingroot.item.patch
@@ -1,12 +1,16 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [     
-    "fufloranbath",
-    "fufloranchair",
-    "fuflorandoor",
-    "fufloranlamp",
-    "fufloransofa",
-    "fuflorantable",
-    "speedbootsweak_tech",
-    "livingroot"
-    ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fufloranbath" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fufloranchair" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuflorandoor" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fufloranlamp" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fufloransofa" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuflorantable" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "speedbootsweak_tech" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "livingroot" }
+  ]
 ]

--- a/items/generic/crafting/monsterdrops/phasematter.item.patch
+++ b/items/generic/crafting/monsterdrops/phasematter.item.patch
@@ -1,3 +1,9 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "morphiteore" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "morphiteore" }
+  ]
 ]

--- a/items/generic/crafting/monsterdrops/scorchedcore.item.patch
+++ b/items/generic/crafting/monsterdrops/scorchedcore.item.patch
@@ -1,8 +1,12 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-  "isn_plasmalight",
-  "fuheataugment1",
-  "hellfirebow",
-  "magnorbhellfire"
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "isn_plasmalight" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuheataugment1" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "hellfirebow" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "magnorbhellfire" }
+  ]
 ]

--- a/items/generic/crafting/monsterdrops/sharpenedclaw.item.patch
+++ b/items/generic/crafting/monsterdrops/sharpenedclaw.item.patch
@@ -1,9 +1,13 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [    
-  "fudragontable",
-  "fudragonbed",
-  "fudragonchair",
-  "fudragonlamp",
-  "fudragontrophy"
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudragontable" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudragonbed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudragonchair" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudragonlamp" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudragontrophy" }
+  ]
 ]

--- a/items/generic/crafting/monsterdrops/staticcell.item.patch
+++ b/items/generic/crafting/monsterdrops/staticcell.item.patch
@@ -1,8 +1,12 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [
-    "staticcell", 
-    "fusteampunkhead", 
-    "fusteampunkchest", 
-    "fusteampunklegs"
-    ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "staticcell" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fusteampunkhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fusteampunkchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fusteampunklegs" }
+  ]
 ]

--- a/items/generic/crafting/monsterdrops/venomsample.item.patch
+++ b/items/generic/crafting/monsterdrops/venomsample.item.patch
@@ -1,5 +1,12 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [     
-    "furadaugment1", "fupoisonwand", "poisonprotectionback", "biooozeprotection"
-    ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "furadaugment1" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fupoisonwand" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "poisonprotectionback" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "biooozeprotection" }
+  ]
 ]

--- a/items/generic/crafting/monsterplating.item.patch
+++ b/items/generic/crafting/monsterplating.item.patch
@@ -1,7 +1,11 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-    "fumonsterplatedchest", 
-    "fumonsterplatedhead", 
-    "fumonsterplatedlegs" 
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fumonsterplatedchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fumonsterplatedhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fumonsterplatedlegs" }
+  ]
 ]

--- a/items/generic/crafting/moonstoneore.item.patch
+++ b/items/generic/crafting/moonstoneore.item.patch
@@ -1,6 +1,17 @@
 [
-	{"op":"replace","path":"/description","value":"An unusually malleable, yet resilient metal."},
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "moonstonebar", "phasematter" ] },
-	{"op":"add","path":"/radioMessagesOnPickup","value": [ "pickupMoonstone" ] },
-	{"op":"replace","path":"/price","value": 60 }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op": "test", "path": "/radioMessagesOnPickup", "inverse" : true },
+    { "op": "add", "path": "/radioMessagesOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "moonstonebar" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "phasematter" },
+    { "op" : "add", "path" : "/radioMessagesOnPickup/-", "value" : "pickupMoonstone" },
+    { "op": "replace", "path": "/description", "value": "An unusually malleable, yet resilient metal." },
+    {"op": "replace", "path": "/price", "value": 60 }
+  ]
 ]

--- a/items/generic/crafting/plutoniumore.item.patch
+++ b/items/generic/crafting/plutoniumore.item.patch
@@ -1,8 +1,16 @@
 [
-	{"op":"add", "path":"/learnBlueprintsOnPickup", "value":["plutoniumrod"]},
-  {"op":"add","path":"/fuelAmount",
-	"value": 75
-	},
-	{"op":"add", "path":"/itemTags", "value":["reagent"]},
-	{"op":"replace", "path":"/category", "value":"fuel"}
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op": "test", "path": "/itemTags", "inverse" : true },
+    { "op": "add", "path": "/itemTags", "value": [] }
+  ],
+  [
+    { "op": "add", "path": "/learnBlueprintsOnPickup/-", "value": "plutoniumrod" },
+    { "op": "add", "path": "/itemTags/-", "value" : "reagent" },
+    { "op": "add", "path": "/fuelAmount", "value": 75 },
+    { "op": "replace", "path": "/category", "value": "fuel" }
+  ]
 ]

--- a/items/generic/crafting/plutoniumrod.item.patch
+++ b/items/generic/crafting/plutoniumrod.item.patch
@@ -1,6 +1,12 @@
 [
-	{"op":"add","path":"/fuelAmount", "value": 200},
-	{"op":"replace", "path":"/rarity", "value":"uncommon"},
-	{"op":"add", "path":"/itemTags", "value":["reagent"]},
-	{"op":"replace", "path":"/category", "value":"fuel"}
+  [
+    { "op": "test", "path": "/itemTags", "inverse" : true },
+    { "op": "add", "path": "/itemTags", "value": [] }
+  ],
+  [
+    { "op": "add", "path": "/fuelAmount", "value": 200 },
+    { "op": "replace", "path": "/rarity", "value": "uncommon" },
+    { "op": "replace", "path": "/category", "value": "fuel" },
+    { "op": "add", "path": "/itemTags/-", "value" : "reagent" }
+  ]
 ]

--- a/items/generic/crafting/polymer.item.patch
+++ b/items/generic/crafting/polymer.item.patch
@@ -1,23 +1,25 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": 
-  [ 
-  "labchair", 
-  "labcomputer", 
-  "labcupboard", 
-  "labdoor", 
-  "labbookcase", 
-  "labtable", 
-  "fuokeahitechwall1", 
-  "fuokeahitechwall2",
-  "fuoperativehead",
-  "fuoperativechest",
-  "fuoperativelegs",
-  "zaibatsulegs", 
-  "zaibatsuchest",
-  "boosterlegs",
-  "boosterchest"
-  ] 
-  },
-  {"op":"replace","path":"/shortdescription","value":"Plastic Polymer"},
-  {"op":"replace","path":"/description","value":"A handy, simple plastic with many uses."}
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "labchair" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "labcomputer" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "labcupboard" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "labdoor" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "labbookcase" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "labtable" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuokeahitechwall1" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuokeahitechwall2" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuoperativehead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuoperativechest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuoperativelegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "zaibatsulegs" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "zaibatsuchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "boosterlegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "boosterchest" },
+    {"op":"replace","path":"/shortdescription","value":"Plastic Polymer"},
+    {"op":"replace","path":"/description","value":"A handy, simple plastic with many uses."}
+  ]
 ]

--- a/items/generic/crafting/prisiliteore.item.patch
+++ b/items/generic/crafting/prisiliteore.item.patch
@@ -1,8 +1,18 @@
 [
-        {"op":"replace","path":"/rarity","value":"uncommon"},
-	{"op":"replace","path":"/description","value":"Beautiful crystalline-metallic ore."},
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "prisilitestar" ] },
-	{"op":"add","path":"/radioMessagesOnPickup","value": [ "pickupPrism" ] },
-	{"op":"replace","path":"/price","value": 70 },
-	{"op":"replace","path":"/category","value":"craftingMaterial" }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op": "test", "path": "/radioMessagesOnPickup", "inverse" : true },
+    { "op": "add", "path": "/radioMessagesOnPickup", "value": [] }
+  ],
+  [
+    { "op": "add", "path": "/radioMessagesOnPickup/-", "value": "pickupPrism" },
+    { "op": "add", "path": "/learnBlueprintsOnPickup/-", "value": "prisilitestar" },
+    { "op": "replace", "path": "/rarity", "value": "uncommon" },
+    { "op": "replace", "path": "/description", "value": "Beautiful crystalline-metallic ore." },
+    { "op": "replace", "path": "/price", "value": 70 },
+    { "op": "replace", "path": "/category", "value": "craftingMaterial" }
+  ]
 ]

--- a/items/generic/crafting/prisilitestar.item.patch
+++ b/items/generic/crafting/prisilitestar.item.patch
@@ -1,12 +1,16 @@
 [
-  {"op":"replace","path":"/rarity","value":"uncommon"},
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-  "aliencompound", 
-  "prismaticbow",
-  "fustarkillerhead",
-  "fustarkillerchest",
-  "fustarkillerpants"
-  ] },
-  {"op":"replace","path":"/price","value": 72 },
-  {"op":"replace","path":"/category","value":"craftingMaterial" }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "aliencompound" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "prismaticbow" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fustarkillerhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fustarkillerchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fustarkillerpants" },
+    { "op" : "replace", "path" : "/rarity", "value" : "uncommon" },
+    { "op" : "replace", "path" : "/price", "value" : 72 },
+    { "op" : "replace", "path" : "/category", "value" : "craftingMaterial" }
+  ]
 ]

--- a/items/generic/crafting/refinedaegisalt.item.patch
+++ b/items/generic/crafting/refinedaegisalt.item.patch
@@ -1,11 +1,15 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-  "furailgun", 
-  "fuaegisaltminigun", 
-  "fucloudgun", 
-	"mantizitier5apants",
-	"mantizitier5ahead",
-	"mantizitier5achest",
-	"densealloy"
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "furailgun" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuaegisaltminigun" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucloudgun" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier5apants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier5ahead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier5achest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "densealloy" }
+  ]
 ]

--- a/items/generic/crafting/refinedferozium.item.patch
+++ b/items/generic/crafting/refinedferozium.item.patch
@@ -1,16 +1,20 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-  "fufreezecannon", 
-  "fubeamgun", 
-  "fushocklance", 
-  "fuminelayer", 
-  "fuprecursorhead", 
-  "fuprecursorchest", 
-  "fuprecursorpants",
-	"mantizitier5mpants",
-	"mantizitier5mhead",
-	"mantizitier5mchest",
-	"densealloy",
-	"warcleaver"
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fufreezecannon" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fubeamgun" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fushocklance" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuminelayer" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuprecursorhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuprecursorchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuprecursorpants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier5mpants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier5mhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier5mchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "densealloy" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "warcleaver" }
+  ]
 ]

--- a/items/generic/crafting/refinedviolium.item.patch
+++ b/items/generic/crafting/refinedviolium.item.patch
@@ -1,12 +1,16 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-  "fuenergyblaster",
-  "fusunwalkerhead", 
-  "fusunwalkerchest", 
-  "fusunwalkerpants",
-	"kirhostier6apants",
-	"kirhostier6ahead",
-	"kirhostier6achest",
-	"densealloy"
-] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuenergyblaster" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fusunwalkerhead" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fusunwalkerchest" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fusunwalkerpants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "kirhostier6apants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "kirhostier6ahead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "kirhostier6achest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "densealloy" }
+  ]
 ]

--- a/items/generic/crafting/silk.item.patch
+++ b/items/generic/crafting/silk.item.patch
@@ -1,12 +1,16 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-  "ff_plastic", 
-  "mantizitogachest",
-  "mantizitogalegs",
-  "mantizimerchchest",
-  "mantizimerchlegs",
-  "warriorrobeschest",
-  "warriorrobespants",
-  "warriorrobeshead"
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ff_plastic" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitogachest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitogalegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizimerchchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizimerchlegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "warriorrobeschest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "warriorrobespants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "warriorrobeshead" }
+  ]
 ]

--- a/items/generic/crafting/silverbar.item.patch
+++ b/items/generic/crafting/silverbar.item.patch
@@ -1,6 +1,10 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	"pumpinfu",
-	"isn_windarray"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "pumpinfu" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "isn_windarray" }
+  ]
 ]

--- a/items/generic/crafting/solariumore.item.patch
+++ b/items/generic/crafting/solariumore.item.patch
@@ -1,3 +1,9 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "solariumstar" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "solariumstar" }
+  ]
 ]

--- a/items/generic/crafting/solariumstar.item.patch
+++ b/items/generic/crafting/solariumstar.item.patch
@@ -1,8 +1,12 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	"solariumstar",
-	"mantizitier6apants",
-	"mantizitier6ahead",
-	"mantizitier6achest"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "solariumstar" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier6apants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier6ahead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mantizitier6achest" }
+  ]
 ]

--- a/items/generic/crafting/syntheticmaterial.item.patch
+++ b/items/generic/crafting/syntheticmaterial.item.patch
@@ -1,7 +1,11 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-   "tacticalchest", 
-   "tacticalpants", 
-   "tacticalhead"
-   ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tacticalchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tacticalpants" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tacticalhead" }
+  ]
 ]

--- a/items/generic/crafting/teleportercore.item.patch
+++ b/items/generic/crafting/teleportercore.item.patch
@@ -1,14 +1,18 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-  "blackteleporter",
-  "brassteleporter",
-  "futureteleporter",
-  "scienceteleporter",
-  "stoneteleporter",
-  "tombteleporter",
-  "woodenteleporter",
-  "crossteleporter",
-  "futeleporter",
-  "translocator"
-  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "blackteleporter" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "brassteleporter" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "futureteleporter" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "scienceteleporter" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "stoneteleporter" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tombteleporter" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "woodenteleporter" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "crossteleporter" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "futeleporter" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "translocator" }
+  ]
 ]

--- a/items/generic/crafting/thread.item.patch
+++ b/items/generic/crafting/thread.item.patch
@@ -1,10 +1,12 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": 
-  [ 
-  "gutterpunklegs", 
-  "gutterpunkchest",
-  "glitterfolklegs",
-  "glitterfolkchest"
-  ] 
-  }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "gutterpunklegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "gutterpunkchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "glitterfolklegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "glitterfolkchest" }
+  ]
 ]

--- a/items/generic/crafting/titaniumbar.item.patch
+++ b/items/generic/crafting/titaniumbar.item.patch
@@ -1,17 +1,21 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [
-	"titaniumshield",
-	"titaniummachinepistol",
-	"titaniumsniperrifle",
-	"gladiatorshield",
-	"battery",
-	"teslastaff1",
-	"corewhip",
-	"minirocketlauncher",
-	"fu_rocketturret",
-	"kelpsteelhatchet",
-	"fupioneerhead",
-	"fupioneerchest",
-	"fupioneerpants"
-	] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "titaniumshield" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "titaniummachinepistol" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "titaniumsniperrifle" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "gladiatorshield" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "battery" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "teslastaff1" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "corewhip" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "minirocketlauncher" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fu_rocketturret" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "kelpsteelhatchet" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fupioneerhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fupioneerchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fupioneerpants" }
+  ]
 ]

--- a/items/generic/crafting/titaniumore.item.patch
+++ b/items/generic/crafting/titaniumore.item.patch
@@ -1,11 +1,15 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ 
-	  "fu_powersensorlarge",
-	  "isn_hydroponicstray", 
-	  "isn_battery_t1", 
-	  "isn_thermalgenerator",
-	  "titaniumbar", 
-	  "isn_solarpanel", 
-	  "isn_powersensor"
-	  ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fu_powersensorlarge" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "isn_hydroponicstray" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "isn_battery_t1" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "isn_thermalgenerator" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "titaniumbar" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "isn_solarpanel" }, 
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "isn_powersensor" }
+  ]
 ]

--- a/items/generic/crafting/triangliumore.item.patch
+++ b/items/generic/crafting/triangliumore.item.patch
@@ -1,24 +1,24 @@
 [
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup",
-    "value": [
-      "triangliumpyramid"
-    ]
-  },
-  {
-    "op": "add",
-    "path": "/price",
-    "value": 80
-  },
-  {
-    "op": "replace",
-    "path": "/rarity",
-    "value": "rare"
-  },
-   {
-    "op": "replace",
-    "path": "/category",
-    "value": "craftingMaterial"
-  }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "triangliumpyramid" },
+    {
+      "op": "add",
+      "path": "/price",
+      "value": 80
+    },
+    {
+      "op": "replace",
+      "path": "/rarity",
+      "value": "rare"
+    },
+     {
+      "op": "replace",
+      "path": "/category",
+      "value": "craftingMaterial"
+    }
+  ]
 ]

--- a/items/generic/crafting/tungstenbar.item.patch
+++ b/items/generic/crafting/tungstenbar.item.patch
@@ -1,14 +1,18 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [
-	"bugnet2",
-        "hardenedsteelblade",
-        "fusteelgirdirmaterial",
-        "microscope",
-        "retexironblock",
-        "labfence",
-	"handhoe",
-        "tungstenbow",
-	"fudefenseaugment1",
-	"HarvesterBeam"
-    ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "bugnet2" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "hardenedsteelblade" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fusteelgirdirmaterial" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "microscope" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "retexironblock" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "labfence" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "handhoe" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tungstenbow" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fudefenseaugment1" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "HarvesterBeam" }
+  ]
 ]

--- a/items/generic/crafting/uraniumrod.item.patch
+++ b/items/generic/crafting/uraniumrod.item.patch
@@ -1,5 +1,11 @@
 [
-	{"op":"add","path":"/fuelAmount","value": 100},
-	{"op":"add", "path":"/itemTags", "value":["reagent"]},
- 	{"op":"replace", "path":"/category", "value":"fuel"}
+  [
+    { "op": "test", "path": "/itemTags", "inverse" : true },
+    { "op": "add", "path": "/itemTags", "value": [] }
+  ],
+  [
+    {"op":"add","path":"/fuelAmount","value": 100},
+    {"op":"add", "path":"/itemTags/-", "value":"reagent"},
+    {"op":"replace", "path":"/category", "value":"fuel"}
+  ]
 ]

--- a/items/generic/crafting/volatilepowder.item.patch
+++ b/items/generic/crafting/volatilepowder.item.patch
@@ -1,3 +1,10 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "distortionsphere2_tech", "k3rifle" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "distortionsphere2_tech" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "k3rifle" }
+  ]
 ]

--- a/items/generic/crafting/wildvines.item.patch
+++ b/items/generic/crafting/wildvines.item.patch
@@ -1,3 +1,12 @@
 [
- {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "chitinchest", "chitinlegs", "chitinhead", "vinewhip" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "chitinchest" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "chitinlegs" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "chitinhead" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "vinewhip" }
+  ]
 ]

--- a/items/generic/crafting/wire.item.patch
+++ b/items/generic/crafting/wire.item.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "coil", "stickofram" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "coil" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "stickofram" }
+  ]
 ]

--- a/items/generic/produce/thornfruit.consumable.patch
+++ b/items/generic/produce/thornfruit.consumable.patch
@@ -1,3 +1,11 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "thornjuice", "blexplantseed", "yellowfootseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "thornjuice" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "blexplantseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "yellowfootseed" }
+  ]
 ]

--- a/items/liquids/fuel.liqitem.patch
+++ b/items/liquids/fuel.liqitem.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "erchiuspillar" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "erchiuspillar" }
+  ]
 ]

--- a/items/liquids/oil.liqitem.patch
+++ b/items/liquids/oil.liqitem.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "ff_plastic", "chainsaw" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ff_plastic" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "chainsaw" }
+  ]
 ]

--- a/items/liquids/poison.liqitem.patch
+++ b/items/liquids/poison.liqitem.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "venomsample" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "venomsample" }
+  ]
 ]

--- a/items/liquids/water.liqitem.patch
+++ b/items/liquids/water.liqitem.patch
@@ -1,4 +1,11 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "ff_plastic", "chainsaw" ] },
-  {"op":"add","path":"/pickupQuestTemplates","value": [ "fuquest_water" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ff_plastic" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "chainsaw" },
+    { "op" : "add", "path" : "/pickupQuestTemplates", "value" : [ "fuquest_water" ] }
+  ]
 ]

--- a/items/materials/fullwood1.matitem.patch
+++ b/items/materials/fullwood1.matitem.patch
@@ -1,3 +1,10 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "darkwoodmaterial", "eggincubator" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "darkwoodmaterial" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "eggincubator" }
+  ]
 ]

--- a/items/materials/obsidian.matitem.patch
+++ b/items/materials/obsidian.matitem.patch
@@ -1,7 +1,9 @@
 [
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup",
-    "value": [ "scorchedcore" ]
-  }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "scorchedcore" }
+  ]
 ]

--- a/items/materials/sand.matitem.patch
+++ b/items/materials/sand.matitem.patch
@@ -1,3 +1,10 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "sandpillar1", "sandpillar2" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "sandpillar1" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "sandpillar2" }
+  ]
 ]

--- a/items/tools/bugnet.sword.patch
+++ b/items/tools/bugnet.sword.patch
@@ -1,3 +1,9 @@
 [
-	{"op":"add","path":"/learnBlueprintsOnPickup","value": [ "beestation" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "beestation" }
+  ]
 ]

--- a/items/tools/flashlight.flashlight.patch
+++ b/items/tools/flashlight.flashlight.patch
@@ -1,9 +1,9 @@
 [
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup",
-    "value": [
-      "fuflashlight"
-    ]
-  }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fuflashlight" }
+  ]
 ]

--- a/objects/farmables/automato/automatoseed.object.patch
+++ b/objects/farmables/automato/automatoseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "ghostmushroomseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ghostmushroomseed" }
+  ]
 ]

--- a/objects/farmables/automato/wildautomatoseed.object.patch
+++ b/objects/farmables/automato/wildautomatoseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "ghostmushroomseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ghostmushroomseed" }
+  ]
 ]

--- a/objects/farmables/avesmingo/avesmingoseed.object.patch
+++ b/objects/farmables/avesmingo/avesmingoseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "mutaviskseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mutaviskseed" }
+  ]
 ]

--- a/objects/farmables/avesmingo/wildavesmingoseed.object.patch
+++ b/objects/farmables/avesmingo/wildavesmingoseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "mutaviskseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mutaviskseed" }
+  ]
 ]

--- a/objects/farmables/banana/bananaseed.object.patch
+++ b/objects/farmables/banana/bananaseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "whitespine", "ighantseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "whitespine" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ighantseed" }
+  ]
 ]

--- a/objects/farmables/banana/wildbananaseed.object.patch
+++ b/objects/farmables/banana/wildbananaseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "whitespine", "ighantseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "whitespine" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ighantseed" }
+  ]
 ]

--- a/objects/farmables/beakseed/beakseedseed.object.patch
+++ b/objects/farmables/beakseed/beakseedseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "talonseedseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "talonseedseed" }
+  ]
 ]

--- a/objects/farmables/beakseed/wildbeakseedseed.object.patch
+++ b/objects/farmables/beakseed/wildbeakseedseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "talonseedseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "talonseedseed" }
+  ]
 ]

--- a/objects/farmables/bolbohn/bolbohnseed.object.patch
+++ b/objects/farmables/bolbohn/bolbohnseed.object.patch
@@ -1,9 +1,9 @@
 [
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup",
-    "value": [
-      "bolbohnseed"
-    ]
-  }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "bolbohnseed" }
+  ]
 ]

--- a/objects/farmables/bolbohn/wildbolbohnseed.object.patch
+++ b/objects/farmables/bolbohn/wildbolbohnseed.object.patch
@@ -1,9 +1,9 @@
 [
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup",
-    "value": [
-      "bolbohnseed"
-    ]
-  }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "bolbohnseed" }
+  ]
 ]

--- a/objects/farmables/boltbulb/boltbulbseed.object.patch
+++ b/objects/farmables/boltbulb/boltbulbseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "goldshroomseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "goldshroomseed" }
+  ]
 ]

--- a/objects/farmables/boltbulb/wildboltbulbseed.object.patch
+++ b/objects/farmables/boltbulb/wildboltbulbseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "goldshroomseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "goldshroomseed" }
+  ]
 ]

--- a/objects/farmables/boneboo/bonebooseed.object.patch
+++ b/objects/farmables/boneboo/bonebooseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "naileryseed", "pasakavineseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "naileryseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "pasakavineseed" }
+  ]
 ]

--- a/objects/farmables/boneboo/wildbonebooseed.object.patch
+++ b/objects/farmables/boneboo/wildbonebooseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "naileryseed", "pasakavineseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "naileryseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "pasakavineseed" }
+  ]
 ]

--- a/objects/farmables/chili/chiliseed.object.patch
+++ b/objects/farmables/chili/chiliseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "ignuschiliseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ignuschiliseed" }
+  ]
 ]

--- a/objects/farmables/chili/wildchiliseed.object.patch
+++ b/objects/farmables/chili/wildchiliseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "ignuschiliseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ignuschiliseed" }
+  ]
 ]

--- a/objects/farmables/coffee/coffeeseed.object.patch
+++ b/objects/farmables/coffee/coffeeseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "jillyrootseed", "ginsengseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "jillyrootseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ginsengseed" }
+  ]
 ]

--- a/objects/farmables/coffee/wildcoffeeseed.object.patch
+++ b/objects/farmables/coffee/wildcoffeeseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "jillyrootseed", "ginsengseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "jillyrootseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "ginsengseed" }
+  ]
 ]

--- a/objects/farmables/coralcreep/coralcreepseed.object.patch
+++ b/objects/farmables/coralcreep/coralcreepseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "cellpodsplant" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "cellpodsplant" }
+  ]
 ]

--- a/objects/farmables/coralcreep/wildcoralcreepseed.object.patch
+++ b/objects/farmables/coralcreep/wildcoralcreepseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "cellpodsplant" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "cellpodsplant" }
+  ]
 ]

--- a/objects/farmables/corn/cornseed.object.patch
+++ b/objects/farmables/corn/cornseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "biscornseed", "thornitoxseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "biscornseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "thornitoxseed" }
+  ]
 ]

--- a/objects/farmables/corn/wildcornseed.object.patch
+++ b/objects/farmables/corn/wildcornseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "biscornseed", "thornitoxseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "biscornseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "thornitoxseed" }
+  ]
 ]

--- a/objects/farmables/currentcorn/currentcornseed.object.patch
+++ b/objects/farmables/currentcorn/currentcornseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "shinyacornseed", "batterystem" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "shinyacornseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "batterystem" }
+  ]
 ]

--- a/objects/farmables/currentcorn/wildcurrentcornseed.object.patch
+++ b/objects/farmables/currentcorn/wildcurrentcornseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "shinyacornseed", "batterystem" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "shinyacornseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "batterystem" }
+  ]
 ]

--- a/objects/farmables/dirturchin/dirturchinseed.object.patch
+++ b/objects/farmables/dirturchin/dirturchinseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "mireurchinseed", "yellowfootseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mireurchinseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "yellowfootseed" }
+  ]
 ]

--- a/objects/farmables/dirturchin/wilddirturchinseed.object.patch
+++ b/objects/farmables/dirturchin/wilddirturchinseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "mireurchinseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mireurchinseed" }
+  ]
 ]

--- a/objects/farmables/dunestalk/dunestalkseed.object.patch
+++ b/objects/farmables/dunestalk/dunestalkseed.object.patch
@@ -1,7 +1,9 @@
 [
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup",
-    "value": [ "dunestalkseed" ]
-  }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "dunestalkseed" }
+  ]
 ]

--- a/objects/farmables/dunestalk/wildedunestalkseed.object.patch
+++ b/objects/farmables/dunestalk/wildedunestalkseed.object.patch
@@ -1,7 +1,9 @@
 [
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup",
-    "value": [ "dunestalkseed" ]
-  }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "dunestalkseed" }
+  ]
 ]

--- a/objects/farmables/eggshoot/eggshootseed.object.patch
+++ b/objects/farmables/eggshoot/eggshootseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "aenemaflower" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "aenemaflower" }
+  ]
 ]

--- a/objects/farmables/eggshoot/wildeggshootseed.object.patch
+++ b/objects/farmables/eggshoot/wildeggshootseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "aenemaflower" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "aenemaflower" }
+  ]
 ]

--- a/objects/farmables/feathercrown/feathercrownseed.object.patch
+++ b/objects/farmables/feathercrown/feathercrownseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "oonfortaseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "oonfortaseed" }
+  ]
 ]

--- a/objects/farmables/feathercrown/wildfeathercrownseed.object.patch
+++ b/objects/farmables/feathercrown/wildfeathercrownseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "oonfortaseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "oonfortaseed" }
+  ]
 ]

--- a/objects/farmables/grapes/grapesseed.object.patch
+++ b/objects/farmables/grapes/grapesseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "corvexseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "corvexseed" }
+  ]
 ]

--- a/objects/farmables/grapes/wildgrapesseed.object.patch
+++ b/objects/farmables/grapes/wildgrapesseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "corvexseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "corvexseed" }
+  ]
 ]

--- a/objects/farmables/kiwi/kiwiseed.object.patch
+++ b/objects/farmables/kiwi/kiwiseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "fusnowberryseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fusnowberryseed" }
+  ]
 ]

--- a/objects/farmables/kiwi/wildkiwiseed.object.patch
+++ b/objects/farmables/kiwi/wildkiwiseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "fusnowberryseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fusnowberryseed" }
+  ]
 ]

--- a/objects/farmables/mushroom/mushroomseed.object.patch
+++ b/objects/farmables/mushroom/mushroomseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "shockshroomseed", "yellowfootseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "shockshroomseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "yellowfootseed" }
+  ]
 ]

--- a/objects/farmables/neonmelon/neonmelonseed.object.patch
+++ b/objects/farmables/neonmelon/neonmelonseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "bluemelonseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "bluemelonseed" }
+  ]
 ]

--- a/objects/farmables/neonmelon/wildneonmelonseed.object.patch
+++ b/objects/farmables/neonmelon/wildneonmelonseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "bluemelonseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "bluemelonseed" }
+  ]
 ]

--- a/objects/farmables/oculemon/oculemonseed.object.patch
+++ b/objects/farmables/oculemon/oculemonseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "gazelemonseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "gazelemonseed" }
+  ]
 ]

--- a/objects/farmables/oculemon/wildoculemonseed.object.patch
+++ b/objects/farmables/oculemon/wildoculemonseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "gazelemonseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "gazelemonseed" }
+  ]
 ]

--- a/objects/farmables/pearlpea/pearlpeaseed.object.patch
+++ b/objects/farmables/pearlpea/pearlpeaseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "littlegoodberryseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "littlegoodberryseed" }
+  ]
 ]

--- a/objects/farmables/pearlpea/wildpearlpeaseed.object.patch
+++ b/objects/farmables/pearlpea/wildpearlpeaseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "littlegoodberryseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "littlegoodberryseed" }
+  ]
 ]

--- a/objects/farmables/pineapple/pineappleseed.object.patch
+++ b/objects/farmables/pineapple/pineappleseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "quellstem" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "quellstem" }
+  ]
 ]

--- a/objects/farmables/pineapple/wildpineappleseed.object.patch
+++ b/objects/farmables/pineapple/wildpineappleseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "quellstem" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "quellstem" }
+  ]
 ]

--- a/objects/farmables/potato/potatoseed.object.patch
+++ b/objects/farmables/potato/potatoseed.object.patch
@@ -1,3 +1,11 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "diodiahybridseed", "poetree", "bolbohnseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "diodiahybridseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "poetree" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "bolbohnseed" }
+  ]
 ]

--- a/objects/farmables/potato/wildpotatoseed.object.patch
+++ b/objects/farmables/potato/wildpotatoseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "diodiahybridseed", "poetree" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "diodiahybridseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "poetree" }
+  ]
 ]

--- a/objects/farmables/pussplum/pussplumseed.object.patch
+++ b/objects/farmables/pussplum/pussplumseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "isn_meatplant" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "isn_meatplant" }
+  ]
 ]

--- a/objects/farmables/pussplum/wildpussplumseed.object.patch
+++ b/objects/farmables/pussplum/wildpussplumseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "isn_meatplant" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "isn_meatplant" }
+  ]
 ]

--- a/objects/farmables/reefpod/reefpodseed.object.patch
+++ b/objects/farmables/reefpod/reefpodseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "aquapodseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "aquapodseed" }
+  ]
 ]

--- a/objects/farmables/reefpod/wildreefpodseed.object.patch
+++ b/objects/farmables/reefpod/wildreefpodseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "aquapodseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "aquapodseed" }
+  ]
 ]

--- a/objects/farmables/rice/riceseed.object.patch
+++ b/objects/farmables/rice/riceseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "stranglevineseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "stranglevineseed" }
+  ]
 ]

--- a/objects/farmables/rice/wildriceseed.object.patch
+++ b/objects/farmables/rice/wildriceseed.object.patch
@@ -1,3 +1,10 @@
+
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "stranglevineseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "stranglevineseed" }
+  ]
 ]

--- a/objects/farmables/sugarcane/sugarcaneseed.object.patch
+++ b/objects/farmables/sugarcane/sugarcaneseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "minkocoapodseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "minkocoapodseed" }
+  ]
 ]

--- a/objects/farmables/sugarcane/wildsugarcaneseed.object.patch
+++ b/objects/farmables/sugarcane/wildsugarcaneseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "minkocoapodseed", "mutaviskseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "minkocoapodseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mutaviskseed" }
+  ]
 ]

--- a/objects/farmables/thornplant/thornplant.object.patch
+++ b/objects/farmables/thornplant/thornplant.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "blexplantseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "blexplantseed" }
+  ]
 ]

--- a/objects/farmables/tomato/tomatoseed.object.patch
+++ b/objects/farmables/tomato/tomatoseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "teratomatoseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "teratomatoseed" }
+  ]
 ]

--- a/objects/farmables/tomato/wildtomatoseed.object.patch
+++ b/objects/farmables/tomato/wildtomatoseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "teratomatoseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "teratomatoseed" }
+  ]
 ]

--- a/objects/farmables/toxictop/toxictopseed.object.patch
+++ b/objects/farmables/toxictop/toxictopseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "slimeplantseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "slimeplantseed" }
+  ]
 ]

--- a/objects/farmables/toxictop/wildtoxictopseed.object.patch
+++ b/objects/farmables/toxictop/wildtoxictopseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "slimeplantseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "slimeplantseed" }
+  ]
 ]

--- a/objects/farmables/wartweed/wartweedseed.object.patch
+++ b/objects/farmables/wartweed/wartweedseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "onionseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "onionseed" }
+  ]
 ]

--- a/objects/farmables/wartweed/wildwartweedseed.object.patch
+++ b/objects/farmables/wartweed/wildwartweedseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "onionseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "onionseed" }
+  ]
 ]

--- a/objects/farmables/wheat/wheatseed.object.patch
+++ b/objects/farmables/wheat/wheatseed.object.patch
@@ -1,3 +1,10 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "brackentreeseed", "dunestalkseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "brackentreeseed" },
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "dunestalkseed" }
+  ]
 ]

--- a/objects/farmables/wheat/wildwheatseed.object.patch
+++ b/objects/farmables/wheat/wildwheatseed.object.patch
@@ -1,3 +1,9 @@
 [
-  {"op":"add","path":"/learnBlueprintsOnPickup","value": [ "brackentreeseed" ] }
+  [
+    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+  ],
+  [
+    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "brackentreeseed" }
+  ]
 ]

--- a/objects/outpost/coffeemachine/coffeemachine.object.patch
+++ b/objects/outpost/coffeemachine/coffeemachine.object.patch
@@ -1,10 +1,40 @@
 [
-	{ "op": "add", "path": "/autoCloseCooldown", "value": 3600 },
-	{ "op": "add", "path": "/frameCooldown", "value": 5 },
-	{ "op": "add", "path": "/objectType", "value": "container" },
-	{ "op": "add", "path": "/openSounds", "value": [ "/sfx/objects/campfire_use.ogg" ] },
-	{ "op": "add", "path": "/recipeGroup", "value": "coffeemachine" },
-	{ "op": "add", "path": "/slotCount", "value": 2 },
-	{ "op": "add", "path": "/uiConfig", "value": "/interface/objectcrafting/coffeemachine.config" },
-	{ "op": "replace", "path": "/category", "value": "crafting" }
+  [
+    { "op": "test", "path": "/openSounds", "inverse" : true },
+    { "op": "add", "path": "/openSounds", "value": [] }
+  ],
+  [
+    { "op": "test", "path": "/uiConfig", "inverse" : true },
+    { "op": "add", "path": "/uiConfig", "value": "" }
+  ],
+  [
+    { "op": "test", "path": "/recipeGroup", "inverse" : true },
+    { "op": "add", "path": "/recipeGroup", "value": "" }
+  ],
+  [
+    { "op": "test", "path": "/autoCloseCooldown", "inverse" : true },
+    { "op": "add", "path": "/autoCloseCooldown", "value": 0 }
+  ],
+  [
+    { "op": "test", "path": "/frameCooldown", "inverse" : true },
+    { "op": "add", "path": "/frameCooldown", "value": 0 }
+  ],
+  [
+    { "op": "test", "path": "/slotCount", "inverse" : true },
+    { "op": "add", "path": "/slotCount", "value": 0 }
+  ],
+  [
+    { "op": "test", "path": "/objectType", "inverse" : true },
+    { "op": "add", "path": "/objectType", "value": "" }
+  ],
+  [
+    { "op" : "add", "path" : "/openSounds/-", "value" : "/sfx/objects/campfire_use.ogg" },
+    { "op": "replace", "path": "/autoCloseCooldown", "value": 3600 },
+    { "op": "replace", "path": "/frameCooldown", "value": 5 },
+    { "op": "replace", "path": "/objectType", "value": "container" },
+    { "op": "replace", "path": "/recipeGroup", "value": "coffeemachine" },
+    { "op": "replace", "path": "/slotCount", "value": 2 },
+    { "op": "replace", "path": "/uiConfig", "value": "/interface/objectcrafting/coffeemachine.config" },
+    { "op": "replace", "path": "/category", "value": "crafting" }
+  ]
 ]


### PR DESCRIPTION
A few improvements to the patch files particularly when adding properties to objects that didn't have them.

Most of the changes were made to accommodate adding the learnBlueprintsOnPickup property.

The problems arose when another mod is loaded before Frackin' Universe, Alphabetically or otherwise, where the other mod also adds the learnBlueprintsOnPickup property. Frackin' Universe overridea the changes made in the other mod with the patch files it currently has.

I can break this PR up into multiple if you'd like, whoever is reviewing this, it could be easier to review and revert if there are problems I didn't discover.