### PR TITLE
ITDs get slot-specific round-robin mode

### DIFF
--- a/interface/kheAA/kheAA_router/kheAA_routerGui.config
+++ b/interface/kheAA/kheAA_router/kheAA_routerGui.config
@@ -484,6 +484,19 @@
 			"base": "/interface/kheAA/kheAA_router/slotItem.png",
 			"baseImage": "/interface/kheAA/kheAA_router/slotItem.png",
 			"baseImageChecked": "/interface/kheAA/kheAA_router/slotItemSel.png"
+		},
+		"roundRobinSlotMode": {
+			"callback": "roundRobinSlotToggle",
+			"type": "button",
+			"checkable": true,
+			"caption": "Slot Split",
+			         // Inv. Logic
+					 // Round Robin
+			"hAnchor": "left",
+			"position": [72, 17],
+			"base": "/interface/kheAA/kheAA_router/slotItem.png",
+			"baseImage": "/interface/kheAA/kheAA_router/slotItem.png",
+			"baseImageChecked": "/interface/kheAA/kheAA_router/slotItemSel.png"
 		}
 	},
 	"scriptWidgetCallbacks": [
@@ -496,7 +509,8 @@
 		"invSlots",
 		"subOutputSlot",
 		"addOutputSlot",
-		"roundRobinToggle"
+		"roundRobinToggle",
+		"roundRobinSlotToggle"
 	],
 
 	"scripts": ["/interface/kheAA/kheAA_router/kheAA_routerGui.lua"],

--- a/interface/kheAA/kheAA_router/kheAA_routerGui.lua
+++ b/interface/kheAA/kheAA_router/kheAA_routerGui.lua
@@ -34,16 +34,17 @@ end
 
 function initialize(conf)
 	inputSlots={}
-	for k,v in pairs(conf[1]) do
+	for k,v in pairs(conf[1] or {}) do
 		inputSlots[k]={v,"-1"}
 	end
-	for k,v in pairs(conf[2]) do
+	for k,v in pairs(conf[2] or {}) do
 		outputSlots[k]={v,"-1"}
 	end
 	filterInverted=conf[3]
 	filterType=conf[4]
 	invertSlots=conf[5]
 	widget.setChecked("roundRobinMode", conf[6])
+	widget.setChecked("roundRobinSlotMode", conf[7])
 	redrawListSlots(inputList, inputSlots);
 	redrawListSlots(outputList, outputSlots);
 	redrawItemFilters()
@@ -182,6 +183,11 @@ end
 function roundRobinToggle(name)
 	roundRobin = widget.getChecked(name)
 	world.sendEntityMessage(myBox, "setRR", roundRobin)
+end
+
+function roundRobinSlotToggle(name)
+	roundRobin = widget.getChecked(name)
+	world.sendEntityMessage(myBox, "setRRS", roundRobin)
 end
 
 

--- a/objects/kheAA/kheAA_router/kheAA_router.lua
+++ b/objects/kheAA/kheAA_router/kheAA_router.lua
@@ -10,6 +10,7 @@ function init()
 	message.setHandler("setInputSlots", function (msg, _, slots) storage.inputSlots = slots end)
 	message.setHandler("setOutputSlots", function (msg, _, slots) storage.outputSlots = slots end)
 	message.setHandler("setRR", function (msg, _, rr) storage.roundRobin = rr end)
+	message.setHandler("setRRS", function (msg, _, rr) storage.roundRobinSlots = rr end)
 	object.setInteractive(true)
 end
 
@@ -59,26 +60,26 @@ function initVars()
 end
 
 function sendConfig()
-	if storage.inputSlots == nil then
+	if not storage.inputSlots then
 		storage.inputSlots = {};
 	end
-	if storage.outputSlots == nil then
+	if not storage.outputSlots then
 		storage.outputSlots = {};
 	end
-	if storage.filterInverted == nil then
+	if not storage.filterInverted then
 		storage.filterInverted={}
 		for i=1,5 do
 			storage.filterInverted[i]=false;
 		end
 	end
-	if storage.filterType == nil then
+	if not storage.filterType then
 		storage.filterType={};
 		for i=1,5 do
 			storage.filterType[i]=-1;
 		end
 	end
-	if storage.invertSlots==nil then
+	if not storage.invertSlots then
 		storage.invertSlots={false,false}
 	end
-	return({storage.inputSlots,storage.outputSlots,storage.filterInverted,storage.filterType,storage.invertSlots,storage.roundRobin})
+	return {storage.inputSlots,storage.outputSlots,storage.filterInverted,storage.filterType,storage.invertSlots,storage.roundRobin or false,storage.roundRobinSlots or false}
 end


### PR DESCRIPTION
ITDs learn another new trick: round-robin within containers! Activate "Split Slots" mode on the ITD and combine it with output slot settings to split outputs within containers evenly between all valid outputs. This mode won't do anything if there are no output slot restrictions set unless output is inverted. "Split Slots" stacks with the "Even Split" mode to combo well with multi-Fission Reactor setups.