### PR TITLE
Slightly improved compatibility with Yes Chef mod

### DIFF
--- a/objects/generic/extractionlab_recipes.config
+++ b/objects/generic/extractionlab_recipes.config
@@ -919,7 +919,7 @@
   {"inputs":{"choppedgrapefruit":1},"outputs":{"tissueculture":[5,5,7]}},
   {"inputs":{"choppedgrapes":1},"outputs":{"tissueculture":[5,5,7]}},
   {"inputs":{"choppedgreenapple":1},"outputs":{"tissueculture":[5,5,7]}},
-  {"inputs":{"choppedgreenbeen":1},"outputs":{"tissueculture":[5,5,7]}},
+  {"inputs":{"choppedgreenbean":1},"outputs":{"tissueculture":[5,5,7]}},
   {"inputs":{"choppedgreenbellpepper":1},"outputs":{"tissueculture":[5,5,7]}},
   {"inputs":{"choppedjalapenopepper":1},"outputs":{"tissueculture":[5,5,7]}},
   {"inputs":{"choppedkelp":1},"outputs":{"tissueculture":[4,4,6]}},


### PR DESCRIPTION
Checking over in CN Yes Chef: Back in the Kitchen's GitHub repository revealed that the internal name for Prepared Green Beans! is in fact choppedgreenbean rather than choppedgreenbeen. Prepared Green Beans! should now be extractable as intended.