### PR TITLE
Capturable Ship Pets

### DIFF
--- a/interface/objectcrafting/fu_petnamer/fu_petnamer.config
+++ b/interface/objectcrafting/fu_petnamer/fu_petnamer.config
@@ -13,7 +13,7 @@
       "base" : "/interface/objectcrafting/refine.png",
       "hover" : "/interface/objectcrafting/refineover.png",
       "caption" : "Rename",
-	  "callback" : "renamePet"
+	  "callback" : "petHouseButton"
     },
     "itemGrid" : {
       "type" : "itemgrid",
@@ -36,14 +36,29 @@
       "hint" : "Name",
       "maxWidth" : 54,
       "escapeKey" : "close",
-      "enterKey" : "renamePet",
+      "enterKey" : "petHouseButton",
       "focus" : false
     }
   },
   "scripts" : ["/interface/objectcrafting/fu_petnamer/fu_petnamer.lua"],
   "scriptWidgetCallbacks" : [
-	"renamePet",
+	"petHouseButton",
 	"nameTextbox"
   ],
-  "acceptedItems" : ["filledcapturepod", "botpod"]
+  "acceptedItems" : {
+	"filledcapturepod" : true,
+	"botpod" : true,
+	"capturepod" : "filledcapturepod"
+  },
+  "moddedCaptureSupport" : false,
+  "petCaptureWhitelist" : {
+    "petbunny" : true,
+	"petcat" : true,
+	"crasberry" : true,
+	"petorbis" : true,
+	"piglett" : true,
+	"petsnake" : true,
+	"snugget" : true,
+	"petweasel" : true
+  }
 }

--- a/interface/objectcrafting/fu_petnamer/fu_petnamer.lua
+++ b/interface/objectcrafting/fu_petnamer/fu_petnamer.lua
@@ -1,46 +1,84 @@
 require "/scripts/util.lua"
 require "/scripts/interp.lua"
+require "/scripts/companions/util.lua"
+require "/scripts/messageutil.lua"
 
 function init()
-	
+	acceptedItems = config.getParameter("acceptedItems")
+	if not config.getParameter("moddedCaptureSupport") then
+		petCaptureWhitelist = config.getParameter("petCaptureWhitelist")
+	end
 end
 
 function update(dt)
-	
+	promises:update()
+	if processing then
+		if pod then
+			item.parameters = util.mergeTable(item.parameters, createFilledPod(pod).parameters)
+			renamePet()
+			createNewItem()
+			processing = false
+		end
+	end
 end
 
-function renamePet()
+function petHouseButton()
 	container = pane.containerEntityId()
 	item = world.containerItemAt(container, 0)
 	if item then
-		validItem = false
-		for _,acceptedItem in pairs (config.getParameter("acceptedItems")) do
-			if item.name == acceptedItem then
-				validItem = true
-				break
-			end
-		end
-		if validItem then
-			world.containerConsumeAt(container, 0, 1)
-			newName = widget.getText("nameTextbox")
-			if not item.parameters.pets[1].config.parameters.monsterTypeName then
-				item.parameters.pets[1].config.parameters.monsterTypeName = item.parameters.pets[1].name
-				if item.parameters.currentPets then
-					item.parameters.currentPets[1].config.parameters.monsterTypeName = item.parameters.pets[1].name
+		acceptedItem = acceptedItems[item.name]
+		if acceptedItem then
+			if item.count == 1 then
+				if type(acceptedItem) == "string" then
+					item.name = acceptedItem
+					processing = true
+					promises:add(world.sendEntityMessage(container, "getPetInfo"), function (petInfo)
+						if not petCaptureWhitelist or petCaptureWhitelist[petInfo.petType] then
+							promises:add(world.sendEntityMessage(petInfo.petId, "pet.attemptCapture"), function (pet)
+								pod = pet
+							end, function ()
+								widget.setText("nameTextbox", "Incompatible Mod Detected")
+							end)
+						else
+							widget.setText("nameTextbox", "The BYOS Moded Race Support Patch Is Required For Modded Pets")
+						end
+					end)
+				else
+					renamePet()
+					createNewItem()
 				end
 			end
-			if newName and newName ~= "" then
-				item.parameters.pets[1].name = newName
-				item.parameters.pets[1].config.parameters.shortdescription = newName
-				if item.parameters.currentPets then
-					item.parameters.currentPets[1].name = newName
-					item.parameters.currentPets[1].config.parameters.shortdescription = newName
-				end
-				item.parameters.tooltipFields.subtitle = newName
-				item.parameters.subtitle = newName
-				item.parameters.podItemHasPriority = true
-			end
-			world.containerAddItems(container, item)
 		end
 	end
+end
+
+function renamePet()
+	textboxName = widget.getText("nameTextbox")
+	if not item.parameters.pets[1].config.parameters.monsterTypeName then
+		item.parameters.pets[1].config.parameters.monsterTypeName = item.parameters.pets[1].name
+		if item.parameters.currentPets then
+			item.parameters.currentPets[1].config.parameters.monsterTypeName = item.parameters.pets[1].name
+		end
+	end
+	if textboxName and textboxName == "" then
+		newName = item.parameters.pets[1].config.parameters.monsterTypeName
+	else
+		newName = textboxName
+	end
+	if newName then
+		item.parameters.pets[1].name = newName
+		item.parameters.pets[1].config.parameters.shortdescription = newName
+		if item.parameters.currentPets then
+			item.parameters.currentPets[1].name = newName
+			item.parameters.currentPets[1].config.parameters.shortdescription = newName
+		end
+		item.parameters.tooltipFields.subtitle = newName
+		item.parameters.subtitle = newName
+		item.parameters.podItemHasPriority = true
+	end
+end
+
+function createNewItem()
+	world.containerConsumeAt(container, 0, 1)
+	world.containerAddItems(container, item)
 end

--- a/interface/objectcrafting/fu_racialiser/fu_racialiser.lua
+++ b/interface/objectcrafting/fu_racialiser/fu_racialiser.lua
@@ -84,7 +84,6 @@ function getNewParameters(pet, treasure)
 	if itemConfig then
 		if item then
 			shortDescriptionNew = item.config.shortdescription .. " (" .. info.name .. ")"
-			sb.logInfo(tostring(shortDescriptionNew))
 			newParameters = util.mergeTable(newParameters, {shortdescription = shortDescriptionNew})
 		end
 		inventoryIconNew = itemConfig.directory .. itemConfig.config.inventoryIcon
@@ -152,7 +151,7 @@ function getNewOrientations()
 	return newOrientations, newPlacementImage, newPlacementImagePosition
 end
 
-function getBYOSParameters(BYOSItemType, pet, treasure) --figure out how to give them the name change
+function getBYOSParameters(BYOSItemType, pet, treasure)
 	itemType = BYOSItemType
 	if itemType then
 		info = raceInfo[count]

--- a/monsters/pets/bunny/petbunny.animation.patch
+++ b/monsters/pets/bunny/petbunny.animation.patch
@@ -1,0 +1,71 @@
+[
+	{
+		"op" : "add", 
+		"path" : "/animatedParts/stateTypes/releaseParticles",
+		"value" : {
+			"default" : "off",
+			"states" : {
+				"off" : {
+					"frames" : 1,
+					"properties" : {
+						"particleEmittersOff" : [ "releaseParticles" ]
+					}
+				},
+				"on" : {
+					"frames" : 1,
+					"cycle" : 0.1,
+					"mode" : "transition",
+					"transition" : "off",
+					"properties" : {
+						"particleEmittersOn" : [ "releaseParticles" ]
+					}
+				}
+			}
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/captureParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/releaseParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportOut",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportIn",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/levelUp",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterlevelup" }
+			]
+		}
+	}
+]

--- a/monsters/pets/cat/petcat.animation.patch
+++ b/monsters/pets/cat/petcat.animation.patch
@@ -1,0 +1,71 @@
+[
+	{
+		"op" : "add", 
+		"path" : "/animatedParts/stateTypes/releaseParticles",
+		"value" : {
+			"default" : "off",
+			"states" : {
+				"off" : {
+					"frames" : 1,
+					"properties" : {
+						"particleEmittersOff" : [ "releaseParticles" ]
+					}
+				},
+				"on" : {
+					"frames" : 1,
+					"cycle" : 0.1,
+					"mode" : "transition",
+					"transition" : "off",
+					"properties" : {
+						"particleEmittersOn" : [ "releaseParticles" ]
+					}
+				}
+			}
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/captureParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/releaseParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportOut",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportIn",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/levelUp",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterlevelup" }
+			]
+		}
+	}
+]

--- a/monsters/pets/crasberry/crasberry.animation.patch
+++ b/monsters/pets/crasberry/crasberry.animation.patch
@@ -1,0 +1,71 @@
+[
+	{
+		"op" : "add", 
+		"path" : "/animatedParts/stateTypes/releaseParticles",
+		"value" : {
+			"default" : "off",
+			"states" : {
+				"off" : {
+					"frames" : 1,
+					"properties" : {
+						"particleEmittersOff" : [ "releaseParticles" ]
+					}
+				},
+				"on" : {
+					"frames" : 1,
+					"cycle" : 0.1,
+					"mode" : "transition",
+					"transition" : "off",
+					"properties" : {
+						"particleEmittersOn" : [ "releaseParticles" ]
+					}
+				}
+			}
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/captureParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/releaseParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportOut",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportIn",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/levelUp",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterlevelup" }
+			]
+		}
+	}
+]

--- a/monsters/pets/groundPet.lua
+++ b/monsters/pets/groundPet.lua
@@ -1,4 +1,5 @@
 require "/scripts/util.lua"
+require "/scripts/companions/capturable.lua"
 
 function init()
   self.pathing = {}
@@ -60,7 +61,8 @@ function init()
   end
 
   self.lastInteract = 0
-  monster.setInteractive(false)
+  monster.setInteractive(true)
+  capturable.init()
 end
 
 function receiveNotification(notification)
@@ -100,6 +102,7 @@ function update(dt)
     util.debugText(self.state.stateDesc(), mcontroller.position(), "blue")
   end
   drawDebugResources()
+  capturable.update(dt)
 end
 
 function setAnchor(entityId)
@@ -147,7 +150,7 @@ function findAnchor()
     end
   end
 
-  if not storage.home then
+  if not storage.home and not capturable.ownerUuid() then
     status.setResource("health", 0)
   else
     -- Pet spawned by a colony deed -- allow the pet to continue living until
@@ -370,4 +373,17 @@ function move(direction, options)
   end
 
   return false, "ledge"
+end
+
+function shouldDie()
+  return status.resource("health") <= 0 or capturable.justCaptured
+end
+
+function die()
+  if not capturable.justCaptured then
+    if self.deathBehavior then
+      self.deathBehavior:run(script.updateDt())
+    end
+    capturable.die()
+  end
 end

--- a/monsters/pets/orbis/petorbis.animation.patch
+++ b/monsters/pets/orbis/petorbis.animation.patch
@@ -1,0 +1,71 @@
+[
+	{
+		"op" : "add", 
+		"path" : "/animatedParts/stateTypes/releaseParticles",
+		"value" : {
+			"default" : "off",
+			"states" : {
+				"off" : {
+					"frames" : 1,
+					"properties" : {
+						"particleEmittersOff" : [ "releaseParticles" ]
+					}
+				},
+				"on" : {
+					"frames" : 1,
+					"cycle" : 0.1,
+					"mode" : "transition",
+					"transition" : "off",
+					"properties" : {
+						"particleEmittersOn" : [ "releaseParticles" ]
+					}
+				}
+			}
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/captureParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/releaseParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportOut",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportIn",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/levelUp",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterlevelup" }
+			]
+		}
+	}
+]

--- a/monsters/pets/piglett/piglett.animation.patch
+++ b/monsters/pets/piglett/piglett.animation.patch
@@ -1,0 +1,71 @@
+[
+	{
+		"op" : "add", 
+		"path" : "/animatedParts/stateTypes/releaseParticles",
+		"value" : {
+			"default" : "off",
+			"states" : {
+				"off" : {
+					"frames" : 1,
+					"properties" : {
+						"particleEmittersOff" : [ "releaseParticles" ]
+					}
+				},
+				"on" : {
+					"frames" : 1,
+					"cycle" : 0.1,
+					"mode" : "transition",
+					"transition" : "off",
+					"properties" : {
+						"particleEmittersOn" : [ "releaseParticles" ]
+					}
+				}
+			}
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/captureParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/releaseParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportOut",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportIn",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/levelUp",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterlevelup" }
+			]
+		}
+	}
+]

--- a/monsters/pets/snake/petsnake.animation.patch
+++ b/monsters/pets/snake/petsnake.animation.patch
@@ -1,0 +1,71 @@
+[
+	{
+		"op" : "add", 
+		"path" : "/animatedParts/stateTypes/releaseParticles",
+		"value" : {
+			"default" : "off",
+			"states" : {
+				"off" : {
+					"frames" : 1,
+					"properties" : {
+						"particleEmittersOff" : [ "releaseParticles" ]
+					}
+				},
+				"on" : {
+					"frames" : 1,
+					"cycle" : 0.1,
+					"mode" : "transition",
+					"transition" : "off",
+					"properties" : {
+						"particleEmittersOn" : [ "releaseParticles" ]
+					}
+				}
+			}
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/captureParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/releaseParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportOut",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportIn",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/levelUp",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterlevelup" }
+			]
+		}
+	}
+]

--- a/monsters/pets/snugget/snugget.animation.patch
+++ b/monsters/pets/snugget/snugget.animation.patch
@@ -1,0 +1,71 @@
+[
+	{
+		"op" : "add", 
+		"path" : "/animatedParts/stateTypes/releaseParticles",
+		"value" : {
+			"default" : "off",
+			"states" : {
+				"off" : {
+					"frames" : 1,
+					"properties" : {
+						"particleEmittersOff" : [ "releaseParticles" ]
+					}
+				},
+				"on" : {
+					"frames" : 1,
+					"cycle" : 0.1,
+					"mode" : "transition",
+					"transition" : "off",
+					"properties" : {
+						"particleEmittersOn" : [ "releaseParticles" ]
+					}
+				}
+			}
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/captureParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/releaseParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportOut",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportIn",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/levelUp",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterlevelup" }
+			]
+		}
+	}
+]

--- a/monsters/pets/weasel/petweasel.animation.patch
+++ b/monsters/pets/weasel/petweasel.animation.patch
@@ -1,0 +1,71 @@
+[
+	{
+		"op" : "add", 
+		"path" : "/animatedParts/stateTypes/releaseParticles",
+		"value" : {
+			"default" : "off",
+			"states" : {
+				"off" : {
+					"frames" : 1,
+					"properties" : {
+						"particleEmittersOff" : [ "releaseParticles" ]
+					}
+				},
+				"on" : {
+					"frames" : 1,
+					"cycle" : 0.1,
+					"mode" : "transition",
+					"transition" : "off",
+					"properties" : {
+						"particleEmittersOn" : [ "releaseParticles" ]
+					}
+				}
+			}
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/captureParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/releaseParticles",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportOut",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monstercapture" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/teleportIn",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterrelease" }
+			]
+		}
+	},
+	{
+		"op" : "add",
+		"path" : "/particleEmitters/levelUp",
+		"value" : {
+			"particles" : [
+				{ "particle" : "monsterlevelup" }
+			]
+		}
+	}
+]

--- a/objects/ship/fu_byospethouse/fu_byospethouse.lua
+++ b/objects/ship/fu_byospethouse/fu_byospethouse.lua
@@ -1,36 +1,43 @@
 function init()
-  --Instantly spawn the pet when first created
-  storage.spawnTimer = storage.spawnTimer and 0.5 or 0
-  storage.petParams = storage.petParams or {}
+	--Instantly spawn the pet when first created
+	storage.spawnTimer = storage.spawnTimer and 0.5 or 0
+	storage.petParams = storage.petParams or {}
 
-  self.monsterType = config.getParameter("shipPetType", "petcat")
-  self.spawnOffset = config.getParameter("spawnOffset", {0, 2})
+	self.monsterType = config.getParameter("shipPetType", "petweasel")
+	self.spawnOffset = config.getParameter("spawnOffset", {0, 2})
+	message.setHandler("getPetInfo", function ()
+		petInfo = {petId = self.petId, petType = self.monsterType}
+		return petInfo
+    end)
 end
 
 function hasPet()
-  return self.petId ~= nil
+	return self.petId ~= nil
 end
 
 function setPet(entityId, params)
-  if self.petId == nil or self.petId == entityId then
-    self.petId = entityId
-    storage.petParams = params
-  else
-    return false
-  end
+	if self.petId == nil or self.petId == entityId then
+		self.petId = entityId
+		storage.petParams = params
+	else
+		return false
+	end
 end
 
 function update(dt)
-  if self.petId and not world.entityExists(self.petId) then
-    self.petId = nil
-  end
+	if self.petId and not world.entityExists(self.petId) then
+		self.petId = nil
+	end
 
-  if storage.spawnTimer < 0 and self.petId == nil then
-    storage.petParams.level = 1
-    self.petId = world.spawnMonster(self.monsterType, object.toAbsolutePosition(self.spawnOffset), storage.petParams)
-    world.callScriptedEntity(self.petId, "setAnchor", entity.id())
-    storage.spawnTimer = 0.5
-  else
-    storage.spawnTimer = storage.spawnTimer - dt
-  end
+	if storage.spawnTimer < 0 and self.petId == nil then
+		storage.petParams.level = 1
+		storage.petParams.damageTeamType = "ghostly"
+		storage.petParams.capturable = true
+		storage.petParams.captureHealthFraction = 1
+		self.petId = world.spawnMonster(self.monsterType, object.toAbsolutePosition(self.spawnOffset), storage.petParams)
+		world.callScriptedEntity(self.petId, "setAnchor", entity.id())
+		storage.spawnTimer = 0.5
+	else
+		storage.spawnTimer = storage.spawnTimer - dt
+	end
 end


### PR DESCRIPTION
Makes so that if you put an empty capture pod in a pet house and rename it, it'll put the pet tied to the pet house inside as well. The FU BYOS Modded Race Support Mod is required for modded race pets to work with it. Will probs be tweaked to work better later.