### PR TITLE
stuff

### DIFF
--- a/interface/scripted/logicgates/3statecyclerGUI.lua
+++ b/interface/scripted/logicgates/3statecyclerGUI.lua
@@ -25,7 +25,7 @@ function update()
 end
 
 function initialize(conf)
-	sb.logInfo("conf: %s",conf)
+	--sb.logInfo("conf: %s",conf)
 	for k,v in pairs(conf) do
 		box[k]=v
 	end
@@ -109,5 +109,5 @@ function fillBoxes()
 	widget.setText("inputLeft",tostring(box.leftValue))
 	widget.setText("inputMid",tostring(box.midValue))
 	widget.setText("inputRight",tostring(box.rightValue))
-	sb.logInfo("fillboxes: %s",box)
+	--sb.logInfo("fillboxes: %s",box)
 end

--- a/objects/kheAA/kheAA_unhandledToken/kheAA_unhandledToken.item
+++ b/objects/kheAA/kheAA_unhandledToken/kheAA_unhandledToken.item
@@ -1,0 +1,9 @@
+{
+  "itemName" : "kheAA_unhandledToken",
+  "price" : 50,
+  "rarity" : "Uncommon",
+  "category" : "Unhandled",
+  "inventoryIcon" : "/items/generic/crafting/siliconboard.png",
+  "description" : "A silicon board. It's been programmed to help identify troublesome items for processing.",
+  "shortdescription" : "ITD Unhandled Handler"
+}

--- a/scripts/kheAA/transferUtil.lua
+++ b/scripts/kheAA/transferUtil.lua
@@ -61,9 +61,6 @@ function transferUtil.routeItems()
 				local sourceItems=world.containerItems(sourceContainer)
 				if sourceItems then
 					for indexIn,item in pairs(sourceItems) do
-						if unhandled[item.name] then
-							break
-						end
 						local pass,mod = transferUtil.checkFilter(item)
 						if pass then
 							if transferUtil.validInputSlot(indexIn) then
@@ -169,9 +166,6 @@ function transferUtil.routeMoney()
 					--local conf = root.itemConfig(item.name)
 					--sb.logInfo("%s",conf)
 					--if conf.config.currency then
-					if unhandled[item.name] then
-						break
-					end
 					if transferUtil.getType(item) == "currency" then
 						local leftOverItems = world.containerAddItems(targetContainer,item)
 						if leftOverItems then
@@ -491,7 +485,7 @@ end
 
 function transferUtil.getType(item)
 	if not item.name then
-		return "generic"
+		return "unhandled"
 	elseif item.name == "sapling" then
 		return item.name
 	elseif item.currency then
@@ -516,16 +510,15 @@ function transferUtil.getType(item)
 	if itemCat then
 		return string.lower(itemCat)
 	elseif not unhandled[item.name] then
-		sb.logInfo("Unhandled Item:\n%s",itemRoot)
+		--sb.logInfo("Unhandled Item:\n%s",itemRoot)
 		unhandled[item.name]=true
 	end
-	return string.lower(item.name)
+	return "unhandled"
 end
 
 function transferUtil.getCategory(item)
 	local itemCat=transferUtil.getType(item)
-	--sb.logInfo("%s::%s",itemCat,string.lower(transferUtil.itemTypes[itemCat] or "generic"))
-	return transferUtil.itemTypes[itemCat] or "generic"
+	return transferUtil.itemTypes[itemCat] or "unhandled"
 end
 
 function transferUtil.loadSelfContainer()

--- a/scripts/kheAA/transferUtil.lua
+++ b/scripts/kheAA/transferUtil.lua
@@ -61,6 +61,9 @@ function transferUtil.routeItems()
 				local sourceItems=world.containerItems(sourceContainer)
 				if sourceItems then
 					for indexIn,item in pairs(sourceItems) do
+						if unhandled[item.name] then
+							break
+						end
 						local pass,mod = transferUtil.checkFilter(item)
 						if pass then
 							if transferUtil.validInputSlot(indexIn) then

--- a/scripts/kheAA/transferconfig.config
+++ b/scripts/kheAA/transferconfig.config
@@ -2,6 +2,9 @@
 	// list of item categories and what general category they fall into for filters
 	// khe's note: no capitalization! everything must be lower-case, as the code converts category strings to lowercase.
 	"categories" : {
+		// special
+		"unhandled":"unhandled",
+		
 		// materials
 		"block" : "material",
 		"liquid" : "material",
@@ -22,6 +25,7 @@
 		"grapplinghook" : "tool",
 		"thrownitem" : "tool",
 		"throwableitem" : "tool",
+	
 
 		// rail-related
 		"rail" : "rail",
@@ -105,12 +109,14 @@
 		"mysteriousreward" : "treasure",
 		"smallfossil" : "treasure",
 		"shiplicense" : "treasure",
-		"currency" : "treasure",
 		"upgradecomponent" : "treasure",
 		"tradingcard" : "treasure",
 		"trophy" : "treasure",
 		"actionfigure" : "treasure",
 		"artifact" : "treasure",
+		
+		//currency has special handling now, and is its own separate category
+		"currency" : "currency",
 
 		// consumables
 		"drink" : "consumable",
@@ -142,6 +148,15 @@
 		"teleportmarker" : "building",
 		"shippingcontainer" : "building",
 		"storage" : "building",
+		// enhanced storage
+		"reshapes storage matter":"building",
+		"modifies storage matter":"building",
+		"extracts storage matter":"building",
+		// macrochips
+		"virtual circuit manager":"building",
+		"macrochip data":"building",
+		// gardenbot fences
+		"gardenbot fence":"building",
 
 		// farming stuff
 		"seed" : "farming",
@@ -199,6 +214,7 @@
 		"generic" : "generic",
 		"quest" : "generic",
 		"tech" : "generic",
+		"science!":"generic",
 
 		// beez
 		"queen" : "bee",


### PR DESCRIPTION
3-state cycler ui debug printing removed.
added special new 'unhandled' category token item. needs a recipe.
added and edited transferconfig
transferutil got a minor performance upgrade, and now treats 'unhandled' objects as their own separate category. works well with the token.