### PR TITLE
Minor Music Player Changes

### DIFF
--- a/objects/generic/fm_musicplayer/fm_musicplayer.object
+++ b/objects/generic/fm_musicplayer/fm_musicplayer.object
@@ -4,7 +4,7 @@
   "rarity" : "Common",
   "category" : "decorative",
 
-  "description" : "Can play music.",
+  "description" : "Can play music when switched on (using wiring).",
   "shortdescription" : "Music Player",
   "race" : "generic",
   "learnBlueprintsOnPickup" : ["fm_portablemusicplayer"],
@@ -54,5 +54,5 @@
   
   "soundEffect" : "",
   "soundEffectRangeMultiplier" : 1.0,
-  "broadcastArea" : [-20, -20, 20, 20]
+  "broadcastArea" : [-30, -30, 30, 30]
 }


### PR DESCRIPTION
Makes it obvious that you need to switch the music player on using wiring and changes the range from 20 blocks to 30 blocks.