### PR TITLE
Fission Reactor Fuel rebalance

### DIFF
--- a/objects/power/isn_fissionreactornew/isn_fissionreactor.lua
+++ b/objects/power/isn_fissionreactornew/isn_fissionreactor.lua
@@ -70,6 +70,9 @@ function update(dt)
 	local myLocation = entity.position()
 	world.debugText("R:" .. storage.radiation, {myLocation[1]-1, myLocation[2]-2}, "red"); 
 
+	-- the effects here don't addup in damage, just it creates more particles & more noise.
+	-- therefore I think we could rework this for a single instance. sayter said that he or someone else
+	-- could match this with the current radiation resistance
 	if storage.radiation >= 50 then
 		isn_projectileAllInRange("isn_fissionrads",4)
 	end
@@ -89,6 +92,7 @@ function update(dt)
 end
 
 function isn_powerSlotCheck(slotnum)
+	-- any further edits has to keep in mind the ratio uranium to enriched uranium, plutonium to enriched plutonium, and solarium to ultronium
 	fuel = {
 	  biofuelcannister = 4,
 	  biofuelcannisteradv = 4,
@@ -97,12 +101,12 @@ function isn_powerSlotCheck(slotnum)
 	  neptuniumrod = 6,
 	  tritium = 6,
 	  deuterium = 7,
-	  thoriumrod = 7,
-	  enricheduranium = 8,
+	  thoriumrod = 9, -- gets increased power from 7 to 9 (+28%), but loses in consumption rate, from 1/100 to 1/80 (-25%)
+	  enricheduranium = 10, -- gets increased power from 8 to 10 + gain efficiency from 1/100 to 1/500
 	  plutoniumrod = 10,
-	  enrichedplutonium = 12,
-	  solariumstar = 15,
-	  ultronium = 20
+	  enrichedplutonium = 16, -- gets increased power from 12 to 16  + gain efficiency 5x
+	  solariumstar = 19, -- gets higher power from 15 to 19 (+26%) but loses out in efficiency from 1/100 to 1/80 (-25%)
+	  ultronium = 21 --  increased power from 20 to 21 & increased efficiency (5x)
 	}
 	return fuel[world.containerItemAt(entity.id(),slotnum) and world.containerItemAt(entity.id(),slotnum).name or 'nil'] or 0
 end
@@ -111,20 +115,30 @@ function isn_slotDecayCheck(slot, chance)
 	local slotContent = world.containerItemAt(entity.id(),slot)
 	local myLocation = entity.position()
 
-	world.debugText("CHECK",{myLocation[1]-1,myLocation[2]-3.5},"cyan")
+	--world.debugText("CHECK",{myLocation[1]-1,myLocation[2]-3.5},"cyan")
 
 	if slotContent == nil then return false end
 
 	if slotContent.name == "biofuelcannister" or slotContent.name == "biofuelcannisteradv" or slotContent.name == "biofuelcannistermax" then
-		if math.random(1,60) <= chance then world.debugText("DECAY",{myLocation[1]+2,myLocation[2]-3.5},"cyan"); return true end
+		if math.random(1,60) <= chance then 
+			--I have commented out the world.debugText cause that seems unecessary ???? Whismerhill
+			--world.debugText("DECAY",{myLocation[1]+2,myLocation[2]-3.5},"cyan");
+			return true
+		end
 	end
 	
-	if slotContent.name == "tritium" or slotContent.name == "deuterium" or slotContent.name == "uraniumrod" or slotContent.name == "plutoniumrod" or slotContent.name == "neptuniumrod" then
-		if math.random(1,80) <= chance then world.debugText("DECAY",{myLocation[1]+2,myLocation[2]-3.5},"cyan"); return true end
-	end	
-	
-	if slotContent.name == "solariumstar" or slotContent.name == "thoriumrod" or slotContent.name == "enricheduranium" or slotContent.name == "enrichedplutonium" or slotContent.name == "ultronium" then
-		if math.random(1,100) <= chance then world.debugText("DECAY",{myLocation[1]+2,myLocation[2]-3.5},"cyan"); return true end
+	if slotContent.name == "tritium" or slotContent.name == "deuterium" or slotContent.name == "uraniumrod" or slotContent.name == "plutoniumrod" or slotContent.name == "neptuniumrod" or slotContent.name == "thoriumrod" or slotContent.name == "solariumstar" then
+		if math.random(1,80) <= chance then
+			--world.debugText("DECAY",{myLocation[1]+2,myLocation[2]-3.5},"cyan");
+			return true
+		end
+	end
+	-- low decay rate gets even lower : from 1/100 to 1/500 e.g. fuel should be 5x more durable
+	if slotContent.name == "enricheduranium" or slotContent.name == "enrichedplutonium" or slotContent.name == "ultronium" then
+		if math.random(1,500) <= chance then 
+			--world.debugText("DECAY",{myLocation[1]+2,myLocation[2]-3.5},"cyan");
+			return true
+		end
 	end	
 	
 	return false
@@ -136,64 +150,53 @@ function isn_doSlotDecay(slot)
 
 	local waste = world.containerItemAt(entity.id(),4)
 	local tritium = world.containerItemAt(entity.id(),5)
+	local wastestack
+	local tritiumstack
+
 	
-	
-	
-	if (waste ~= nil) then
+	if waste then
 		-- sb.logInfo("Waste found in slot. Name is " .. waste.name)
 		if (waste.name == "toxicwaste") then
 		  -- sb.logInfo("increasing storage.radiation")
 		  storage.radiation = storage.radiation + 5
+		  wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
 		else
 		  -- sb.logInfo("not toxic waste, ejecting")
-		  world.containerConsumeAt(entity.id(),4,waste.count) --delete waste
-		  world.spawnItem(waste.name,entity.position(),waste.count) --drop it on the ground
+		  local wastecount = waste.count -- variable to ensure no change of quantities in between calculations.
+		  world.containerConsumeAt(entity.id(),4,wastecount) --delete waste
+		  world.spawnItem(waste.name,entity.position(),wastecount) --drop it on the ground
 		end
+	else -- (waste == nil)
+		wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
 	end
-	local wastestack
-	
-	if (tritium ~= nil) then
+		
+	if tritium then
 		if (tritium.name == "tritium") then
-		  storage.radiation = storage.radiation + 5
+			storage.radiation = storage.radiation + 5
+			if (math.random(100) < storage.critChance) then
+				tritiumstack = world.containerSwapItems(entity.id(),{name = "tritium", count = 1, data={}},5)
+				wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
+			end
 		else
-		  world.containerConsumeAt(entity.id(),5,tritium.count) --delete waste
-		  world.spawnItem(tritium.name,entity.position(),tritium.count) --drop it on the ground
+			local tritiumcount = tritium.count
+			world.containerConsumeAt(entity.id(),5,tritiumcount) --delete waste
+			world.spawnItem(tritium.name,entity.position(),tritiumcount) --drop it on the ground
 		end
-	end
-        local tritiumstack
-        
-        
-	if (waste == nil) then
-		wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
-	elseif (waste.name == "toxicwaste") then
+	elseif (math.random(100) < storage.critChance) then -- (tritium == nil)
+		tritiumstack = world.containerSwapItems(entity.id(),{name = "tritium", count = 1, data={}},5)
 		wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
 	end
 
-
-	if (tritium == nil) then
-		if math.random(100) < storage.critChance then
-		  tritiumstack = world.containerSwapItems(entity.id(),{name = "tritium", count = 1, data={}},5)
-		  wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
-		end	
-	elseif (tritium.name == "tritium") and (math.random(100) < storage.critChance) then
-		if math.random(100) < storage.critChance then
-		  tritiumstack = world.containerSwapItems(entity.id(),{name = "tritium", count = 1, data={}},5)
-		  wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
-		end	
-	end
 	
-	
-	if (wastestack ~= nil) and (wastestack.count > 0) then
+	if wastestack  and (wastestack.count > 0) then
 		world.spawnItem(wastestack.name,entity.position(),wastestack.count) --drop it on the ground
 		storage.radiation = storage.radiation + 5
 	end
 
-	if (tritiumstack ~= nil) and (tritiumstack.count > 0) then
+	if tritiumstack and (tritiumstack.count > 0) then
 		world.spawnItem(tritiumstack.name,entity.position(),tritiumstack.count) --drop it on the ground
 	end
-	
-
-	        
+		        
 end
 
 function isn_getCurrentPowerOutput()


### PR DESCRIPTION
For this fission reactor rebalance,
instead of adding more checks & conditions I just reused what is there (didn't want to lengthen the code & potentially the execution time)
I moved solarium star & thorium rod away from the "low decay" group
since they lose about 25% efficiency in doing so, thorium gets +28% power & solarium +26%

only enriched uranium, enriched plutonium and ultronium stay in the "low decay" group
this group gets 5x better efficiency.
which means that when going from uranium to enriched uranium you gain a total of +66% power +625% efficiency, which compensates for the 10 to 11x lower amount of enriched after conversion.

same for plutonium +60% power, +625% efficiency

ultronium  has a slightly higher ratio of conversion from solarium star , amount divided by 6.67. so it only gets +10% power & +625% efficiency over solarium star.

*code shortened, less redundant conditions
*local variables added to prevent the game possibly recalculating amounts in between deletions & additions (thanks Kherae)