### PR TITLE
Saves the pets original name in the capture pod

### DIFF
--- a/interface/objectcrafting/fu_petnamer/fu_petnamer.lua
+++ b/interface/objectcrafting/fu_petnamer/fu_petnamer.lua
@@ -23,6 +23,12 @@ function renamePet()
 		if validItem then
 			world.containerConsumeAt(container, 0, 1)
 			newName = widget.getText("nameTextbox")
+			if not item.parameters.pets[1].config.parameters.monsterTypeName then
+				item.parameters.pets[1].config.parameters.monsterTypeName = item.parameters.pets[1].name
+				if item.parameters.currentPets then
+					item.parameters.currentPets[1].config.parameters.monsterTypeName = item.parameters.pets[1].name
+				end
+			end
 			if newName and newName ~= "" then
 				item.parameters.pets[1].name = newName
 				item.parameters.pets[1].config.parameters.shortdescription = newName


### PR DESCRIPTION
Saves the pets original name in the capture pod when the pet is renamed so that the pet GUI can use it when it's implemented (any pets already renamed will have the changed name instead of the proper name)