### PR TITLE
honestly, i just forgot to change something (minor performance tweak)

### DIFF
--- a/projectiles/npcs/webspitfrank/webspitfrank.projectile
+++ b/projectiles/npcs/webspitfrank/webspitfrank.projectile
@@ -19,8 +19,7 @@
 		  "tileSprayed" : "spidersilkblockmik",
 		  "timeToLive" : 0.2,
 		  "layerSprayed" : "foreground",
-		  "waitUntil" : 5,
-		  "speed" : 30
+		  "speed" : 25
 		  }
 		}
 	  ]
@@ -39,8 +38,7 @@
 		  "tileSprayed" : "spidersilkblockmik",
 		  "timeToLive" : 0.2,
 		  "layerSprayed" : "foreground",
-		  "waitUntil" : 5,
-		  "speed" : 30
+		  "speed" : 25
 		  }
 		}
 	  ]
@@ -60,7 +58,7 @@
 		  "timeToLive" : 0.2,
 		  "layerSprayed" : "foreground",
 		  "waitUntil" : 5,
-		  "speed" : 30
+		  "speed" : 25
 		  }
 		}
 	  ]
@@ -79,8 +77,7 @@
 		  "tileSprayed" : "spidersilkblockmik",
 		  "timeToLive" : 0.2,
 		  "layerSprayed" : "foreground",
-		  "waitUntil" : 5,
-		  "speed" : 30
+		  "speed" : 25
 		  }
 		}
 	  ]


### PR DESCRIPTION
nothing major, but back when i was coding this projectile (webspitfrank), before it spawned pass-thru blocks, it trapped effectively by delaying the spawn.
i can now get rid of that delay, making it work better.  also reduced the size of the web blast, to cope with the new center filled area.