### PR TITLE
Science Outpost Bar Improvements

### DIFF
--- a/behaviors/npc/lounger.behavior.patch
+++ b/behaviors/npc/lounger.behavior.patch
@@ -1,0 +1,3 @@
+[ 
+	{"op":"replace","path":"/root/children/0/children/0/parameters/range","value":{"value":1} } 
+]

--- a/npcs/scienceoutpost/starboozenpc.npctype
+++ b/npcs/scienceoutpost/starboozenpc.npctype
@@ -3,9 +3,13 @@
   "baseType" : "fuoutpostcivilian",
   "damageTeam" : 1,
     "scriptConfig" : {
+	"behavior" : "lounger",
         "offeredQuests" : [ "1boozekit", "2brew_a", "2brew_b", "2brew_c","2brew_d","3hops", "4malt", "5wort", "6beer", "7distill", "8spirits", "9merrymead" ],
         "turnInQuests" : [ "1boozekit", "3hops", "4malt", "5wort", "6beer", "7distill", "8spirits", "9merrymead" ],
-        
+    
+	"behaviourConfig" : {
+	  "range" : 1
+	},
     "wander" : {
       "timeRange" : [2.0, 10.0],
       "chatDistance" : 4,

--- a/objects/generic/fu_Barkeep_spot/fu_Barkeep_spot.object
+++ b/objects/generic/fu_Barkeep_spot/fu_Barkeep_spot.object
@@ -14,27 +14,29 @@
       "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
-	  "renderLayer" : "Player+10",
 	  "sitCoverImage" : "/objects/generic/fu_Barkeep_spot/fu_Barkeep_spot_Aurora.png",
 	  "direction" : "left",
 	  "flipImages" : true,
 	  "sitPosition" : [-10, 24],
 
       "spaceScan" : 0.1,
-      "anchors" : [ "bottom" ]
+      "anchors" : [ "bottom" ],
+	  "collision" : "platform",
+      "collisionSpaces" : [ [0, 1], [1, 1], [2, 1] ]
     },
 	{
       "image" : "fu_Barkeep_spot_Aurora.png:<color>",
       "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
-	  "renderLayer" : "Player+10",
 	  "sitCoverImage" : "/objects/generic/fu_Barkeep_spot/fu_Barkeep_spot_Aurora.png",
 	  "direction" : "right",
 	  "sitPosition" : [14, 24],
 
       "spaceScan" : 0.1,
-      "anchors" : [ "bottom" ]
+      "anchors" : [ "bottom" ],
+	  "collision" : "platform",
+      "collisionSpaces" : [ [0, 1], [1, 1], [2, 1] ]
     }
   ],
   


### PR DESCRIPTION
Make's it so that the bar spot no longer renders on top of the player, makes it have platform collision on top of the table part and makes the starbooze npc use lounger behaviour.