### PR TITLE
Removed drops from precursor spawner mobs

### DIFF
--- a/objects/minibiome/precursor/fu_precursorspawner/fu_precursorspawner.lua
+++ b/objects/minibiome/precursor/fu_precursorspawner/fu_precursorspawner.lua
@@ -24,12 +24,20 @@ function update(dt)
 						monsterType = pet.config.type
 						monsterSeed = pet.config.parameters.seed
 						monsterColour = pet.config.parameters.colors
+						monsterAggro = pet.config.parameters.aggresive
+						dropPool = {}
+						dropPool["default"] = "empty"
 						spawnPosition = vec2.add(object.position(), {0, 8})
+						--if world.threatLevel() < 5 then
+							--monsterLevel = 5
+						--else
+							monsterLevel = world.threatLevel()
+						--end
 							if monsterType and monsterSeed then
 								if monsterColour then
-									world.spawnMonster(monsterType, spawnPosition, {level = world.threatLevel(), seed = monsterSeed, colors = monsterColour});
+									world.spawnMonster(monsterType, spawnPosition, {level = monsterLevel, seed = monsterSeed, colors = monsterColour, aggresive = monsterAggro, dropPools = dropPool});
 								else
-									world.spawnMonster(monsterType, spawnPosition, {level = world.threatLevel(), seed = monsterSeed});
+									world.spawnMonster(monsterType, spawnPosition, {level = monsterLevel, seed = monsterSeed, aggresive = monsterAggro, dropPools = dropPool});
 								end
 							end
 						end


### PR DESCRIPTION
Mad it so the mobs spawned by the precursor spawner no longer drop anything (will probably change it later since currently it is pretty much useless)