### PR TITLE
Small set bonuses description fixes

### DIFF
--- a/items/armors/tier2/sanguine/bloodgarb.chest
+++ b/items/armors/tier2/sanguine/bloodgarb.chest
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Uncommon",
   "description" : "Set Bonus:
-^cyan;+5% Crit (Daggers, Whips), + 0.2% Regen^reset;
+^cyan;+4% Crit (Daggers, Whips), + 0.2% Regen^reset;
 ^green;+10% Speed, +10% Shadow Resistance^reset;",
   "shortdescription" : "Sanguine Vest",
   "category" : "chestarmour",

--- a/items/armors/tier2/sanguine/bloodgarb.head
+++ b/items/armors/tier2/sanguine/bloodgarb.head
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Uncommon",
   "description" : "Set Bonus:
-^cyan;+5% Crit (Daggers, Whips), + 0.2% Regen^reset;
+^cyan;+4% Crit (Daggers, Whips), + 0.2% Regen^reset;
 ^green;+10% Speed, +10% Shadow Resistance^reset;",
   "shortdescription" : "Sanguine Crown",
   "category" : "headarmour",

--- a/items/armors/tier3/dweller/hooded.head
+++ b/items/armors/tier3/dweller/hooded.head
@@ -6,7 +6,7 @@
   "rarity" : "rare",
   "description" : "Set Bonus:
 ^#c74eff;Immune: Slime, Mud, Ice, Snow, Tar^reset;
-^green;Detects Ore(wip), +120% Mining Laser damage^reset;", 
+^green;+120% Mining Laser damage^reset;", 
   "shortdescription" : "Dweller Cowl",
   "category" : "headarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier3/dweller/hooded.legs
+++ b/items/armors/tier3/dweller/hooded.legs
@@ -6,7 +6,7 @@
   "rarity" : "rare",
   "description" : "Set Bonus:
 ^#c74eff;Immune: Slime, Mud, Ice, Snow, Tar^reset;
-^green;Detects Ore(wip), +120% Mining Laser damage^reset;", 
+^green;+120% Mining Laser damage^reset;", 
   "shortdescription" : "Dweller Greaves",
   "category" : "legarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier3/ff_slimearmor2/ff_slimearmor2.chest
+++ b/items/armors/tier3/ff_slimearmor2/ff_slimearmor2.chest
@@ -6,8 +6,8 @@
   "rarity" : "Rare",
   "description" : "Set Bonus:
 ^cyan;+18% Poison/Radiation Resist, +10% Damage, +6% Crit (Slime weapons). ^reset;
-^#e43774;Immune: Poison, Bioooze, Slime. Spawns minions. ^reset;
-^green;Immune: Mud, Slime, Mud and Clay tiles^reset;", 
+^#e43774;Immune: Poison, Bioooze, Slime. Spawns minions. +Slime Weapon Damage^reset;
+^green;Immune: Mud, Slime, Mud and Clay tiles^reset;",   
   "shortdescription" : "Black Slime Chest",
   "category" : "^#e43774;Upgradeable Armor^reset;",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier3/ff_slimearmor2/ff_slimearmor2.head
+++ b/items/armors/tier3/ff_slimearmor2/ff_slimearmor2.head
@@ -6,7 +6,7 @@
   "rarity" : "Rare",
   "description" : "Set Bonus:
 ^cyan;+18% Poison/Radiation Resist, +10% Damage, +6% Crit (Slime weapons). ^reset;
-^#e43774;Immune: Poison, Bioooze, Slime. Spawns minions. ^reset;
+^#e43774;Immune: Poison, Bioooze, Slime. Spawns minions. +Slime Weapon Damage^reset;
 ^green;Immune: Mud, Slime, Mud and Clay tiles^reset;",   
   "shortdescription" : "Black Slime Helm",
   "category" : "^#e43774;Upgradeable Armor^reset;",


### PR DESCRIPTION
Some pieces from the Sanguine armor set and the Black Slime armor set had different/wrong/missing stuff from their bonuses descriptions. This PR fixes it.

I also noticed that the "Dweller Armor" chest piece is missing the "Detects Ore(wip)", and I could not find the effect implementation. Should the "Detects Ore(wip)" be present on the chest piece or removed from all others?