### PR TITLE
Rocket Boots II fix + small tweaks

### DIFF
--- a/interface/scripted/techshop/techshop.config
+++ b/interface/scripted/techshop/techshop.config
@@ -668,7 +668,7 @@
             "prereq" : [ "longjump4" ],
             "recipeReq" : true,
             "item" : "gravityjump_tech"
-        },        
+        },
         {
             "name" : "quadjump",
             "recipe" : [
@@ -705,7 +705,18 @@
             "recipeReq" : true,
             "item" : "rocketboots_tech"
         },
-
+        {
+            "name" : "rocketboots2",
+            "recipe" : [
+                { "name" : "techcard", "count" : 8 },
+                { "name" : "precursorcharger", "count" : 2 },
+                { "name" : "precursorbattery", "count" : 4 },
+                { "name" : "precursorcore", "count" : 2 }
+            ],
+            "prereq" : [ "rocketboots" ],
+            "recipeReq" : true,
+            "item" : "rocketboots2_tech"
+        },
         {
             "name" : "emergencybounce",
             "recipe" : [
@@ -777,18 +788,6 @@
             "prereq" : [ "multijump" ],
             "recipeReq" : true,
             "item" : "screwattack_tech"
-        },
-        {
-            "name" : "rocketboots2",
-            "recipe" : [
-                { "name" : "techcard", "count" : 8 },
-                { "name" : "precursorcharger", "count" : 2 },
-                { "name" : "precursorbattery", "count" : 4 },
-                { "name" : "precursorcore", "count" : 2 }
-            ],
-            "prereq" : [ "rocketboots_tech" ],
-            "recipeReq" : true,
-            "item" : "rocketboots2_tech"
-        }        
+        }
     ]
 }

--- a/tech/items/gravityjump.item
+++ b/tech/items/gravityjump.item
@@ -1,6 +1,6 @@
 {
   "itemName" : "gravityjump_tech",
-  "rarity" : "legendary",
+  "rarity" : "essential",
   "price" : 11100,
   "category" : "Tech",
   "inventoryIcon" : "techcard_purple.png",

--- a/tech/items/rocketboots2.item
+++ b/tech/items/rocketboots2.item
@@ -1,6 +1,6 @@
 {
   "itemName" : "rocketboots2_tech",
-  "rarity" : "legendary",
+  "rarity" : "essential",
   "price" : 10230,
   "category" : "Tech",
   "inventoryIcon" : "techcard_blue.png",

--- a/tech/items/screwattack.item
+++ b/tech/items/screwattack.item
@@ -2,7 +2,7 @@
   "itemName" : "screwattack_tech",
   "rarity" : "essential",
   "price" : 11000,
-  "category" : "craftingMaterial",
+  "category" : "Tech",
   "inventoryIcon" : "techcard_legs.png",
   "description" : "Perform a super-awesome screw attack jump!",
   "shortdescription" : "^#77acc3;Screw Attack^reset;",


### PR DESCRIPTION
Fixes bad prereq for Rocket Boots II, preventing it from being unlocked.
Also puts Rocket Boots II and Gravity Jump at the Essential rarity like the other Precursor techs, and changes the category of Screw Attack from "craftingMaterial" to "Tech" (like the rest).

Rocket Boots II rearranged to appear directly after Rocket Boots instead of at the end of the list.