### PR TITLE
Bandraflora, Bulbop, Densinium Burrower

### DIFF
--- a/monsters/walkers/bulbopish/bulbop2/bulbop2.monstertype
+++ b/monsters/walkers/bulbopish/bulbop2/bulbop2.monstertype
@@ -33,14 +33,14 @@
           "name" : "action-hop",
           "cooldown" : 0.0,
           "parameters" : {
-            "verticalSpeed" : 50,
-            "horizontalSpeed" : 34,
+            "verticalSpeed" : 48,
+            "horizontalSpeed" : 16,
             "hopSequence" : 2,
             "timeBetweenHops" : 0.0,
             "windupTime" : 0.1,
             "landTime" : 0.1,
             "hopAwayFromWall" : false,
-            "wallVerticalSpeed" : 65
+            "wallVerticalSpeed" : 48
           }
         }
       ],
@@ -50,8 +50,8 @@
           "name" : "action-hop",
           "cooldown" : 0.0,
           "parameters" : {
-            "verticalSpeed" : 55,
-            "horizontalSpeed" : 30,
+            "verticalSpeed" : 24,
+            "horizontalSpeed" : 8,
             "hopSequence" : 5,
             "timeBetweenHops" : 0.05,
             "hopAwayFromWall" : true
@@ -113,7 +113,7 @@
           "baseValue" : 9
         },
         "maxHealth" : {
-          "baseValue" : 35
+          "baseValue" : 50
         },
         "protection" : {
           "baseValue" : 0.0

--- a/monsters/walkers/mandrafloraish/bandraflora/bandraflora.animation
+++ b/monsters/walkers/mandrafloraish/bandraflora/bandraflora.animation
@@ -223,6 +223,7 @@
 
   "sounds" : {
     "aggroHop" : [ "/sfx/npc/monsters/monster_surprise.ogg" ],
-    "deathPuff" : [ "/sfx/npc/enemydeathpuff.ogg" ]
+    "deathPuff" : [ "/sfx/npc/enemydeathpuff.ogg" ],
+    "fire" : [ "/sfx/projectiles/spit1.ogg", "/sfx/projectiles/spit2.ogg" ]
   }
 }

--- a/monsters/walkers/mandrafloraish/bandraflora/bandraflora.monstertype
+++ b/monsters/walkers/mandrafloraish/bandraflora/bandraflora.monstertype
@@ -27,21 +27,48 @@
       "keepTargetInRange" : 50,
       "targetOutOfSightTime" : 2.5,
 
-      "foundTargetActions" : [  ],
+      "foundTargetActions" : [ 
+        {
+          "name" : "action-statuseffect",
+          "parameters" : {
+          "effect" : "bandrafloraspawnbydamage",
+          "duration" : 600
+          }
+        }       
+       ],
 
       "fleeActions" : [],
 
       "hostileActions" : [
         {
-          "name" : "action-charge",
+          "name" : "action-fire",
+          "cooldown" : 0.5,
           "parameters" : {
-            "maximumRange" : 35,
+            "projectileCount" : 3,
+            "projectileType" : "poisonballoon",
+            "projectileParameters" : {},
+            "power" : 0,
+	    "fireState": "charge",
+	    "winddownState": "chargewinddown",
+	    "windupState": "chargewindup",
+	    "fireDelay" : 0.3,
+	    "fireArc" : true,
+	    "highArc" : true,
+            "maximumRange" : 7,
+            "minimumRange" : 0
+          }
+        },
+        {
+          "name" : "action-charge",
+	  "cooldown" : 3.0,
+          "parameters" : {
+            "maximumRange" : 15,
             "windupTime" : 0.6,
 
             "aimAtTarget" : true,
             "chargeTime" : 2,
-            "chargeSpeed" : 40,
-            "chargeControlForce" : 600,
+            "chargeSpeed" : 10,
+            "chargeControlForce" : 300,
             "wallCrashSound" : "",
             "wallCrashEmitter" : "",
 
@@ -101,30 +128,9 @@
       ],
       
       "concurrentHostileActions" : [ 
-        {
-          "name" : "action-projectile",
-          "cooldown" : 0.5,
-          "parameters" : {
-            "projectileCount" : 1,
-            "projectileType" : "poisonballoon",
-            "projectileParameters" : {},
-            "power" : 0,
-            "aimDirection" : [1, 1],
-            "inaccuracy" : 3.5,
-            "fireOffset" : [0, 0]
-          }
-        }       
       ],
       
       "concurrentActions" : [
-        {
-          "name" : "action-spawncompanions",
-          "parameters" : {
-            "maxCount" : 5,
-            "spawnCooldown" : 5.0,
-            "monsterType" : "bulbop2"
-          }
-        }       
       ],
       
       "wanderActions" : [

--- a/stats/monstereffects/segmentprojectilecoordinator/burrowergravitypulse.statuseffect
+++ b/stats/monstereffects/segmentprojectilecoordinator/burrowergravitypulse.statuseffect
@@ -3,6 +3,7 @@
   "effectConfig" : {
     "projectile" : "densiniumgravity",
     "pulse" : 3,
+    "reverse" : true,
     "track" : true
   },
   "defaultDuration" : 10000,

--- a/stats/monstereffects/spawnbydamage/bandrafloraspawnbydamage.statuseffect
+++ b/stats/monstereffects/spawnbydamage/bandrafloraspawnbydamage.statuseffect
@@ -1,0 +1,12 @@
+{
+  "name" : "bandrafloraspawnbydamage",
+  "effectConfig" : {
+    "spawnCount" : 3,
+    "spawnMonster" : "bulbop2"
+  },
+  "defaultDuration" : 600,
+  "scripts" : [
+    "spawnbydamage.lua"
+  ],
+  "scriptDelta" : 10
+}


### PR DESCRIPTION
Bandraflora uses a fire multiple projectile action at short range, replacing the on damage projectile - still uses poison balloons.  Bandraflora's bulbop2 spawns are now controlled like the eyeslimeking spawns - by damage.   To make sure the bulbop2s survive the initial spawn their health has been increased.  Their jump speeds were nerfed heavily for early game balance's sake.  Densinium Burrower had the flow of its gravity pulse reversed so when you're running away from it you can see the fields approaching rather than having to anticipate the jump from tail to head.