### PR TITLE
longswords upgradeable

### DIFF
--- a/items/active/weapons/melee/longsword/commonlongsword.activeitem
+++ b/items/active/weapons/melee/longsword/commonlongsword.activeitem
@@ -8,7 +8,7 @@
   "tooltipKind" : "sword",
   "category" : "longsword",
   "twoHanded" : false,
-  "itemTags" : ["weapon","melee","longsword"],
+  "itemTags" : ["weapon","melee","longsword","upgradeableWeapon"],
 
   "animation" : "combolongsword.animation",
   "animationParts" : { },

--- a/items/active/weapons/melee/longsword/rarelongsword.activeitem
+++ b/items/active/weapons/melee/longsword/rarelongsword.activeitem
@@ -8,7 +8,7 @@
   "tooltipKind" : "sword",
   "category" : "longsword",
   "twoHanded" : false,
-  "itemTags" : ["weapon","melee","longsword"],
+  "itemTags" : ["weapon","melee","longsword","upgradeableWeapon"],
 
   "animation" : "combolongsword.animation",
   "animationParts" : { },

--- a/items/active/weapons/melee/longsword/uncommonlongsword.activeitem
+++ b/items/active/weapons/melee/longsword/uncommonlongsword.activeitem
@@ -8,7 +8,7 @@
   "tooltipKind" : "sword",
   "category" : "longsword",
   "twoHanded" : false,
-  "itemTags" : ["weapon","melee","longsword"],
+  "itemTags" : ["weapon","melee","longsword","upgradeableWeapon"],
 
   "animation" : "combolongsword.animation",
   "animationParts" : { },


### PR DESCRIPTION
The random generated longswords seem missing "upgradeableWeapon" tag. Please ignore this pull request if they are intended not to be upgradeable.