### PR TITLE
Makes capture bot no longer drop capture pods

### DIFF
--- a/monsters/flyers/servitors/capturebot/servitorcapturebot.monstertype
+++ b/monsters/flyers/servitors/capturebot/servitorcapturebot.monstertype
@@ -55,7 +55,7 @@
 		  "minimumRange":3, 
 		  "windupState":"fire", 
 		  "windupTime":0.6, 
-		"projectileType":"capturepod", 
+		"projectileType":"capturepodgun", 
 		"projectileParameters":{
 		  "inaccuracy":0.0, 
 		  "speed":85, 


### PR DESCRIPTION
Changed it so that the capture bot uses the capture gun projectiles (so that it doesn't create capture pods when it misses).