### PR TITLE
Fixes unbreakable block behind the captains chair

### DIFF
--- a/ships/fu_byos/blockKey.config
+++ b/ships/fu_byos/blockKey.config
@@ -225,7 +225,7 @@
     {
       "value" : [0, 255, 255, 255],
       "foregroundBlock" : false,
-      "backgroundBlock" : true,
+      "backgroundBlock" : false,
       "object" : "fu_byoscaptainschair",
       "objectDirection" : "right"
     },


### PR DESCRIPTION
Makes it so there is no longer an invisible background behind the captains chair in the BYOS ship