### PR TITLE
Add massive worlds to all non-ocean planet types

### DIFF
--- a/celestial.config.patch
+++ b/celestial.config.patch
@@ -1429,7 +1429,8 @@
           "orbitRange" : [4, 5],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "binarySunScorching"},
+            {"weight" : 0.4, "item" : "binarySunScorching"},
+            {"weight" : 0.3, "item" : "binarySunScorchingNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1444,7 +1445,8 @@
           "orbitRange" : [6, 7],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "binarySunHot"},
+            {"weight" : 0.4, "item" : "binarySunHot"},
+            {"weight" : 0.3, "item" : "binarySunHotNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1459,7 +1461,8 @@
           "orbitRange" : [8, 9],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "binarySunHabitable"},
+            {"weight" : 0.4, "item" : "binarySunHabitable"},
+            {"weight" : 0.3, "item" : "binarySunHabitableNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1473,7 +1476,8 @@
           "orbitRange" : [10, 10],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "binarySunCool"},
+            {"weight" : 0.4, "item" : "binarySunCool"},
+            {"weight" : 0.3, "item" : "binarySunCoolNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1487,7 +1491,8 @@
           "orbitRange" : [11, 11],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "binarySunFrozen"},
+            {"weight" : 0.4, "item" : "binarySunFrozen"},
+            {"weight" : 0.3, "item" : "binarySunFrozenNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1550,7 +1555,8 @@
           "orbitRange" : [4, 5],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "redSunScorching"},
+            {"weight" : 0.4, "item" : "redSunScorching"},
+            {"weight" : 0.3, "item" : "redSunScorchingNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1565,7 +1571,8 @@
           "orbitRange" : [6, 7],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "redSunHot"},
+            {"weight" : 0.4, "item" : "redSunHot"},
+            {"weight" : 0.3, "item" : "redSunHotNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1580,7 +1587,8 @@
           "orbitRange" : [8, 9],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "redSunHabitable"},
+            {"weight" : 0.4, "item" : "redSunHabitable"},
+            {"weight" : 0.3, "item" : "redSunHabitableNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1594,7 +1602,8 @@
           "orbitRange" : [10, 10],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "redSunCool"},
+            {"weight" : 0.4, "item" : "redSunCool"},
+            {"weight" : 0.3, "item" : "redSunCoolNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1608,7 +1617,8 @@
           "orbitRange" : [11, 11],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "redSunFrozen"},
+            {"weight" : 0.4, "item" : "redSunFrozen"},
+            {"weight" : 0.3, "item" : "redSunFrozenNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1671,7 +1681,8 @@
           "orbitRange" : [4, 5],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunScorching"},
+            {"weight" : 0.4, "item" : "blueSunScorching"},
+            {"weight" : 0.3, "item" : "blueSunScorchingNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1686,7 +1697,8 @@
           "orbitRange" : [6, 7],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunHot"},
+            {"weight" : 0.4, "item" : "blueSunHot"},
+            {"weight" : 0.3, "item" : "blueSunHotNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1701,7 +1713,8 @@
           "orbitRange" : [8, 9],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunHabitable"},
+            {"weight" : 0.4, "item" : "blueSunHabitable"},
+            {"weight" : 0.3, "item" : "blueSunHabitableNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1715,7 +1728,8 @@
           "orbitRange" : [10, 10],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunCold"},
+            {"weight" : 0.4, "item" : "blueSunCold"},
+            {"weight" : 0.3, "item" : "blueSunColdNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1729,7 +1743,8 @@
           "orbitRange" : [11, 11],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunFrozen"},
+            {"weight" : 0.4, "item" : "blueSunFrozen"},
+            {"weight" : 0.3, "item" : "blueSunFrozenNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1793,7 +1808,8 @@
           "orbitRange" : [4, 5],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunScorching"},
+            {"weight" : 0.4, "item" : "blueSunScorching"},
+            {"weight" : 0.3, "item" : "blueSunScorchingNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1808,7 +1824,8 @@
           "orbitRange" : [6, 7],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunHot"},
+            {"weight" : 0.4, "item" : "blueSunHot"},
+            {"weight" : 0.3, "item" : "blueSunHotNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1823,7 +1840,8 @@
           "orbitRange" : [8, 9],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunHabitable"},
+            {"weight" : 0.4, "item" : "blueSunHabitable"},
+            {"weight" : 0.3, "item" : "blueSunHabitableNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1837,7 +1855,8 @@
           "orbitRange" : [10, 10],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunCold"},
+            {"weight" : 0.4, "item" : "blueSunCold"},
+            {"weight" : 0.3, "item" : "blueSunColdNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1851,7 +1870,8 @@
           "orbitRange" : [11, 11],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blueSunFrozen"},
+            {"weight" : 0.4, "item" : "blueSunFrozen"},
+            {"weight" : 0.3, "item" : "blueSunFrozenNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1907,7 +1927,8 @@
           "orbitRange" : [4, 5],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blackSunScorching"},
+            {"weight" : 0.4, "item" : "blackSunScorching"},
+            {"weight" : 0.3, "item" : "blackSunScorchingNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1921,7 +1942,8 @@
           "orbitRange" : [6, 7],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blackSunHot"},
+            {"weight" : 0.4, "item" : "blackSunHot"},
+            {"weight" : 0.3, "item" : "blackSunHotNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1935,7 +1957,8 @@
           "orbitRange" : [7, 9],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blackSunHabitable"},
+            {"weight" : 0.4, "item" : "blackSunHabitable"},
+            {"weight" : 0.3, "item" : "blackSunHabitableNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1949,7 +1972,8 @@
           "orbitRange" : [10, 10],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blackSunCool"},
+            {"weight" : 0.4, "item" : "blackSunCool"},
+            {"weight" : 0.3, "item" : "blackSunCoolNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -1963,7 +1987,8 @@
           "orbitRange" : [11, 11],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "blackSunFrozen"},
+            {"weight" : 0.4, "item" : "blackSunFrozen"},
+            {"weight" : 0.3, "item" : "blackSunFrozenNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -2027,7 +2052,8 @@
           "orbitRange" : [4, 5],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "dyingSunScorching"},
+            {"weight" : 0.4, "item" : "dyingSunScorching"},
+            {"weight" : 0.3, "item" : "dyingSunScorchingNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -2041,7 +2067,8 @@
           "orbitRange" : [7, 8],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "dyingSunHot"},
+            {"weight" : 0.4, "item" : "dyingSunHot"},
+            {"weight" : 0.3, "item" : "dyingSunHotNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -2055,7 +2082,8 @@
           "orbitRange" : [9, 9],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "dyingSunHabitable"},
+            {"weight" : 0.4, "item" : "dyingSunHabitable"},
+            {"weight" : 0.3, "item" : "dyingSunHabitableNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -2069,7 +2097,8 @@
           "orbitRange" : [10, 10],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "dyingSunCool"},
+            {"weight" : 0.4, "item" : "dyingSunCool"},
+            {"weight" : 0.3, "item" : "dyingSunCoolNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -2083,7 +2112,8 @@
           "orbitRange" : [11, 11],
           "bodyProbability" : 0.7,
           "planetaryTypes" : [
-            {"weight" : 0.7, "item" : "dyingSunFrozen"},
+            {"weight" : 0.4, "item" : "dyingSunFrozen"},
+            {"weight" : 0.3, "item" : "dyingSunFrozenNoOcean"},
             {"weight" : 0.07, "item" : "fugasplanet"},
             {"weight" : 0.04, "item" : "AsteroidField"}
           ],
@@ -2457,10 +2487,93 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/redSunScorchingNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Scorching Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_scorched.png",
+        "terrestrialType" : [ "barren", "ffunknown", "sulphuric", "volcanic", "magma" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
     "path" : "/planetaryTypes/redSunHot",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Hot Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_hot.png",
+        "terrestrialType" : [ "arboreal", "barren", "chromatic", "thickjungle", "ffunknown", "savannah" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/redSunHotNoOcean",
     "value" : {
       "satelliteProbability" : 0.35,
       "maxSatelliteCount" : 2,
@@ -2488,11 +2601,30 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
 },
-
 
 {
     "op" : "add",
@@ -2525,6 +2657,61 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/redSunHabitableNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Habitable Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_habitable.png",
+
+        "terrestrialType" : [ "arboreal", "barren", "bog", "mountainous", "thickjungle", "crystalmoon", "desert", "forest", "ffunknown" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
@@ -2565,7 +2752,61 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/redSunCoolNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Cool Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_cool.png",
 
+        "terrestrialType" : [ "barren", "bog", "mountainous", "crystalmoon", "snow", "forest", "ffunknown", "tundra" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 
 {
@@ -2598,6 +2839,60 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/redSunFrozenNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Frozen Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_frozen.png",
+        "terrestrialType" : [ "crystalmoon", "snow", "arctic", "ffunknown", "tundra", "icewaste" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
@@ -2638,6 +2933,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/binarySunScorchingNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Scorching Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_scorched.png",
+        "terrestrialType" : [ "scorchedcity", "barren", "ffunknown", "volcanic", "magma" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -2673,7 +3022,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/binarySunHotNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Hot Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_hot.png",
+        "terrestrialType" : [ "scorchedcity", "barren", "bog", "urbanwasteland", "irradiated", "ffunknown", "superdense", "slimeworld", "jungle", "alien", "savannah", "midnight" ]
+      },
 
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -2705,6 +3107,60 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/binarySunHabitableNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Habitable Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_habitable.png",
+        "terrestrialType" : [ "arboreal", "barren", "bog", "urbanwasteland", "eden", "irradiated", "ffunknown", "superdense", "slimeworld", "forest", "jungle", "alien" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
@@ -2744,8 +3200,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/binarySunCoolNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Cool Planet",
+        // "smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_cool.png",
+        "terrestrialType" : [ "arboreal", "barren", "bog", "urbanwasteland", "eden", "irradiated", "ffunknown", "superdense", "slimeworld", "thickjungle", "jungle", "alien", "toxic", "metallicmoon", "tundra" ]
+      },
 
-
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -2781,7 +3289,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/binarySunFrozenNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Frozen Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_frozen.png",
+        "terrestrialType" : [ "crystalmoon", "snow", "arctic", "ffunknown", "tundra" ]
+      },
 
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 
 {
@@ -2814,6 +3375,60 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blueSunScorchingNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Scorching Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_scorched.png",
+        "terrestrialType" : [ "scorchedcity", "ffunknown", "volcanic", "magma", "infernus", "tarball" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
@@ -2853,7 +3468,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blueSunHotNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Hot Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_hot.png",
+        "terrestrialType" : [ "scorchedcity", "ffunknown", "volcanic", "magma", "infernus", "desertwastes", "tabularasa", "fungus", "tarball", "arboreal2" ]
+      },
 
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -2885,6 +3553,60 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blueSunHabitableNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Habitable Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_habitable.png",
+        "terrestrialType" : [ "barren", "scorchedcity", "volcanic", "urbanwasteland", "desertwastes", "tabularasa", "fungus", "tarball", "alien", "arboreal2", "toxic" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
@@ -2924,8 +3646,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blueSunColdNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Cool Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_cool.png",
+        "terrestrialType" : [ "savannah", "urbanwasteland", "desert", "tabularasa", "fungus", "tarball", "alien", "toxic", "jungle", "thickjungle" ]
+      },
 
-
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -2957,6 +3731,60 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blueSunFrozenNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Frozen Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_frozen.png",
+        "terrestrialType" : [ "snow", "arctic", "frozenvolcanic", "tundra" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
@@ -2997,6 +3825,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/dyingSunScorchingNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Scorching Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_scorched.png",
+        "terrestrialType" : [ "sulphuric", "ffunknown", "volcanic", "magma" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -3032,7 +3914,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/dyingSunHotNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Hot Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_hot.png",
+        "terrestrialType" : [ "atropus", "protoworld", "jungle", "arboreal2", "urbanwasteland", "alien", "desert" ]
+      },
 
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -3064,6 +3999,60 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/dyingSunHabitableNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Habitable Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_habitable.png",
+        "terrestrialType" : [ "atropus", "protoworld", "arboreal", "urbanwasteland", "alien", "desert" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
@@ -3103,8 +4092,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/dyingSunCoolNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Cool Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_cool.png",
+        "terrestrialType" : [ "penumbra", "tundra", "barren", "alien", "desert" ]
+      },
 
-
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -3136,6 +4177,60 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/dyingSunFrozenNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Frozen Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_frozen.png",
+        "terrestrialType" : [ "snow", "arctic", "tundra" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
@@ -3176,6 +4271,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blackSunScorchingNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Scorching Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_scorched.png",
+        "terrestrialType" : [ "sulphuricdark", "infernusdark", "magmadark", "shadow" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -3207,6 +4356,60 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blackSunHotNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Hot Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_hot.png",
+        "terrestrialType" : [ "atropusdark", "penumbra", "lightless", "shadow", "arborealdark", "sulphuricdark", "protoworlddark" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }
@@ -3247,6 +4450,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blackSunHabitableNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Habitable Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_habitable.png",
+        "terrestrialType" : [ "atropusdark", "penumbra", "lightless", "shadow", "arborealdark", "sulphuricdark", "protoworlddark", "midnight" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -3282,8 +4539,60 @@
       ]
     }
 },
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blackSunCoolNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Cool Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_cool.png",
+        "terrestrialType" : [ "penumbra", "lightless", "atropusdark", "arborealdark", "desertwastesdark", "midnight", "metallicmoon" ]
+      },
 
-
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
+        }
+      ]
+    }
+},
 
 {
     "op" : "add",
@@ -3315,6 +4624,60 @@
           "imageScale" : 0.15,
           "smallImageScale" : 0.6,
           "worldSize" : "large"
+        }
+      ]
+    }
+},
+{
+    "op" : "add",
+    "path" : "/planetaryTypes/blackSunFrozenNoOcean",
+    "value" : {
+      "satelliteProbability" : 0.35,
+      "maxSatelliteCount" : 2,
+      
+      "baseParameters" : {
+        "worldType" : "Terrestrial",
+        "description" : "Frozen Planet",
+        //"smallImage" : "/celestial/system/planet_small.png",
+        "smallImage": "/celestial/system/planet_small_frozen.png",
+        "terrestrialType" : [ "snowdark", "arcticdark", "icewastedark", "tundradark", "penumbra", "shadow" ]
+      },
+
+      "variationParameters" : [
+        {
+          "imageScale" : 0.075,
+          "smallImageScale" : 0.4,
+          "worldSize" : "small"
+        },
+        {
+          "imageScale" : 0.1,
+          "smallImageScale" : 0.5,
+          "worldSize" : "medium"
+        },
+        {
+          "imageScale" : 0.15,
+          "smallImageScale" : 0.6,
+          "worldSize" : "large"
+        },
+        {
+          "imageScale" : 0.18,
+          "smallImageScale" : 0.65,
+          "worldSize" : "huge"
+        },
+        {
+          "imageScale" : 0.20,
+          "smallImageScale" : 0.7,
+          "worldSize" : "mega"
+        },
+        {
+          "imageScale" : 0.25,
+          "smallImageScale" : 0.75,
+          "worldSize" : "immense"
+        },
+        {
+          "imageScale" : 0.3,
+          "smallImageScale" : 0.8,
+          "worldSize" : "mammoth"
         }
       ]
     }


### PR DESCRIPTION
By creating an additional "NoOcean" planetaryType for each orbital zone, it is possible to have the best of both worlds (*snerk*) by having huge, etc. worlds generate, but also have oceanic-type worlds restricted to no greater than large.  (My list: tidewater, ocean, strangesea, bloodstonesea, aethersea; may need refinement as I'm a Tier-3-for-lifer kind of guy and haven't witnessed the latter three.)

- Duplicates all planetaryTypes with an additional *NoOcean type
- Removes "tidewater", "ocean", "strangesea", "bloodstonesea", "aethersea" from *NoOcean planetaryTypes' terrestrialTypes list
- Adds additional *NoOcean planetaryTypes to orbitRegions of all systemTypes
- Weighting 0.4 Normal, 0.3 NoOcean, to preserve same generation frequency of gas giants and asteroids
- As NoOcean types can also generate smaller worlds, massive worlds are now about 20%-30% as common as pre-removal and even more awesome and special when they do occur
- They're great again!

Disadvantages:
- If a new world type is introduced, author will have to remember to add to both the normal and NoOcean terrestrialType list for appropriate system types
- Ocean worlds are slightly reduced in frequency (roughly 40%), although this is an advantage in disguise (we've got one known ocean-covered world in the known universe so far, and it's only 2/3 ocean, most of that only a couple kilometres deep)