### PR TITLE
Price & charisma fix + Repel, Immunization, Hivemind

### DIFF
--- a/interface/scripted/spaceStation/spaceStation.config
+++ b/interface/scripted/spaceStation/spaceStation.config
@@ -483,14 +483,14 @@
 			"visible" : false,
 			"hAnchor" : "left",
 			"textAlign" : "left",
-			"position" : [73, 32],
+			"position" : [80, 32],
 			"fontSize" : 9,
 			"value" : "Benefits"
         },
 		
 		"benefitsBuyPriceLabel" : {
 			"type" : "label",
-			"position" : [73, 19],
+			"position" : [80, 19],
 			"visible" : false,
 			"hAnchor" : "left",
 			"textAlign" : "left",
@@ -500,7 +500,7 @@
 		
 		"benefitsBuyPriceMult" : {
 			"type" : "label",
-			"position" : [111, 19],
+			"position" : [118, 19],
 			"visible" : false,
 			"hAnchor" : "left",
 			"textAlign" : "left",
@@ -510,7 +510,7 @@
 		
 		"benefitsSellPriceLabel" : {
 			"type" : "label",
-			"position" : [73, 25],
+			"position" : [80, 25],
 			"visible" : false,
 			"hAnchor" : "left",
 			"textAlign" : "left",
@@ -520,7 +520,7 @@
 		
 		"benefitsSellPriceMult" : {
 			"type" : "label",
-			"position" : [111, 25],
+			"position" : [118, 25],
 			"visible" : false,
 			"hAnchor" : "left",
 			"textAlign" : "left",
@@ -1052,10 +1052,6 @@
 	"scientificUpdateDelay" : 10,	// Each # scriptDelats will update the scientific list (for price purposes)
 	"shopUpdateDelay" : 5,			// Each # scriptDelats will update the shop list (reason same as above)
 	"shopSellSlots" : [4,8],		// [rows, columns] of sell slots
-	"shopBuyMult" : 3,
-	"shopBuyMultMin" : 1.2,
-	"shopSellMult" : 0.3,
-	"shopSellMultMax" : 2.1,
 	
 	"scriptWidgetCallbacks" : [ "commandProcessor", "goodsSelected", "buyGoods", "sellGoods", "specialSelected", "scientificSelected", "tradeA", "tradeB", "invest", "investMax", "investAmount", "shopSelected", "shopBuyAmount", "shopBuy", "shopSell", "shopIncrement", "shopDecrement", "itemGrid", "shopItemSlot", "shopItemSlotRight", "shopSell" ],
 	"canvasClickCallbacks" : { "dialogueCanvas" : "canvasClickEvent" },

--- a/interface/scripted/spaceStation/spaceStationData.config
+++ b/interface/scripted/spaceStation/spaceStationData.config
@@ -70,20 +70,20 @@
 		[ "^gray;Glass Cannon",				8000,		"/interface/statuses/medicalStationSpecials/glasscannon.png", 			"medicalglasscannon",		"Doubles power multiplier, but reduces protection by 90%"],
 		[ "^green;Immunization",			8000,		"/interface/statuses/medicalStationSpecials/immunization.png", 			"medicalimmunization",		"Provides immunity to most negative status effect, but halves all resistances."],
 		[ "^white;Juggernaut",				8000,		"/interface/statuses/medicalStationSpecials/juggernaut.png", 			"medicaljuggernaut",		"You become immune to knockback and gain 50 protection, but your movement speed is reduced by 33%."],
-		[ "^green;Toxic Cloud",				8000,		"/interface/statuses/medicalStationSpecials/toxiccloud.png", 			"medicaltoxiccloud",		"Emit a toxic cloud every 3 seconds that damages and poisons enemies. Lasts 5 seconds. Whenever a cloud is released, you take a small amount of poison damage, and consume some food."],
+		[ "^green;Toxic Cloud",				8000,		"/interface/statuses/medicalStationSpecials/toxiccloud.png", 			"medicaltoxiccloud",		"Every 3 seconds a toxic cloud that lasts 5 seconds and deals 30 piercing damage is released at your location. Every time this happens, you take 5 piercing damage, and you consume a bit of food."],
 		[ "^#B200FF;Experiment #322",		8000,		"/interface/statuses/medicalStationSpecials/experimental.png", 			"medicalexperimental",		"Applies random positive and/or negative statuses every 10 seconds which last 15-25 seconds."],
 		[ "^red;Trollblood",				8000,		"/interface/statuses/medicalStationSpecials/trollblood.png", 			"medicaltrollblood",		"Regenerate 40% of damage taken over 5 seconds, but suffer 20% reduction in max health, and +0.5 sec energy block time."],
 		[ "^green;Renergizer",				8000,		"/interface/statuses/medicalStationSpecials/renergizer.png", 			"medicalrenergizer",		"Total energy regeneration is increased by 33%, and max energy is increased by 50. Total food consumption is increased by 25% and energy block time is increased by 0.75 seconds."],
 		[ "^yellow;Hypopanic",				8000,		"/interface/statuses/medicalStationSpecials/hypopanic.png", 			"medicalhypopanicc",		"Energy regen is multiplied by 33%, but maximum is reduced by 50. In addition, you gain increased movement speed the less energy you have (up to +67% speed at 35% energy remaining). Taking damage briefly stop energy regen, and  consumes energy for 150% of damage."],
-		[ "^green;Hivemind",				8000,		"/interface/statuses/medicalStationSpecials/hivemind.png", 				"medicalhivemind",			"Shoots a projectile at the closest enemy in a 500 unit radius with a clear line of fire every 2 seconds, dealing 35 base damage on impact. Drains 0.5% of your current health every 0.5 seconds as long as you have more than 10%."],
+		[ "^green;Hivemind",				8000,		"/interface/statuses/medicalStationSpecials/hivemind.png", 				"medicalhivemind",			"Shoots a projectile at the closest enemy in a medium radius with a clear line of fire every second, dealing 10 base damage (^orange;affected by power multiplier^reset;) on impact. Drains 0.5% of your current health every 0.5 seconds as long as you have more than 10%."],
 		[ "^cyan;Mitochondria",				8000,		"/interface/statuses/medicalStationSpecials/mitochondria.png", 			"medicalmitochondria",		"Consumes 2 energy to regenerate 1 health every 0.15 seconds. Energy will regenerate only at full health."],
-		[ "^#7A7D81;Shadow Repel",			8000,		"/interface/statuses/medicalStationSpecials/shadowrepel.png", 			"medicalshadowrepel",		"Increases shadow resistance by 50 and grants immunity to shadow status effects, but reduces all other resistances to 33%."],
-		[ "^#C5B00A;Radiation Repel",		8000,		"/interface/statuses/medicalStationSpecials/radiationrepel.png", 		"medicalradrepel",			"Increases radiation resistance by 50 and grants immunity to radiation status effects, but reduces all other resistances to 33%."],
-		[ "^#69B115;Poison Repel",			8000,		"/interface/statuses/medicalStationSpecials/poisonrepel.png", 			"medicalpoisonrepel",		"Increases poison resistance by 50 and grants immunity to poison status effects, but reduces all other resistances to 33%."],
-		[ "^#A1F1FE;Ice Repel",				8000,		"/interface/statuses/medicalStationSpecials/icerepel.png", 				"medicalicerepel",			"Increases ice resistance by 50 and grants immunity to ice status effects, but reduces all other resistances to 33%."],
-		[ "^#E99400;Fire Repel",			8000,		"/interface/statuses/medicalStationSpecials/firerepel.png", 			"medicalfirerepel",			"Increases fire resistance by 50 and grants immunity to fire status effects, but reduces all other resistances to 33%."],
-		[ "^#9711E4;Electrical Repel",		8000,		"/interface/statuses/medicalStationSpecials/electricrepel.png", 		"medicalelectricrepel",		"Increases electric resistance by 50 and grants immunity to electric status effects, but reduces all other resistances to 33%."],
-		[ "^#6062EB;Cosmic Repel",			8000,		"/interface/statuses/medicalStationSpecials/cosmicrepel.png", 			"medicalcosmicrepel",		"Increases cosmic resistance by 50 and grants immunity to cosmic status effects, but reduces all other resistances to 33%."]
+		[ "^#7A7D81;Shadow Repel",			8000,		"/interface/statuses/medicalStationSpecials/shadowrepel.png", 			"medicalshadowrepel",		"Increases shadow resistance by 50% and grants immunity to shadow status effects, but reduces the overall effectiveness of other ressistances (except physical) by 33%."],
+		[ "^#C5B00A;Radiation Repel",		8000,		"/interface/statuses/medicalStationSpecials/radiationrepel.png", 		"medicalradrepel",			"Increases radiation resistance by 50% and grants immunity to radiation status effects, but reduces the overall effectiveness of other ressistances (except physical) by 33%."],
+		[ "^#69B115;Poison Repel",			8000,		"/interface/statuses/medicalStationSpecials/poisonrepel.png", 			"medicalpoisonrepel",		"Increases poison resistance by 50% and grants immunity to poison status effects, but reduces the overall effectiveness of other ressistances (except physical) by 33%."],
+		[ "^#A1F1FE;Ice Repel",				8000,		"/interface/statuses/medicalStationSpecials/icerepel.png", 				"medicalicerepel",			"Increases ice resistance by 50% and grants immunity to ice status effects, but reduces the overall effectiveness of other ressistances (except physical) by 33%."],
+		[ "^#E99400;Fire Repel",			8000,		"/interface/statuses/medicalStationSpecials/firerepel.png", 			"medicalfirerepel",			"Increases fire resistance by 50% and grants immunity to fire status effects, but reduces the overall effectiveness of other ressistances (except physical) by 33%."],
+		[ "^#9711E4;Electrical Repel",		8000,		"/interface/statuses/medicalStationSpecials/electricrepel.png", 		"medicalelectricrepel",		"Increases electric resistance by 50% and grants immunity to electric status effects, but reduces the overall effectiveness of other ressistances (except physical) by 33%."],
+		[ "^#6062EB;Cosmic Repel",			8000,		"/interface/statuses/medicalStationSpecials/cosmicrepel.png", 			"medicalcosmicrepel",		"Increases cosmic resistance by 50% and grants immunity to cosmic status effects, but reduces the overall effectiveness of other ressistances (except physical) by 33%."]
 	],
 	
 	"crewRaces" : [ "apex", "avian", "floran", "glitch", "human", "hylotl", "novakid" ],
@@ -102,11 +102,13 @@
 	},
 	
 	"trading" : {
-		"sellPriceIncreasePerLevel"	: 0.10,
+		"sellPriceIncreasePerLevel"	: 0.02,
+		"charismaSellPriceIncrease"	: 0.02,
 		"buyPriceReductionPerLevel"	: 0.05,
-		"initialInvestRequired"		: 100,
-		"investMaxLevel"			: 20,
-		"maxLevelCharismaBonus"		: 0.15
+		"charismaBuyPriceReduction"	: 0.05,
+		"initialInvestRequired"		: 500,
+		"investRequirementMult"		: 1.35,	// invest requirement = initial * (mult ^ level)
+		"investMaxLevel"			: 20
 	},
 	
 	"quests" : {
@@ -138,6 +140,11 @@
 		"maxUniqueItems" : 7,
 		"minGenericItems" : 8,
 		"maxGenericItems" : 11,
+		
+		"initBuyMult" : 3,
+		"initSellMult" : 0.3,
+		"minBuyMult" : 1.2,
+		"maxSellMult" : 0.9,
 		
 		// System rolls a number from 1 to 100. If its below the value on a certain level, that level is chosen
 		// 1 = 101, 2 = 100, 3 = 90, 4 = 65, 5 = 45, 6 = 25, 7 = 10, 8 = 3

--- a/stats/effects/medicalStationSpecials/hivemind/hivemind.statuseffect
+++ b/stats/effects/medicalStationSpecials/hivemind/hivemind.statuseffect
@@ -10,8 +10,8 @@
 		"healthDrainPcnt" : 0.005, // Drains X% of current health every interval
 		"minHealthPcnt" : 0.10,
 		"drainInterval" : 0.5,
-		"spawnInterval" : 2,
-		"spawnBaseDamage" : 35,
+		"spawnInterval" : 1,
+		"spawnBaseDamage" : 10,
 		"spawnSearchRadius" : 500,
 		"spawnSpeed" : 100
 	}

--- a/stats/effects/medicalStationSpecials/immunization/immunization.lua
+++ b/stats/effects/medicalStationSpecials/immunization/immunization.lua
@@ -2,20 +2,25 @@
 require "/stats/effects/medicalStationSpecials/medicalStatusBase.lua"
 
 function init()
-	local modifierTable = {}
+	local modifierTable = {
+		{stat = "powerMultiplier", effectiveMultiplier = config.getParameter("powerMult", 0)},
+		{stat = "protection", effectiveMultiplier = config.getParameter("protectionMult", 0)}
+	}
+	
 	for _, immunityStat in ipairs(config.getParameter("statImmunities", 0)) do
 		table.insert(modifierTable, {stat = immunityStat, amount = 1})
 	end
 	
-	for _, resist in ipairs(config.getParameter("resistances", 0)) do
-		table.insert(modifierTable, {stat = resist, effectiveMultiplier = config.getParameter("allResistMult", 0)})
-	end
-	
+	self.ephemeralResist = config.getParameter("statusesWithoutBlockingStat", 0)
 	self.modifierGroupID = effect.addStatModifierGroup(modifierTable)
 	baseInit()
 end
 
 function update(dt)
+	for _, effect in ipairs(self.ephemeralResist) do
+		status.removeEphemeralEffect(effect)
+	end
+	
 	baseUpdate(dt)
 end
 

--- a/stats/effects/medicalStationSpecials/immunization/immunization.statuseffect
+++ b/stats/effects/medicalStationSpecials/immunization/immunization.statuseffect
@@ -7,38 +7,37 @@
 	"scripts" : [ "immunization.lua" ],
 	
 	"effectConfig" : {
-		"allResistMult" : 0.5,
-		"resistances" : [
-			"physicalResistance",
-			"fireResistance",
-			"poisonResistance",
-			"iceResistance",
-			"electricResistance",
-			"radioactiveResistance",
-			"cosmicResistance",
-			"shadowResistance"
-		],
+		"powerMult" : 0.9,
+		"protectionMult" : 0.9,
 		"statImmunities" : [
-			"ffextremeradiationImmunity",
-			"biomeradiationImmunity",
-			"ffextremeheatImmunity",
-			"biomeheatImmunity",
-			"ffextremecoldImmunity",
-			"biomecoldImmunity",
 			"biooozeImmunity",
 			"shadowgasImmunity",
 			"sulphuricImmunity",
 			"fireStatusImmunity",
 			"liquidnitrogenImmunity",
-			"breathProtection",
 			"poisonStatusImmunity",
 			"slushslowImmunity",
 			"snowslowImmunity",
 			"protoImmunity",
 			"shadowImmunity",
-			"pressureImmunity",
 			"darknessImmunity",
-			"radiationburnImmunity"
+			"radiationburnImmunity",
+			"electricStatusImmunity",
+			"iceStatusImmunity",
+			"stunImmunity",
+			"slimeImmunity",
+			"tarStatusImmunity",
+			"beestingImmunity",
+			"boozeImmunity",
+			"sandstormImmunity"
+		],
+		"statusesWithoutBlockingStat" : [
+			"rootfu",
+			"freeze",
+			"freezefu",
+			"freezefu2",
+			"frozenburning",
+			"slow"
 		]
 	}
 }

--- a/stats/effects/medicalStationSpecials/repel/repel_base.lua
+++ b/stats/effects/medicalStationSpecials/repel/repel_base.lua
@@ -2,17 +2,19 @@
 require "/stats/effects/medicalStationSpecials/medicalStatusBase.lua"
 
 function init()
-	local resist = config.getParameter("resist", 0)
-	local otherResistsMult = config.getParameter("otherResistsMult", 0)
 	local statusImmunities = config.getParameter("statusImmunities", 0)
-	local elements = { "physical", "fire", "poison", "ice", "electric", "radioactive", "cosmic", "shadow" }
 	local modifierTable = {}
+
+	self.elements = { "fire", "poison", "ice", "electric", "radioactive", "cosmic", "shadow" }
+	self.resist = config.getParameter("resist", 0)
+	self.otherResistsMult = config.getParameter("otherResistsMult", 0)
+	self.resistsTableID = nil
+	self.recalcInterval = 1
+	self.recalcCooldown = 0
 	
-	for _, element in ipairs(elements) do
-		if element == resist then
+	for _, element in ipairs(self.elements) do
+		if element == self.resist then
 			table.insert(modifierTable, {stat = element.."Resistance", amount = config.getParameter("bonusResistFlat", 0)})
-		else
-			table.insert(modifierTable, {stat = element.."Resistance", effectiveMultiplier = otherResistsMult})
 		end
 	end
 	
@@ -27,9 +29,33 @@ function init()
 end
 
 function update(dt)
+	if self.recalcCooldown <= 0 then
+		if self.resistsTableID then
+			effect.removeStatModifierGroup(self.resistsTableID)
+		end
+		
+		local resistsTable = {}
+		for _, element in ipairs(self.elements) do
+			if element ~= self.resist and status.statPositive(element.."Resistance") then
+				table.insert(resistsTable, {stat = element.."Resistance", effectiveMultiplier = self.otherResistsMult})
+			end
+		end
+		
+		if #resistsTable > 0 then
+			self.resistsTableID = effect.addStatModifierGroup(resistsTable)
+		end
+		self.recalcCooldown = self.recalcInterval
+	else
+		self.recalcCooldown = self.recalcCooldown - dt
+	end
+	
 	baseUpdate(dt)
 end
 
 function uninit()
+	if self.resistsTableID then
+		effect.removeStatModifierGroup(self.resistsTableID)
+	end
+	
 	baseUninit(self.modifierGroupID)
 end


### PR DESCRIPTION
**Space Stations**
- Trade stations now properly give the bonus you deserve for upgrading them to max level (20). Bonus changed to -5% buy and +2% sell price.
- Trade station buy and sell price change per level is now 5% and 2% respectively.
- Trade stations now properly apply their benefits to their own shops
- Trade stations now display buy/sell rates instead of the bonus they provide
- Adjusted price requirements for upgrading a trading station
**NOTE:** Any bonuses accumulated so far never existed because I forgot to add them when you upgrade it to max. Sorry lol
**NOTE:** Price requirements for upgrading will affect already generated stations after you upgrade them once.

**Medical Enhancers**
- Better phrasing
- **Hivemind**: Shot interval reduced to 1 second, and base damage per shot reduced to 10. (Don't forget its affected by power multiplier)
- **Elemental Repels**: Resistance reduction no longer affects physical or negative resistances.
- **Immunization**:
Old effect - Provides the same status resistances Shoggoth armor does, but halves all resistances
New effect - Provides immunities to most non-weather effects, but reduces overall power multiplier and protection by 10%