### PR TITLE
Nautilus set grants gas immunity now also on liquid planets

### DIFF
--- a/stats/effects/fu_armoreffects/set_bonuses/nautilussetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/nautilussetbonuseffect.lua
@@ -4,6 +4,7 @@ armorBonus2={
 		{stat = "critChance", amount = 3},
 		{stat = "powerMultiplier", amount = 0.15},
 		{stat = "sulphuricImmunity", amount = 1},
+		{stat = "gasImmunity", amount = 1},
 		{stat = "poisonStatusImmunity", amount = 1},
 		{stat = "maxBreath", amount = 700},
 		{stat = "breathRegeneration", baseMultiplier = 1.5}


### PR DESCRIPTION
Added gas immunity to nautilus set. Since the immunity is granted on non-liquid planets, and the set is focused on liquid planets, I assumed it should be there.