### PR TITLE
Minor Item Magnet Fixes

### DIFF
--- a/objects/generic/fu_pickuprangetemp/fu_pickuprangetemp.lua
+++ b/objects/generic/fu_pickuprangetemp/fu_pickuprangetemp.lua
@@ -12,7 +12,7 @@ end
 function update(dt)
 	transferUtil.loadSelfContainer()
 	excavatorCommon.grab(entity.position())
-	world.breakObject(world.objectAt(entity.position()), true)
+	world.breakObject(entity.id(), true)
 end
 
 function anims()

--- a/objects/generic/fu_pickuprangetemp/fu_pickuprangetemp.object
+++ b/objects/generic/fu_pickuprangetemp/fu_pickuprangetemp.object
@@ -7,6 +7,7 @@
 	"shortdescription" : "Grabber",
 	"tooltipKind" : "container",
 	"race" : "generic",
+	"smashOnBreak" : true,
 
 	"category" : "wire",
 	"price" : 15,


### PR DESCRIPTION
Chnaged world.objectAt(entity.position()) to entity.id() and made it smash on break by default instead of only when it breaks itself