### PR TITLE
Military Space Station Weapon fix

### DIFF
--- a/interface/scripted/spaceStation/spaceStationData.config
+++ b/interface/scripted/spaceStation/spaceStationData.config
@@ -364,6 +364,12 @@
 		"maxUniqueItems" : 7,
 		"minGenericItems" : 8,
 		"maxGenericItems" : 11,
+		
+		// System rolls a number from 1 to 100. If its below the value on a certain level, that level is chosen
+		// 1 = 101, 2 = 100, 3 = 90, 4 = 65, 5 = 45, 6 = 25, 7 = 10, 8 = 3
+		// rolled 35 - 5 is chosen
+		"weaponLevelRates" : [ 101, 100, 90, 65, 45, 25, 10, 3],
+		
 		"potentialStock" : {
 			"generic"		: [ "coalore", "ironore", "tungstenore", "titaniumore", "copperore", "corefragmentore", "leather", "bottle", "battery", "cellmateria", "wildvines", "cattlefeed", "venomsample", "stickofram", "staticcell", "sharpenedclaw", "scorchedcore", "phasematter", "livingroot","hardenedcarapace","cryonicextract", "coffeebeans", "orange", "cannedfood", "cheese", "chocolate", "egg", "oculemonade", "reefcola", "soda" ],
 			"medical"		: [ "antidote", "burnspray", "greenstim", "yellowstim", "bluestim", "redstim", "battery", "biosample", "bone", "bottle", "bugshell", "artificialbrain", "devilsbargain", "gravstim", "honeyboon", "portablelight", "portaljuice", "protostim","serumstim","shieldpatch", "waterstim", "bouncewrap", "corvexputty", "crunchychick", "shroomremedy" ],

--- a/quickbar/icons.json.patch
+++ b/quickbar/icons.json.patch
@@ -1,7 +1,12 @@
 [
 	{
 		"op": "add",
-		"path": "/normal/0",
+		"path": "/normal/-",
 		"value": { "label" : "Character Status", "pane" : "/interface/scripted/statWindow/statWindow.config", "icon" : "/items/tools/inspectiontool/inspectionmode.png" }
+	},
+	{
+		"op": "add",
+		"path": "/normal/-",
+		"value": { "label" : "Update Info", "pane" : "/interface/scripted/fu_updateInfoWindow/updateInfoWindow.config", "icon" : "/interface/quest.png" }
 	}
 ]

--- a/scripts/fu_updateInfoWindow.lua
+++ b/scripts/fu_updateInfoWindow.lua
@@ -1,5 +1,5 @@
-require "/scripts/deployment/playermechdeployment.lua"
-origInit = init
+
+local origInit = init
 
 function init()
 	origInit()
@@ -10,5 +10,5 @@ function init()
 		player.interact("ScriptPane", "/interface/scripted/fu_updateInfoWindow/updateInfoWindow.config", player.id())
 	end
 	
-	sb.logInfo("Launched Frackin' Universe version %s", data.version)
+	sb.logInfo("Frackin' Universe version %s", data.version)
 end


### PR DESCRIPTION
Military space stations now sell the exact same weapon you see in the shop (instead of a re-roll), leveled, and with a price to fit the level

+ Minor popup window modifications
Version logging is less misleading to the user
Minor handling modifications
  
+ Added popup window to quickbar
  