### PR TITLE
Daggers made from lame slashy things into burst damaging awesomeness.

### DIFF
--- a/items/active/weapons/melee/dagger/advalloydagger.activeitem
+++ b/items/active/weapons/melee/dagger/advalloydagger.activeitem
@@ -35,7 +35,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.3,
+    "fireTime" : 2.3,
     "baseDps" : 7.72,
     "damageConfig" : {
       "statusEffects" : [ "bleedingshort" ]
@@ -59,7 +59,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.8, 2.5],
@@ -69,7 +69,7 @@
       }
     }
   },
-  "critChance" : 2, 
-  "critBonus" : 4, 
+  "critChance" : 4, 
+  "critBonus" : 15, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/bloodyknife.activeitem
+++ b/items/active/weapons/melee/dagger/bloodyknife.activeitem
@@ -35,7 +35,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.3,
+    "fireTime" : 2.3,
     "baseDps" : 9,
     "damageConfig" : {
       "knockback" : 10
@@ -59,7 +59,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.8, 2.5],
@@ -70,7 +70,7 @@
     }
   },
 
-  "critChance" : 2, 
-  "critBonus" : 6, 
+  "critChance" : 1, 
+  "critBonus" : 20, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/carbondagger.activeitem
+++ b/items/active/weapons/melee/dagger/carbondagger.activeitem
@@ -35,7 +35,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.3,
+    "fireTime" : 2.3,
     "baseDps" : 7.72,
     "damageConfig" : {
       "statusEffects" : [ "bleedingshort" ]
@@ -59,7 +59,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.8, 2.5],
@@ -70,6 +70,6 @@
     }
   },
   "critChance" : 3, 
-  "critBonus" : 1, 
+  "critBonus" : 12, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/curvedagger.activeitem
+++ b/items/active/weapons/melee/dagger/curvedagger.activeitem
@@ -37,7 +37,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.45,
+    "fireTime" : 2.95,
     "baseDps" : 5.5,
     "damageConfig" : {
       "damageSourceKind" : "electric",
@@ -63,7 +63,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.7,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.1, 2.5],
@@ -74,6 +74,6 @@
     }
   },
   "critChance" : 3, 
-  "critBonus" : 3, 
+  "critBonus" : 20, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/effigiumdagger.activeitem
+++ b/items/active/weapons/melee/dagger/effigiumdagger.activeitem
@@ -36,7 +36,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.32,
+    "fireTime" : 2.32,
     "baseDps" : 9.1,
     "damageConfig" : {
       "damageSourceKind": "shadowdagger",
@@ -62,7 +62,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0, 2.5],
@@ -72,7 +72,7 @@
       }
     }
   },
-  "critChance" : 4,
-  "critBonus" : 2,
+  "critChance" : 5,
+  "critBonus" : 20,
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/fuatropusdagger.activeitem
+++ b/items/active/weapons/melee/dagger/fuatropusdagger.activeitem
@@ -36,7 +36,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.3,
+    "fireTime" : 2.3,
     "baseDps" : 7.72,
     "damageConfig" : {
       "statusEffects" : [ "weakpoison" ]
@@ -60,7 +60,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.8, 2.5],
@@ -71,6 +71,6 @@
     }
   },
   "critChance" : 2, 
-  "critBonus" : 4, 
+  "critBonus" : 21, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/irradiumdagger.activeitem
+++ b/items/active/weapons/melee/dagger/irradiumdagger.activeitem
@@ -35,7 +35,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.32,
+    "fireTime" : 2.32,
     "baseDps" : 9.1,
     "damageConfig" : {
       "damageSourceKind": "radioactivedagger",
@@ -61,7 +61,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.8, 2.5],
@@ -71,7 +71,7 @@
       }
     }
   },
-  "critChance" : 2,
-  "critBonus" : 3,
+  "critChance" : 1,
+  "critBonus" : 20,
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/isogendagger.activeitem
+++ b/items/active/weapons/melee/dagger/isogendagger.activeitem
@@ -37,8 +37,8 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.45,
-    "baseDps" : 6.24,
+    "fireTime" : 2.95,
+    "baseDps" : 7.24,
     "damageConfig" : {
       "damageSourceKind" : "ice",
       "knockback" : 10,
@@ -63,7 +63,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.7,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.1, 2.5],
@@ -73,7 +73,7 @@
       }
     }
   },
-  "critChance" : 3, 
-  "critBonus" : 3, 
+  "critChance" : 2, 
+  "critBonus" : 20, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/pyreitedagger.activeitem
+++ b/items/active/weapons/melee/dagger/pyreitedagger.activeitem
@@ -37,7 +37,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.35,
+    "fireTime" : 2.65,
     "baseDps" : 8.24,
     "damageConfig" : {
       "knockback" : 10,
@@ -62,7 +62,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.5,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.1, 2.5],
@@ -73,6 +73,6 @@
     }
   },
   "critChance" : 3,
-  "critBonus" : 3,
+  "critBonus" : 15,
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/quietusknave.activeitem
+++ b/items/active/weapons/melee/dagger/quietusknave.activeitem
@@ -35,7 +35,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.25,
+    "fireTime" : 2.25,
     "baseDps" : 8,
     "damageConfig" : {
       "knockback" : 10
@@ -59,7 +59,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.1, 2.5],
@@ -69,7 +69,7 @@
       }
     }
   },
-  "critChance" : 1, 
-  "critBonus" : 6, 
+  "critChance" : 2, 
+  "critBonus" : 18, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/quietusrogue.activeitem
+++ b/items/active/weapons/melee/dagger/quietusrogue.activeitem
@@ -35,7 +35,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.25,
+    "fireTime" : 2.25,
     "baseDps" : 8,
     "damageConfig" : {
       "knockback" : 10
@@ -59,7 +59,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.1, 2.5],
@@ -69,7 +69,7 @@
       }
     }
   },
-  "critChance" : 2, 
-  "critBonus" : 3, 
+  "critChance" : 5, 
+  "critBonus" : 10, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/silverseablade.activeitem
+++ b/items/active/weapons/melee/dagger/silverseablade.activeitem
@@ -35,7 +35,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.4,
+    "fireTime" : 2.4,
     "baseDps" : 9,
     "damageConfig" : {
       "knockback" : 10
@@ -59,7 +59,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.4, 2.5],
@@ -69,7 +69,7 @@
       }
     }
   },
-  "critChance" : 1, 
-  "critBonus" : 4, 
+  "critChance" : 2, 
+  "critBonus" : 10, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/stonedagger.activeitem
+++ b/items/active/weapons/melee/dagger/stonedagger.activeitem
@@ -35,7 +35,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.30,
+    "fireTime" : 2,
     "baseDps" : 4,
     "damageConfig" : {
       "damageSourceKind" : "bow",
@@ -60,7 +60,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 1.7,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.2, 2.5],
@@ -71,7 +71,7 @@
     }
   },
   
-  "critChance" : 1, 
-  "critBonus" : 2, 
+  "critChance" : 2, 
+  "critBonus" : 10, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/uraniumdagger.activeitem
+++ b/items/active/weapons/melee/dagger/uraniumdagger.activeitem
@@ -36,7 +36,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.32,
+    "fireTime" : 2.32,
     "baseDps" : 9.1,
     "damageConfig" : {
       "damageSourceKind": "radioactivedagger",
@@ -62,7 +62,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.8, 2.5],
@@ -73,6 +73,6 @@
     }
   },
   "critChance" : 1,
-  "critBonus" : 3,
+  "critBonus" : 26,
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/xithricitedagger.activeitem
+++ b/items/active/weapons/melee/dagger/xithricitedagger.activeitem
@@ -37,7 +37,7 @@
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
 
     "class" : "MeleeSlash",
-    "fireTime" : 0.315,
+    "fireTime" : 2.615,
     "baseDps" : 8.14,
     "damageConfig" : {
       "knockback" : 10,
@@ -63,7 +63,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.5,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.1, 2.5],
@@ -74,6 +74,6 @@
     }
   },
   "critChance" : 1,
-  "critBonus" : 4,
+  "critBonus" : 25,
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }

--- a/items/active/weapons/melee/dagger/zerchesiumknife.activeitem
+++ b/items/active/weapons/melee/dagger/zerchesiumknife.activeitem
@@ -35,7 +35,7 @@
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/melee/meleeslash.lua"],
     "class" : "MeleeSlash",
-    "fireTime" : 0.45,
+    "fireTime" : 2.45,
     "baseDps" : 8.24,
     "damageConfig" : {
       "knockback" : 10
@@ -59,7 +59,7 @@
         "allowRotate" : false
       },
       "fire" : {
-        "duration" : 0.2,
+        "duration" : 2.2,
         "armRotation" : -135,
         "weaponRotation" : 40,
         "weaponOffset" : [0.1, 2.5],
@@ -70,6 +70,6 @@
     }
   },
   "critChance" : 1, 
-  "critBonus" : 3, 
+  "critBonus" : 15, 
   "builder" : "/items/buildscripts/buildunrandweapon.lua"
 }


### PR DESCRIPTION
* All FU crafted daggers (except the Cute Dagger and the PLUR ones) now swing a lot slower.
* This allows for burst damage, rather than trying to stay just in range of your dagger, and out of the enemies damagebox.
* Additionally, crit damage bonus increased on these daggers.

-Mikenno