### PR TITLE
Changed shortDescription of isn_battery_t3_ceru to show correct (8W) output

### DIFF
--- a/objects/power/isn_battery_t3_ceru/isn_battery_t3_ceru.object
+++ b/objects/power/isn_battery_t3_ceru/isn_battery_t3_ceru.object
@@ -1,43 +1,67 @@
 {
-  "objectName" : "isn_battery_t3_ceru",
-  "rarity" : "Rare",
-    "colonyTags" : [ "science" ],
-  "category" : "wire",
-  "price" : 5500,
-  "description" : "A power storage unit. Stores up to 4000J of power and dispenses 8W when connected.",
-  "shortdescription" : "^cyan;4000J 6W Battery Unit^white;",
-  "race" : "generic",
-  "printable" : false,
-    "learnBlueprintsOnPickup" : [ "isn_battery_t3_fero" ],
-
-  "inventoryIcon" : "isn_battery_t3_ceru_inv.png",
-  "orientations" : [
+  "objectName": "isn_battery_t3_ceru",
+  "rarity": "Rare",
+  "colonyTags": [
+    "science"
+  ],
+  "category": "wire",
+  "price": 5500,
+  "description": "A power storage unit. Stores up to 4000J of power and dispenses 8W when connected.",
+  "shortdescription": "^cyan;4000J 8W Battery Unit^white;",
+  "race": "generic",
+  "printable": false,
+  "learnBlueprintsOnPickup": [
+    "isn_battery_t3_fero"
+  ],
+  "inventoryIcon": "isn_battery_t3_ceru_inv.png",
+  "orientations": [
     {
-      "dualImage" : "isn_battery_t3_ceru_base.png",
-      "imagePosition" : [0, 0],
-      "spaceScan" : 0.1,
-      "collision" : "platform",
-      "anchors" : [ "bottom" ]
+      "dualImage": "isn_battery_t3_ceru_base.png",
+      "imagePosition": [
+        0,
+        0
+      ],
+      "spaceScan": 0.1,
+      "collision": "platform",
+      "anchors": [
+        "bottom"
+      ]
     }
   ],
-
-  "breakDropOptions" : [],
-
-  "animation" : "isn_battery_t3_ceru.animation",
-  "animationParts" : {
-    "meter" : "isn_battery_t3_ceru_meter.png",
-    "status" : "isn_battery_t3_ceru_status.png",
-    "base" : "isn_battery_t3_ceru_base.png"
+  "breakDropOptions": [],
+  "animation": "isn_battery_t3_ceru.animation",
+  "animationParts": {
+    "meter": "isn_battery_t3_ceru_meter.png",
+    "status": "isn_battery_t3_ceru_status.png",
+    "base": "isn_battery_t3_ceru_base.png"
   },
-  "animationPosition" : [0, 0],
-
-  "scripts" : [ "/scripts/power.lua","/objects/power/isn_battery.lua","/objects/isn_sharedobjectscripts.lua"],
-  "scriptDelta" : 60,
-
-  "outputNodes" : [ [1, 3] ],
-  "inputNodes" : [ [0, 1], [2, 1] ],
-
-  "isn_batteryCapacity" : 4000,
-  "isn_batteryVoltage" : 8,
-  "powertype" : "battery"
+  "animationPosition": [
+    0,
+    0
+  ],
+  "scripts": [
+    "/scripts/power.lua",
+    "/objects/power/isn_battery.lua",
+    "/objects/isn_sharedobjectscripts.lua"
+  ],
+  "scriptDelta": 60,
+  "outputNodes": [
+    [
+      1,
+      3
+    ]
+  ],
+  "inputNodes": [
+    [
+      0,
+      1
+    ],
+    [
+      2,
+      1
+    ]
+  ],
+  "isn_batteryCapacity": 4000,
+  "isn_batteryVoltage": 8,
+  "powertype": "battery"
 }


### PR DESCRIPTION
Was showing `6W` before, but in the .object it says `"isn_batteryVoltage" : 8`
As a stylistic thing, would you prefer it non-prettified?