### PR TITLE
Generated Weapon Pass 1

### DIFF
--- a/items/active/weapons/melee/longsword/uncommonlongsword.activeitem
+++ b/items/active/weapons/melee/longsword/uncommonlongsword.activeitem
@@ -39,7 +39,6 @@
     ],
     "elementalConfig" : {
       "fire" : {
-        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "burning" ] } },
         "animationCustom" : { "sounds" : {
           "fire" : [ "/sfx/melee/swing_broadsword_fire1.ogg", "/sfx/melee/swing_broadsword_fire2.ogg", "/sfx/melee/swing_broadsword_fire3.ogg" ],
           "fire2" : [ "/sfx/melee/swing_shortsword_fire1.ogg", "/sfx/melee/swing_shortsword_fire2.ogg", "/sfx/melee/swing_shortsword_fire3.ogg" ],
@@ -47,7 +46,6 @@
         } }
       },
       "ice" : {
-        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "frostslow" ] } },
         "animationCustom" : { "sounds" : {
           "fire" : [ "/sfx/melee/swing_broadsword_ice1.ogg", "/sfx/melee/swing_broadsword_ice2.ogg", "/sfx/melee/swing_broadsword_ice3.ogg" ],
           "fire2" : [ "/sfx/melee/swing_shortsword_ice1.ogg", "/sfx/melee/swing_shortsword_ice2.ogg", "/sfx/melee/swing_shortsword_ice3.ogg" ],
@@ -55,7 +53,6 @@
         } }
       },
       "poison" : {
-        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "weakpoison" ] } },
         "animationCustom" : { "sounds" : {
           "fire" : [ "/sfx/melee/swing_broadsword_poison1.ogg", "/sfx/melee/swing_broadsword_poison2.ogg", "/sfx/melee/swing_broadsword_poison3.ogg" ],
           "fire2" : [ "/sfx/melee/swing_shortsword_poison1.ogg", "/sfx/melee/swing_shortsword_poison2.ogg", "/sfx/melee/swing_shortsword_poison3.ogg" ],
@@ -63,7 +60,6 @@
         } }
       },
       "electric" : {
-        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "electrified" ] } },
         "animationCustom" : { "sounds" : {
           "fire" : [ "/sfx/melee/swing_broadsword_electric1.ogg", "/sfx/melee/swing_broadsword_electric2.ogg", "/sfx/melee/swing_broadsword_electric3.ogg" ],
           "fire2" : [ "/sfx/melee/swing_shortsword_electric1.ogg", "/sfx/melee/swing_shortsword_electric2.ogg", "/sfx/melee/swing_shortsword_electric3.ogg" ],
@@ -71,21 +67,18 @@
         } }
       },
       "shadow" : {
-      "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "shadowgasfx" ] } },
       "animationCustom" : { "sounds" : {
         "fire" : [ "/sfx/melee/swing_broadsword_poison1.ogg", "/sfx/melee/swing_broadsword_poison2.ogg", "/sfx/melee/swing_broadsword_poison3.ogg" ],
         "fire2" : [ "/sfx/melee/swing_shortsword_poison1.ogg", "/sfx/melee/swing_shortsword_poison2.ogg", "/sfx/melee/swing_shortsword_poison3.ogg" ],
         "fire3" : [ "/sfx/melee/swing_spear_poison1.ogg", "/sfx/melee/swing_spear_poison2.ogg", "/sfx/melee/swing_spear_poison3.ogg" ] }}
       },
       "radioactive" : {
-      "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "radiationburn" ] } },
       "animationCustom" : { "sounds" : {
         "fire" : [ "/sfx/melee/swing_broadsword_poison1.ogg", "/sfx/melee/swing_broadsword_poison2.ogg", "/sfx/melee/swing_broadsword_poison3.ogg" ],
         "fire2" : [ "/sfx/melee/swing_shortsword_poison1.ogg", "/sfx/melee/swing_shortsword_poison2.ogg", "/sfx/melee/swing_shortsword_poison3.ogg" ],
         "fire3" : [ "/sfx/melee/swing_spear_poison1.ogg", "/sfx/melee/swing_spear_poison2.ogg", "/sfx/melee/swing_spear_poison3.ogg" ] }}
       },
       "cosmic" : {
-      "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "defenseboostneg20" ] } },
       "animationCustom" : { "sounds" : {
         "fire" : [ "/sfx/melee/laser_weapon_swing1.ogg", "/sfx/melee/laser_weapon_swing2.ogg", "/sfx/melee/laser_weapon_swing3.ogg" ],
         "fire2" : [ "/sfx/melee/laser_weapon_swing1.ogg", "/sfx/melee/laser_weapon_swing2.ogg", "/sfx/melee/laser_weapon_swing3.ogg" ],

--- a/items/active/weapons/melee/mace/furaremace.activeitem
+++ b/items/active/weapons/melee/mace/furaremace.activeitem
@@ -2,7 +2,7 @@
   "itemName" : "furaremace",
   "price" : 1000,
   "maxStack" : 1,
-  "rarity" : "rare",
+  "rarity" : "Rare",
   "description" : "A face-whacker!",
   "shortdescription" : "Rare Mace",
   "tooltipKind" : "sword2",

--- a/items/active/weapons/melee/mace/furaremace.activeitem
+++ b/items/active/weapons/melee/mace/furaremace.activeitem
@@ -2,9 +2,9 @@
   "itemName" : "furaremace",
   "price" : 1000,
   "maxStack" : 1,
-  "rarity" : "uncommon",
+  "rarity" : "rare",
   "description" : "A face-whacker!",
-  "shortdescription" : "Common Mace",
+  "shortdescription" : "Rare Mace",
   "tooltipKind" : "sword2",
   "category" : "mace",
   "twoHanded" : false,
@@ -44,24 +44,31 @@
     ],
     "elementalConfig" : {
       "fire" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "burning" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_hammer_fire1.ogg", "/sfx/melee/swing_hammer_fire2.ogg", "/sfx/melee/swing_hammer_fire3.ogg" ] ]
       },
       "ice" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "frostslow" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_hammer_ice1.ogg", "/sfx/melee/swing_hammer_ice2.ogg", "/sfx/melee/swing_hammer_ice3.ogg" ] ]
       },
       "poison" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "weakpoison" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_hammer_poison1.ogg", "/sfx/melee/swing_hammer_poison2.ogg", "/sfx/melee/swing_hammer_poison3.ogg" ] ]
       },
       "electric" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "electrified" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_hammer_electric1.ogg", "/sfx/melee/swing_hammer_electric2.ogg", "/sfx/melee/swing_hammer_electric3.ogg" ] ]
       },
       "shadow" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "shadowgasfx" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_hammer_poison1.ogg", "/sfx/melee/swing_hammer_poison2.ogg", "/sfx/melee/swing_hammer_poison3.ogg" ] ]
       },
       "radioactive" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "radiationburn" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_hammer_poison1.ogg", "/sfx/melee/swing_hammer_poison2.ogg", "/sfx/melee/swing_hammer_poison3.ogg" ] ]
       },
       "cosmic" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "defenseboostneg20" ] } },
         "fireSounds" : [ [ "/sfx/melee/laser_weapon_swing1.ogg", "/sfx/melee/laser_weapon_swing2.ogg", "/sfx/melee/laser_weapon_swing3.ogg" ] ]
       }
     },      

--- a/items/active/weapons/melee/mace/fuuncommonmace.activeitem
+++ b/items/active/weapons/melee/mace/fuuncommonmace.activeitem
@@ -2,7 +2,7 @@
   "itemName" : "fuuncommonmace",
   "price" : 500,
   "maxStack" : 1,
-  "rarity" : "uncommon",
+  "rarity" : "Uncommon",
   "description" : "A face-whacker!",
   "shortdescription" : "Uncommon Mace",
   "tooltipKind" : "sword2",

--- a/items/active/weapons/melee/mace/fuuncommonmace.activeitem
+++ b/items/active/weapons/melee/mace/fuuncommonmace.activeitem
@@ -4,7 +4,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "description" : "A face-whacker!",
-  "shortdescription" : "Common Mace",
+  "shortdescription" : "Uncommon Mace",
   "tooltipKind" : "sword2",
   "category" : "mace",
   "twoHanded" : false,

--- a/items/active/weapons/melee/rapier/furarerapier.activeitem
+++ b/items/active/weapons/melee/rapier/furarerapier.activeitem
@@ -45,24 +45,31 @@
     ],
     "elementalConfig" : {
       "fire" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "burning" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_spear_fire1.ogg", "/sfx/melee/swing_spear_fire2.ogg", "/sfx/melee/swing_spear_fire3.ogg" ] ]
       },
       "ice" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "frostslow" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_spear_ice1.ogg", "/sfx/melee/swing_spear_ice2.ogg", "/sfx/melee/swing_spear_ice3.ogg" ] ]
       },
       "poison" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "weakpoison" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_spear_poison1.ogg", "/sfx/melee/swing_spear_poison2.ogg", "/sfx/melee/swing_spear_poison3.ogg" ] ]
       },
       "electric" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "electrified" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_spear_electric1.ogg", "/sfx/melee/swing_spear_electric2.ogg", "/sfx/melee/swing_spear_electric3.ogg" ] ]
       },
       "shadow" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "shadowgasfx" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_spear_poison1.ogg", "/sfx/melee/swing_spear_poison2.ogg", "/sfx/melee/swing_spear_poison3.ogg" ] ]
       },
       "radioactive" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "radiationburn" ] } },
         "fireSounds" : [ [ "/sfx/melee/swing_spear_poison1.ogg", "/sfx/melee/swing_spear_poison2.ogg", "/sfx/melee/swing_spear_poison3.ogg" ] ]
       },
       "cosmic" : {
+        "primaryAbility" : { "damageConfig" : { "statusEffects" : [ "defenseboostneg20" ] } },
         "fireSounds" : [ [ "/sfx/melee/laser_weapon_swing1.ogg", "/sfx/melee/laser_weapon_swing2.ogg", "/sfx/melee/laser_weapon_swing3.ogg" ] ]
       }
     },    

--- a/items/active/weapons/ranged/assaultrifle/swtjc_ewg_uncommonsaw.activeitem
+++ b/items/active/weapons/ranged/assaultrifle/swtjc_ewg_uncommonsaw.activeitem
@@ -96,15 +96,15 @@
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/rifle1.ogg", "/sfx/gun/rifle2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/sniper1.ogg", "/sfx/gun/sniper2.ogg", "/sfx/gun/sniper3.ogg", "/sfx/gun/sniper4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : "radioactiveplasma", "projectileParameters" : { "statusEffects" : [ "radiationburn" ] } },
+        "primaryAbility" : { "projectileType" : "radioactiveplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_pistol1.ogg", "/sfx/gun/plasma_pistol2.ogg", "/sfx/gun/plasma_pistol3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg", "/sfx/gun/pulsecannon1.ogg" ]
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : "shadowplasma", "projectileParameters" : { "statusEffects" : [ "shadowgasfx" ] } },
+        "primaryAbility" : { "projectileType" : "shadowplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_pistol1.ogg", "/sfx/gun/plasma_pistol2.ogg", "/sfx/gun/plasma_pistol3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg", "/sfx/gun/pulsecannon1.ogg" ]
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : "cosmicplasma", "projectileParameters" : { "statusEffects" : [ "percentarmorboostneg2" ] } },
+        "primaryAbility" : { "projectileType" : "cosmicplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_pistol1.ogg", "/sfx/gun/plasma_pistol2.ogg", "/sfx/gun/plasma_pistol3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg", "/sfx/gun/pulsecannon1.ogg" ]
       } 
     },

--- a/items/active/weapons/ranged/grenadelauncher/swtjc_ewg_raremultigrenadelauncher.activeitem
+++ b/items/active/weapons/ranged/grenadelauncher/swtjc_ewg_raremultigrenadelauncher.activeitem
@@ -102,25 +102,25 @@
     ],
     "elementalConfig" : {
       "fire" : {
-        "primaryAbility" : { "projectileType" : [ "fireplasmagrenade", "fireplasmaimpactgrenade", "firestickygrenade", "fireproximitymine" ] }
+        "primaryAbility" : { "projectileType" : [ "fireplasmagrenadestatus", "fireplasmaimpactgrenadestatus", "firestickygrenadestatus", "fireproximityminestatus" ] }
       },
       "ice" : {
-        "primaryAbility" : { "projectileType" : [ "iceplasmagrenade", "iceplasmaimpactgrenade", "icestickygrenade", "iceproximitymine" ] }
+        "primaryAbility" : { "projectileType" : [ "iceplasmagrenadestatus", "iceplasmaimpactgrenadestatus", "icestickygrenadestatus", "iceproximityminestatus" ] }
       },
       "poison" : {
-        "primaryAbility" : { "projectileType" : [ "poisonplasmagrenade", "poisonplasmaimpactgrenade", "poisonstickygrenade", "poisonproximitymine" ] }
+        "primaryAbility" : { "projectileType" : [ "poisonplasmagrenadestatus", "poisonplasmaimpactgrenadestatus", "poisonstickygrenadestatus", "poisonproximityminestatus" ] }
       },
       "electric" : {
-        "primaryAbility" : { "projectileType" : [ "electricplasmagrenade", "electricplasmaimpactgrenade", "electricstickygrenade", "electricproximitymine" ] }
+        "primaryAbility" : { "projectileType" : [ "electricplasmagrenadestatus", "electricplasmaimpactgrenadestatus", "electricstickygrenadestatus", "electricproximityminestatus" ] }
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : [ "radioactiveplasmagrenade", "radioactiveplasmaimpactgrenade", "radioactivestickygrenade", "radioactiveproximitymine" ] }
+        "primaryAbility" : { "projectileType" : [ "radioactiveplasmagrenadestatus", "radioactiveplasmaimpactgrenadestatus", "radioactivestickygrenadestatus", "radioactiveproximityminestatus" ] }
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : [ "shadowplasmagrenade", "shadowplasmaimpactgrenade", "shadowstickygrenade", "shadowproximitymine" ] }
+        "primaryAbility" : { "projectileType" : [ "shadowplasmagrenadestatus", "shadowplasmaimpactgrenadestatus", "shadowstickygrenadestatus", "shadowproximityminestatus" ] }
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : [ "cosmicplasmagrenade", "cosmicplasmaimpactgrenade", "cosmicstickygrenade", "cosmicproximitymine" ] }
+        "primaryAbility" : { "projectileType" : [ "cosmicplasmagrenadestatus", "cosmicplasmaimpactgrenadestatus", "cosmicstickygrenadestatus", "cosmicproximityminestatus" ] }
       }      
     },
     "animationParts" : {

--- a/items/active/weapons/ranged/machinepistol/swtjc_ewg_uncommonsubmachinegun.activeitem
+++ b/items/active/weapons/ranged/machinepistol/swtjc_ewg_uncommonsubmachinegun.activeitem
@@ -80,31 +80,31 @@
     ],
     "elementalConfig" : {
       "fire" : {
-        "primaryAbility" : { "projectileType" : "fireplasma", "projectileParameters" : { "statusEffects" : [ "burning" ] } },
+        "primaryAbility" : { "projectileType" : "fireplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_mp1.ogg", "/sfx/gun/plasma_mp2.ogg", "/sfx/gun/plasma_mp3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg" ]
       },
       "ice" : {
-        "primaryAbility" : { "projectileType" : "iceplasma", "projectileParameters" : { "statusEffects" : [ "frostslow" ] } },
+        "primaryAbility" : { "projectileType" : "iceplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_mp1.ogg", "/sfx/gun/plasma_mp2.ogg", "/sfx/gun/plasma_mp3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg" ]
       },
       "poison" : {
-        "primaryAbility" : { "projectileType" : "poisonplasma", "projectileParameters" : { "statusEffects" : [ "weakpoison" ] } },
+        "primaryAbility" : { "projectileType" : "poisonplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_mp1.ogg", "/sfx/gun/plasma_mp2.ogg", "/sfx/gun/plasma_mp3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg" ]
       },
       "electric" : {
-        "primaryAbility" : { "projectileType" : "electricplasma", "projectileParameters" : { "statusEffects" : [ "electrified" ] } },
+        "primaryAbility" : { "projectileType" : "electricplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_mp1.ogg", "/sfx/gun/plasma_mp2.ogg", "/sfx/gun/plasma_mp3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg" ]
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : "radioactiveplasma", "projectileParameters" : { "statusEffects" : [ "radiationburn" ] } },
+        "primaryAbility" : { "projectileType" : "radioactiveplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_mp1.ogg", "/sfx/gun/plasma_mp2.ogg", "/sfx/gun/plasma_mp3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg" ]
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : "shadowplasma", "projectileParameters" : { "statusEffects" : [ "shadowgasfx" ] } },
+        "primaryAbility" : { "projectileType" : "shadowplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_mp1.ogg", "/sfx/gun/plasma_mp2.ogg", "/sfx/gun/plasma_mp3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg" ]
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : "cosmicplasma", "projectileParameters" : { "statusEffects" : [ "percentarmorboostneg2" ] } },
+        "primaryAbility" : { "projectileType" : "cosmicplasma" },
         "fireSounds" : [ "/sfx/gun/plasma_mp1.ogg", "/sfx/gun/plasma_mp2.ogg", "/sfx/gun/plasma_mp3.ogg", "/sfx/gun/plasma_ar1.ogg", "/sfx/gun/plasma_ar2.ogg", "/sfx/gun/plasma_ar3.ogg" ]
       }      
     },

--- a/items/active/weapons/ranged/pistol/swtjc_ewg_uncommonbeampistol.activeitem
+++ b/items/active/weapons/ranged/pistol/swtjc_ewg_uncommonbeampistol.activeitem
@@ -96,15 +96,15 @@
         "fireSounds" : [ "/sfx/gun/mp1.ogg", "/sfx/gun/mp2.ogg", "/sfx/gun/mp3.ogg", "/sfx/gun/grenade2.ogg", "/sfx/gun/grapplegun.ogg" ]
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : "radioactiveplasma", "projectileParameters" : { "statusEffects" : [ "radiationburn" ] } },
+        "primaryAbility" : { "projectileType" : "radioactiveplasma" },
         "fireSounds" : [ "/sfx/gun/mp1.ogg", "/sfx/gun/mp2.ogg", "/sfx/gun/mp3.ogg", "/sfx/gun/grenade2.ogg", "/sfx/gun/grapplegun.ogg" ]
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : "shadowplasma", "projectileParameters" : { "statusEffects" : [ "shadowgasfx" ] } },
+        "primaryAbility" : { "projectileType" : "shadowplasma" },
         "fireSounds" : [ "/sfx/gun/mp1.ogg", "/sfx/gun/mp2.ogg", "/sfx/gun/mp3.ogg", "/sfx/gun/grenade2.ogg", "/sfx/gun/grapplegun.ogg" ]
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : "cosmicplasma", "projectileParameters" : { "statusEffects" : [ "percentarmorboostneg2" ] } },
+        "primaryAbility" : { "projectileType" : "cosmicplasma" },
         "fireSounds" : [ "/sfx/gun/mp1.ogg", "/sfx/gun/mp2.ogg", "/sfx/gun/mp3.ogg", "/sfx/gun/grenade2.ogg", "/sfx/gun/grapplegun.ogg" ]
       }
     },

--- a/items/active/weapons/ranged/pistol/swtjc_ewg_uncommonrevolver.activeitem
+++ b/items/active/weapons/ranged/pistol/swtjc_ewg_uncommonrevolver.activeitem
@@ -93,15 +93,15 @@
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/rifle1.ogg", "/sfx/gun/rifle2.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : "radioactiveplasma", "projectileParameters" : { "statusEffects" : [ "radiationburn" ] } },
+        "primaryAbility" : { "projectileType" : "radioactiveplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/rifle1.ogg", "/sfx/gun/rifle2.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : "shadowplasma", "projectileParameters" : { "statusEffects" : [ "shadowgasfx" ] } },
+        "primaryAbility" : { "projectileType" : "shadowplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/rifle1.ogg", "/sfx/gun/rifle2.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : "cosmicplasma", "projectileParameters" : { "statusEffects" : [ "percentarmorboostneg2" ] } },
+        "primaryAbility" : { "projectileType" : "cosmicplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/rifle1.ogg", "/sfx/gun/rifle2.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       }
     },

--- a/items/active/weapons/ranged/shotgun/swtjc_ewg_uncommonautoshotgun.activeitem
+++ b/items/active/weapons/ranged/shotgun/swtjc_ewg_uncommonautoshotgun.activeitem
@@ -93,15 +93,15 @@
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : "radioactiveplasma", "projectileParameters" : { "statusEffects" : [ "radiationburn" ] } },
+        "primaryAbility" : { "projectileType" : "radioactiveplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : "shadowplasma", "projectileParameters" : { "statusEffects" : [ "shadowgasfx" ] } },
+        "primaryAbility" : { "projectileType" : "shadowplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : "cosmicplasma", "projectileParameters" : { "statusEffects" : [ "percentarmorboostneg2" ] } },
+        "primaryAbility" : { "projectileType" : "cosmicplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       } 
     },
@@ -126,33 +126,45 @@
     "gunParts" : ["butt", "middle", "barrel"],
     "altAbilities" : [
       "bouncingshot",
+      "deathbomb",
+      "explosiveburst",
+      "explosiveshot",
+      "grenadelauncher",
+      "lance",
+      "markedshot",
+      "piercingshot",
+      "shrapnelbomb",
+      "spray",
+      "stickyshot",
+
       "swtjc_ewg_bouncingspray",
       "swtjc_ewg_bouncingspread",
       "swtjc_ewg_bouncingpiercingshot",
       "swtjc_ewg_explosivebouncingshot",
-      "lance",
-      "swtjc_ewg_clusterbomb",
-      "deathbomb",
-      "explosiveburst",
-      "explosiveshot",
       "swtjc_ewg_explosivespray",
       "swtjc_ewg_explosivespread",
-      "grenadelauncher",
-      "swtjc_ewg_markedshotweak",
-      "markedshot",
-      "piercingshot",
       "swtjc_ewg_piercingspray",
       "swtjc_ewg_piercingspread",
       "swtjc_ewg_railgun",
-      "shrapnelbomb",
-      "spray",
       "swtjc_ewg_spreadshot",
-      "stickyshot",
       "swtjc_ewg_stickyspray",
       "swtjc_ewg_stickyspread",
+
+      "swtjc_ewg_clusterbomb",
+      "swtjc_ewg_markedshotweak",
+      "swtjc_ewg_proximitymines",
+
+      "swtjc_ewg_bouncingorbitals",
+      "swtjc_ewg_cellspray",
+      "swtjc_ewg_cellspread",
       "swtjc_ewg_darkplasma",
+      "swtjc_ewg_elementalspray",
+      "swtjc_ewg_explosivebubbles",
+      "swtjc_ewg_forceshield",
       "swtjc_ewg_globelauncher",
-      "swtjc_ewg_proximitymines"
+      "swtjc_ewg_phaseburst",
+      "swtjc_ewg_rocketjump",
+      "swtjc_ewg_shattershot"
     ],
     "palette" : "/items/active/weapons/colors/ranged.weaponcolors",
     "iconDrawables" : ["butt", "middle", "barrel"]

--- a/items/active/weapons/ranged/shotgun/swtjc_ewg_uncommonflakcannon.activeitem
+++ b/items/active/weapons/ranged/shotgun/swtjc_ewg_uncommonflakcannon.activeitem
@@ -97,15 +97,15 @@
         "fireSounds" : [ "/sfx/gun/grenadeblast_electric1.ogg", "/sfx/gun/grenadeblast_electric2.ogg", "/sfx/gun/grenadeblast_electric3.ogg" ]
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : "radioactiveplasma", "projectileParameters" : { "statusEffects" : [ "radiationburn" ] } },
+        "primaryAbility" : { "projectileType" : "radioactiveplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : "shadowplasma", "projectileParameters" : { "statusEffects" : [ "shadowgasfx" ] } },
+        "primaryAbility" : { "projectileType" : "shadowplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : "cosmicplasma", "projectileParameters" : { "statusEffects" : [ "percentarmorboostneg2" ] } },
+        "primaryAbility" : { "projectileType" : "cosmicplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       } 
     },

--- a/items/active/weapons/ranged/shotgun/swtjc_ewg_uncommonsawedoffshotgun.activeitem
+++ b/items/active/weapons/ranged/shotgun/swtjc_ewg_uncommonsawedoffshotgun.activeitem
@@ -94,15 +94,15 @@
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : "radioactiveplasma", "projectileParameters" : { "statusEffects" : [ "radiationburn" ] } },
+        "primaryAbility" : { "projectileType" : "radioactiveplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : "shadowplasma", "projectileParameters" : { "statusEffects" : [ "shadowgasfx" ] } },
+        "primaryAbility" : { "projectileType" : "shadowplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : "cosmicplasma", "projectileParameters" : { "statusEffects" : [ "percentarmorboostneg2" ] } },
+        "primaryAbility" : { "projectileType" : "cosmicplasma" },
         "fireSounds" : [ "/sfx/gun/pistol1.ogg", "/sfx/gun/pistol2.ogg", "/sfx/gun/pistol3.ogg", "/sfx/gun/pistol4.ogg", "/sfx/gun/pulserifle1.ogg", "/sfx/gun/pulserifle2.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       } 
     },

--- a/items/active/weapons/ranged/sniperrifle/swtjc_ewg_uncommonantimaterialrifle.activeitem
+++ b/items/active/weapons/ranged/sniperrifle/swtjc_ewg_uncommonantimaterialrifle.activeitem
@@ -94,15 +94,15 @@
         "fireSounds" : [ "/sfx/gun/mech_gun.ogg", "/sfx/gun/mech_gun2.ogg", "/sfx/gun/mech_gun3.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/rifle1.ogg", "/sfx/gun/rifle2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/sniper1.ogg", "/sfx/gun/sniper2.ogg", "/sfx/gun/sniper3.ogg", "/sfx/gun/sniper4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : "radioactiveplasma", "projectileParameters" : { "statusEffects" : [ "radiationburn" ] } },
+        "primaryAbility" : { "projectileType" : "radioactiveplasma" },
         "fireSounds" : [ "/sfx/gun/mech_gun.ogg", "/sfx/gun/mech_gun2.ogg", "/sfx/gun/mech_gun3.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/rifle1.ogg", "/sfx/gun/rifle2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/sniper1.ogg", "/sfx/gun/sniper2.ogg", "/sfx/gun/sniper3.ogg", "/sfx/gun/sniper4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : "shadowplasma", "projectileParameters" : { "statusEffects" : [ "shadowgasfx" ] } },
+        "primaryAbility" : { "projectileType" : "shadowplasma" },
         "fireSounds" : [ "/sfx/gun/mech_gun.ogg", "/sfx/gun/mech_gun2.ogg", "/sfx/gun/mech_gun3.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/rifle1.ogg", "/sfx/gun/rifle2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/sniper1.ogg", "/sfx/gun/sniper2.ogg", "/sfx/gun/sniper3.ogg", "/sfx/gun/sniper4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : "cosmicplasma", "projectileParameters" : { "statusEffects" : [ "percentarmorboostneg2" ] } },
+        "primaryAbility" : { "projectileType" : "cosmicplasma" },
         "fireSounds" : [ "/sfx/gun/mech_gun.ogg", "/sfx/gun/mech_gun2.ogg", "/sfx/gun/mech_gun3.ogg", "/sfx/gun/revolver1.ogg", "/sfx/gun/revolver2.ogg", "/sfx/gun/rifle1.ogg", "/sfx/gun/rifle2.ogg", "/sfx/gun/shotgun1.ogg", "/sfx/gun/shotgun2.ogg", "/sfx/gun/shotgun3.ogg", "/sfx/gun/shotgun4.ogg", "/sfx/gun/sniper1.ogg", "/sfx/gun/sniper2.ogg", "/sfx/gun/sniper3.ogg", "/sfx/gun/sniper4.ogg", "/sfx/gun/dragonhead_fire1.ogg" ]
       } 
     },

--- a/items/active/weapons/ranged/sniperrifle/swtjc_ewg_uncommonbeamrifle.activeitem
+++ b/items/active/weapons/ranged/sniperrifle/swtjc_ewg_uncommonbeamrifle.activeitem
@@ -99,15 +99,15 @@
         "fireSounds" : [ "/sfx/gun/mp1.ogg", "/sfx/gun/mp2.ogg", "/sfx/gun/mp3.ogg", "/sfx/gun/grenade2.ogg", "/sfx/gun/grapplegun.ogg" ]
       },
       "radioactive" : {
-        "primaryAbility" : { "projectileType" : "radioactiveplasma", "projectileParameters" : { "statusEffects" : [ "radiationburn" ] } },
+        "primaryAbility" : { "projectileType" : "radioactiveplasma" },
         "fireSounds" : [ "/sfx/gun/mp1.ogg", "/sfx/gun/mp2.ogg", "/sfx/gun/mp3.ogg", "/sfx/gun/grenade2.ogg", "/sfx/gun/grapplegun.ogg" ]
       },
       "shadow" : {
-        "primaryAbility" : { "projectileType" : "shadowplasma", "projectileParameters" : { "statusEffects" : [ "shadowgasfx" ] } },
+        "primaryAbility" : { "projectileType" : "shadowplasma" },
         "fireSounds" : [ "/sfx/gun/mp1.ogg", "/sfx/gun/mp2.ogg", "/sfx/gun/mp3.ogg", "/sfx/gun/grenade2.ogg", "/sfx/gun/grapplegun.ogg" ]
       },
       "cosmic" : {
-        "primaryAbility" : { "projectileType" : "cosmicplasma", "projectileParameters" : { "statusEffects" : [ "percentarmorboostneg2" ] } },
+        "primaryAbility" : { "projectileType" : "cosmicplasma" },
         "fireSounds" : [ "/sfx/gun/mp1.ogg", "/sfx/gun/mp2.ogg", "/sfx/gun/mp3.ogg", "/sfx/gun/grenade2.ogg", "/sfx/gun/grapplegun.ogg" ]
       } 
     },


### PR DESCRIPTION
First pass on generated weapons with the primary goal of standardization. Most of the changes are either removing status effects from uncommon primary abilities (which, by convention, shouldn't have them) or adding missing status effects to rare primary abilities. 