### PR TITLE
Crappy Crew Bed Description Update

### DIFF
--- a/objects/ship/fu_crewbed0/fu_crewbed0.object
+++ b/objects/ship/fu_crewbed0/fu_crewbed0.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_crewbed0",
   "colonyTags" : ["misc"],
   "rarity" : "legendary",
-  "description" : "These crappy beds attach to a wall. Horribly uncomfortable. ^yellow;Crew +1^reset;",
+  "description" : "These crappy beds attach to a wall. Horribly uncomfortable. Can only place 4. ^yellow;Crew +1^reset;",
   "shortdescription" : "Crappy Crew Bed",
   "race" : "generic",
   "category" : "furniture",


### PR DESCRIPTION
Makes it so that the crappy crew beds say that you can only place 4 of them in thier description.