### PR TITLE
Carvelle MT Compatibility Fix

### DIFF
--- a/items/active/weapons/ranged/unique/carvelle.activeitem
+++ b/items/active/weapons/ranged/unique/carvelle.activeitem
@@ -32,7 +32,7 @@
 
   "scripts" : ["/items/active/weapons/ranged/gun.lua"],
 
-  "elementalType" : "default",
+  "elementalType" : "physical",
 
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/ranged/gunfire.lua"],


### PR DESCRIPTION
Fixed Carvelle Sniper Rifle not initializing correctly when using
Manufacturer's Touch mod