### PR TITLE
ITD_update auto-increment input/output text number for ease of use

### DIFF
--- a/interface/kheAA/kheAA_router/kheAA_routerGui.lua
+++ b/interface/kheAA/kheAA_router/kheAA_routerGui.lua
@@ -64,6 +64,7 @@ function addInputSlot()
 	local text = widget.getText("inputSlotCount")
 	if text ~= "" and tonumber(text) >= 0 then
 		local slot = tonumber(text);
+		widget.setText("inputSlotCount", slot + 1);
 		for _,v in pairs(inputSlots) do
 			if v[1] == slot then
 				return;
@@ -80,6 +81,7 @@ function addOutputSlot()
 	local text = widget.getText("outputSlotCount")
 	if text ~= "" and tonumber(text) >= 0 then
 		local slot = tonumber(text);
+		widget.setText("outputSlotCount", slot + 1);
 		for _,v in pairs(outputSlots) do
 			if v[1] == slot then
 				return;


### PR DESCRIPTION
Incredibly simple update.  When using the Item Transference Device, it's annoying if you want to input and/or output to multiple specific slots and you have to type 1, then click the '+' button, then click over on the text input, erase the 1, then type 2, and repeat. 

This change just makes it so that if after you hit '+' for a number, it auto-increments to the next number and you can just hit '+' a few times to get the specific numbers you need.

Mostly this is just me getting back into practice with GitHub before making larger changes as I haven't used this specific repo-site in a while.