### PR TITLE
patches for vanilla backpacks

### DIFF
--- a/codex/elder/eldershieldbook.codex
+++ b/codex/elder/eldershieldbook.codex
@@ -4,7 +4,7 @@
   "description" : "A descriptive text about armor",
   "icon" : "eldertome8.png",
   "contentPages" : [
-  "While hard to decipher, there are schematics within this book that detail a shield, of sorts, composed of various unusual materials. It states that one should place 5 Noxcium bars, an Elder Tome and 5 Akashic Stones within some sort of altar..."
+  "While hard to decipher, there are schematics within this book that detail a shield, of sorts, composed of various unusual materials. It states that one should place 5 Noxcium bars, an Elder Tome and 5 Elder Fragments within some sort of altar..."
   ],
     "itemConfig" : {
     "rarity" : "legendary",

--- a/items/armors/backitems/baroncape/baroncape.back.patch
+++ b/items/armors/backitems/baroncape/baroncape.back.patch
@@ -1,5 +1,10 @@
 [
   {
+	  "op": "replace",
+	  "path": "/tooltipKind",
+	  "value": "baseaugment"
+	},
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/baroncape/baroncape.back.patch
+++ b/items/armors/backitems/baroncape/baroncape.back.patch
@@ -1,9 +1,9 @@
 [
   {
-	  "op": "replace",
-	  "path": "/tooltipKind",
-	  "value": "baseaugment"
-	},
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
   {
     "op": "add",
     "path": "/statusEffects",

--- a/items/armors/backitems/batterypackAA/batterypackAA.back.patch
+++ b/items/armors/backitems/batterypackAA/batterypackAA.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/batwings/batwings.back.patch
+++ b/items/armors/backitems/batwings/batwings.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/boiler/boiler.back.patch
+++ b/items/armors/backitems/boiler/boiler.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/bonewings/bonewings.back.patch
+++ b/items/armors/backitems/bonewings/bonewings.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/crystalpack/crystalpack.back.patch
+++ b/items/armors/backitems/crystalpack/crystalpack.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/dangerbarrel/dangerbarrel.back.patch
+++ b/items/armors/backitems/dangerbarrel/dangerbarrel.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/demonwings/demonwings.back.patch
+++ b/items/armors/backitems/demonwings/demonwings.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/eye/eye.back.patch
+++ b/items/armors/backitems/eye/eye.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/falconwings/falconwings.back.patch
+++ b/items/armors/backitems/falconwings/falconwings.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/paperwings/paperwings.back.patch
+++ b/items/armors/backitems/paperwings/paperwings.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/parachutepack/parachutepack.back.patch
+++ b/items/armors/backitems/parachutepack/parachutepack.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [ "lowgravavian" ]

--- a/items/armors/backitems/rainbowcape/rainbowcape.back.patch
+++ b/items/armors/backitems/rainbowcape/rainbowcape.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/shortcape/shortcape.back.patch
+++ b/items/armors/backitems/shortcape/shortcape.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/simplecape/simplecape.back.patch
+++ b/items/armors/backitems/simplecape/simplecape.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/tigertail/tigertail.back.patch
+++ b/items/armors/backitems/tigertail/tigertail.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/toxicflower/toxicflower.back.patch
+++ b/items/armors/backitems/toxicflower/toxicflower.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [  

--- a/items/armors/backitems/toxicwaste/toxicwaste.back.patch
+++ b/items/armors/backitems/toxicwaste/toxicwaste.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [  

--- a/items/armors/backitems/tribalwings/tribalwings.back.patch
+++ b/items/armors/backitems/tribalwings/tribalwings.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [

--- a/items/armors/backitems/turtleshell/turtleshell.back.patch
+++ b/items/armors/backitems/turtleshell/turtleshell.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [


### PR DESCRIPTION
add

  {
    "op": "replace",
    "path": "/tooltipKind",
    "value": "baseaugment"
  },

to every existed vanilla pack patches in FU. They should now have augment slots.