### PR TITLE
Fix for changing object ship stats

### DIFF
--- a/objects/ship/fu_shipstatmodifier.lua
+++ b/objects/ship/fu_shipstatmodifier.lua
@@ -6,30 +6,34 @@ function init()
 		reload = false
 		return
 	end
-	if not storage.notNew then
-		applyStats(1)
-		maxAmountCheck()
-		storage.notNew = true
+	if not storage.appliedStats then
+		storage.appliedStats = {capabilities = config.getParameter("capabilities"), stats = config.getParameter("stats"), maxAmount = config.getParameter("maxAmount")}
+		if not storage.notNew then
+			if not maxAmountCheck(true) then
+				applyStats(1)
+			end
+		end
 	end
 end
 
 function die()
 	if reload then
 		applyStats(-1)
-		maxAmountCheck()
+		maxAmountCheck(false)
 	end
 end
 
 function applyStats(multiplier)
-	capabilities = config.getParameter("capabilities")
-	stats = config.getParameter("stats")
-	if capabilities then
-		for _, capability in pairs (capabilities) do
+	if not storage.appliedStats then
+		
+	end
+	if storage.appliedStats.capabilities then
+		for _, capability in pairs (storage.appliedStats.capabilities) do
 			statChange(capability, 1, multiplier)
 		end
 	end
-	if stats then
-		for objectStat, statAmount in pairs (stats) do
+	if storage.appliedStats.stats then
+		for objectStat, statAmount in pairs (storage.appliedStats.stats) do
 			statChange(objectStat, statAmount, multiplier)
 		end
 	end
@@ -40,16 +44,15 @@ function statChange(stat, amount, multiplier)
 	world.setProperty("fu_byos." .. stat, baseAmount + (amount * multiplier))
 end
 
-function maxAmountCheck()
-	maxAmount = config.getParameter("maxAmount")
-	if maxAmount then
+function maxAmountCheck(new)
+	if storage.appliedStats.maxAmount then
 		maxAmountProperty = "fu_byos.object." .. object.name()
 		objectAmount = world.getProperty(maxAmountProperty) or 0
-		if not storage.notNew then
-			if objectAmount and objectAmount >= maxAmount then
+		if new then
+			if objectAmount and objectAmount >= storage.appliedStats.maxAmount then
 				object.smash(false)
 				reload = false
-				return
+				return true
 			else
 				world.setProperty(maxAmountProperty, objectAmount + 1)
 			end


### PR DESCRIPTION
Makes it so that changing the ship stats an object gives does not cause you to lose the new stats when the object is broken even though it only applied the old stats. (IF YOU DON"T WANT REMOVING FTL DRIVES TO REDUCE YOUR SHIP SPEED WHEN BROKEN MAKE SURE TO GO NEAR THEM AT LEAST ONCE IN THE NEXT COUPLE DAYS)