### PR TITLE
Precursor spawner improvements

### DIFF
--- a/objects/minibiome/precursor/fu_precursorspawner/fu_precursorspawner.lua
+++ b/objects/minibiome/precursor/fu_precursorspawner/fu_precursorspawner.lua
@@ -1,5 +1,6 @@
 require "/scripts/util.lua"
 require "/scripts/pathutil.lua"
+local crafting = false
 
 function init()
 	self = config.getParameter("spawner")
@@ -7,45 +8,56 @@ function init()
 end
 
 function update(dt)
-	local slot = 0
-	local fuelSlot = getInputContents(slot)
+	if wireCheck() == true then
+		if crafting == false then
+			local slot = 0
+			local fuelSlot = getInputContents(slot)
+			if fuelSlot == self.fuelType then
+				slot = 1
+				podSlot = getInputContents(slot)
+				if podSlot == self.podType then
+					world.containerConsumeAt(entity.id(),0,1)
+					self.timer = self.spawnTime
+					crafting = true
+				end
+			end
+		end
+	end
 	self.timer = self.timer - dt
-	if fuelSlot == self.fuelType then
-		slot = 1
-		podSlot = getInputContents(slot)
-		if podSlot == self.podType then
-			if self.timer <= 0 then
-				world.containerConsumeAt(entity.id(),0,1)
-				local items = world.containerItems(entity.id(), 1)
-				for _,item in pairs(items) do
-					pets = (item.parameters.pets)
-					if pets then
-						for _,pet in pairs(pets) do
-						monsterType = pet.config.type
-						monsterSeed = pet.config.parameters.seed
-						monsterColour = pet.config.parameters.colors
-						monsterAggro = pet.config.parameters.aggressive
-						dropPool = {}
-						dropPool["default"] = "empty"
-						spawnPosition = vec2.add(object.position(), {0, 8})
-						--if world.threatLevel() < 5 then
-							--monsterLevel = 5
-						--else
-							monsterLevel = world.threatLevel()
-						--end
-							if monsterType and monsterSeed then
-								if monsterColour then
-									world.spawnMonster(monsterType, spawnPosition, {level = monsterLevel, seed = monsterSeed, colors = monsterColour, dropPools = dropPool, aggressive = monsterAggro});
-								else
-									world.spawnMonster(monsterType, spawnPosition, {level = monsterLevel, seed = monsterSeed, dropPools = dropPool, aggressive = monsterAggro});
-								end
+	if self.timer <= 0 then
+		if crafting == true then
+			local items = world.containerItems(entity.id(), 1)
+			for _,item in pairs(items) do
+				pets = (item.parameters.pets)
+				if pets then
+					for _,pet in pairs(pets) do
+					monsterType = pet.config.type
+					monsterSeed = pet.config.parameters.seed
+					monsterColour = pet.config.parameters.colors
+					monsterAggro = pet.config.parameters.aggressive
+					dropPool = {}
+					dropPool["default"] = "empty"
+					spawnPosition = vec2.add(object.position(), {0, 8})
+					--if world.threatLevel() < 5 then
+						--monsterLevel = 5
+					--else
+						monsterLevel = world.threatLevel()
+					--end
+						if monsterType and monsterSeed then
+							if monsterColour then
+								world.spawnMonster(monsterType, spawnPosition, {level = monsterLevel, seed = monsterSeed, colors = monsterColour, dropPools = dropPool, aggressive = monsterAggro});
+							else
+								world.spawnMonster(monsterType, spawnPosition, {level = monsterLevel, seed = monsterSeed, dropPools = dropPool, aggressive = monsterAggro});
 							end
 						end
 					end
 				end
-				self.timer = self.spawnTime
 			end
+			crafting = false
 		end
+	end
+	if not crafting and self.timer <= 0 then
+		self.timer = self.spawnTime
 	end
 end
 
@@ -56,4 +68,17 @@ function getInputContents(slot)
 		contents = stack.name
 	end
 	return contents
+end
+
+function wireCheck()
+	if object.isInputNodeConnected(0) == true then
+		if object.getInputNodeLevel(0) == true then
+			return true
+		else
+			return false
+		end
+	else
+	return true
+	end
+	return false
 end


### PR DESCRIPTION
Consumes fuel then waits 10 seconds before spawning the monster instead of consuming the fuel and spawning the monster after 10 seconds since the last monster was spawned. It also now can be toggled using a switch (when the switch is off it won't start the spawning process but will finish any that has started)