### PR TITLE
Update aviangodwings.back.patch

### DIFF
--- a/items/armors/backitems/aviangodwings/aviangodwings.back.patch
+++ b/items/armors/backitems/aviangodwings/aviangodwings.back.patch
@@ -1,5 +1,10 @@
 [
   {
+    "op": "replace",
+    "path": "/tooltipKind",
+    "value": "baseaugment"
+  },
+  {
     "op": "add",
     "path": "/statusEffects",
     "value": [


### PR DESCRIPTION
I am sorry that last time I forgot this one when editing backpack patches. Now the avian god wings should properly have augment slots.