### PR TITLE
Tech crafting refactoring

### DIFF
--- a/interface/scripted/techshop/techshop.config
+++ b/interface/scripted/techshop/techshop.config
@@ -45,7 +45,8 @@
       "baseImageChecked" : "/interface/crafting/checkboxcheck.png",
       "checkable" : true,
       "checked" : false,
-      "position" : [36, 66.8]
+      "position" : [36, 66.8],
+      "callback" : "materialFilter"
     },
     "lblProduct" : {
       "type" : "label",
@@ -258,7 +259,8 @@
         "filter",
         "btnCraft",
         "itemSelected",
-        "doUnlock"
+        "doUnlock",
+        "materialFilter"
     ],
 
     "techs" : [
@@ -799,6 +801,6 @@
             "prereq" : [ "zeroburst" ],
             "recipeReq" : true,
             "item" : "sonicburst_tech"
-        }        
+        }
     ]
 }

--- a/interface/scripted/techshop/techshop.lua
+++ b/interface/scripted/techshop/techshop.lua
@@ -27,6 +27,14 @@ function init()
 end
 
 function update(dt)
+    -- put this here to remove flickering
+    if self.adminMode and not player.isAdmin() then
+        self.availableTechs = {}
+        self.lockedTechs = config.getParameter("techs")
+        self.adminMode = false
+        self.forceRepop = true
+    end
+
     -- each update, check to see if any new techs have been unlocked, and update accordingly
     for i,tech in pairs(self.lockedTechs) do
         if player.blueprintKnown(tech.item) then
@@ -47,9 +55,6 @@ function update(dt)
             self.adminMode = true
             self.forceRepop = true
         end
-    elseif self.adminMode then
-        self.adminMode = false
-        self.forceRepop = true
     end
 
     updateSearch()


### PR DESCRIPTION
Optimizes the tech crafting menu to reduce lag.
All techs with learned recipes are now shown, with a changed description showing which techs you're missing if you do not have the prerequisite techs.
Clicking "ENABLE" on previously purchased techs no longer consumes resources, but still updates collection or recipe data normally unlocked.
Admin mode features improved (does not consume resources, can view all techs regardless of prerequisites).