### PR TITLE
Stops spam from beer epp when inventory is full

### DIFF
--- a/stats/effects/fu_effects/fu_infiniteitem/fu_infiniteitem.lua
+++ b/stats/effects/fu_effects/fu_infiniteitem/fu_infiniteitem.lua
@@ -1,3 +1,5 @@
+require "/scripts/util.lua"
+
 function init()
   self.value = config.getParameter("refresh")
   script.setUpdateDelta(self.value)
@@ -7,8 +9,21 @@ function update(dt)
 	item = config.getParameter("item")
 	count = world.entityHasCountOfItem(entity.id(), item)
 	maxAmount = config.getParameter("maxAmount")
-	if count and count < maxAmount then
-		configAmount = config.getParameter("amount")
+	configAmount = config.getParameter("amount")
+	canSpawn = true
+	if configAmount > 1000 then
+		maxDrop = 1000
+	else
+		maxDrop = configAmount
+	end
+	for _, entityID in pairs (world.itemDropQuery(entity.position(), 5)) do
+		isItem = util.tableToString(world.itemDropItem(entityID))
+		if isItem == "{ name = " .. item .. ", parameters = { price = 0 }, count = " .. maxDrop .." }" then
+			canSpawn = false
+			break
+		end
+	end
+	if count and count < maxAmount and canSpawn == true then
 		if count + configAmount > maxAmount then
 			amount = maxAmount - count
 		else


### PR DESCRIPTION
Makes it so that the beer epp won't drop liquidbeer if there is a full amount on the ground in a 5 block radius (to prevent massive buildups of it if the player has a full inventory)