### PR TITLE
Fixed typo preventing the mechgauss.recipe from being loaded

### DIFF
--- a/recipes/armory/ranged/guns/mechs/mechgauss.recipe
+++ b/recipes/armory/ranged/guns/mechs/mechgauss.recipe
@@ -2,7 +2,7 @@
   "input" : [
    { "item" : "fugaussrifle", "count" : 1 },
    { "item" : "carbonplate", "count" : 6 },
-   { "item" : "advciricuit", "count" : 2 }
+   { "item" : "advcircuit", "count" : 2 }
   ],
   "output" : {
     "item" : "fugaussmecha",


### PR DESCRIPTION
Pretty ironic that I typoed in the commit message, but still. Just noticed that as I was loading the mod onto my server.