### PR TITLE
Antimatter/Quantum Energy Packs fixed

### DIFF
--- a/items/armors/backitems/morphitepack/batterypack_morphite.back
+++ b/items/armors/backitems/morphitepack/batterypack_morphite.back
@@ -3,11 +3,11 @@
   "price" : 2500,
   "inventoryIcon" : "batterypack_eridianicon.png",
   "dropCollision" : [-4.0, -3.0, 4.0, 3.0],
-  "rarity" : "legendary",
+  "rarity" : "rare",
   "description" : "An advanced energy pack. Grants +30 energy, 12% energy regen and a slight glow.",
   "shortdescription" : "Antimatter Energy Pack",
   "tooltipKind" : "baseaugment",
-  "category" : "enviroProtectionPack",
+  "category" : "^#e43774;Upgradeable EPP^reset;",
   "acceptsAugmentType" : "back",
   "radioMessagesOnPickup" : [ "pickupepp" ],
   

--- a/items/armors/backitems/quantumpack/batterypack_quantum.back
+++ b/items/armors/backitems/quantumpack/batterypack_quantum.back
@@ -1,13 +1,13 @@
 {
   "itemName" : "batterypack_quantum",
-  "price" : 1750,
+  "price" : 5000,
   "inventoryIcon" : "batterypack_quantumicon.png",
   "dropCollision" : [-4.0, -3.0, 4.0, 3.0],
-  "rarity" : "rare",
+  "rarity" : "legendary",
   "description" : "An extremely powerful energy storage tank. Grants +40 energy, 15% energy regen and a slight glow.",
   "shortdescription" : "Quantum Energy Pack",
   "tooltipKind" : "baseaugment",
-  "category" : "^#e43774;Upgradeable EPP^reset;",
+  "category" : "enviroProtectionPack",
   "acceptsAugmentType" : "back",
   "radioMessagesOnPickup" : [ "pickupepp" ],
   

--- a/items/generic/crafting/matterassembler/nuclearcore.item
+++ b/items/generic/crafting/matterassembler/nuclearcore.item
@@ -6,8 +6,7 @@
   "inventoryIcon" : "nuclearcore.png",
   "description" : "Great and terrible nuclear power. Handle with care.",
   "shortdescription" : "^#88e25b;Nuclear Core^white;",
-  "learnBlueprintsOnPickup" : [ 
-  "batterypack_quantum", 
+  "learnBlueprintsOnPickup" : [  
   "warangelhead", 
   "warangellegs", 
   "warangelchest", 

--- a/items/generic/crafting/matterassembler/particlecore.item
+++ b/items/generic/crafting/matterassembler/particlecore.item
@@ -6,5 +6,8 @@
   "inventoryIcon" : "particlecore.png",
   "description" : "The energy source for particle weapons.",
   "shortdescription" : "^#77acc3;Particle Core^white;",
+  "learnBlueprintsOnPickup" : [ 
+  "batterypack_quantum"
+  ],
   "itemTags" : [ "reagent" ]
 }

--- a/recipes/armory/backitems/armor_backpack_morphite.recipe
+++ b/recipes/armory/backitems/armor_backpack_morphite.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "morphiteore", "count" : 6 },
     { "item" : "irradiumbar", "count" : 4 },
-    { "item" : "batterypack_quantum", "count" : 1 },
+    { "item" : "batterypack_protocyte", "count" : 1 },
     { "item" : "mutagene4", "count" : 2 },
     { "item" : "wretchel", "count" : 6 }
   ],

--- a/recipes/armory/backitems/armor_backpack_quantum.recipe
+++ b/recipes/armory/backitems/armor_backpack_quantum.recipe
@@ -2,10 +2,10 @@
   "input" : [
     { "item" : "ff_focusingarray", "count" : 2 },
     { "item" : "helium3gasliquid", "count" : 40 },
-    { "item" : "batterypack_protocyte", "count" : 1 },
+    { "item" : "batterypack_morphite", "count" : 1 },
     { "item" : "densealloy", "count" : 2 },
-    { "item" : "fuprocessor", "count" : 1 },
-    { "item" : "advcircuit", "count" : 4 }
+    { "item" : "fuprocessor", "count" : 2 },
+    { "item" : "particlecore", "count" : 2 }
   ],
   "output" : {
     "item" : "batterypack_quantum",


### PR DESCRIPTION
Quantum now requires the Antimatter as a component, which it should, considering that it is a straight upgrade.
I changed the Quantum's crafting recipe to tier a bit better, and Antimatter now requires the Protocite, rather than Antimatter, Energy Pack.