### PR TITLE
Change customCollections to customCollectionsFU

### DIFF
--- a/interface/scripted/collections/collectionsgui.config
+++ b/interface/scripted/collections/collectionsgui.config
@@ -164,12 +164,12 @@
           "baseImage" : "/interface/scripted/collections/tab_fu_deselect.png",
           "baseImageChecked" : "/interface/scripted/collections/tab_fu_select.png",
           "pressedOffset" : [0, 0],
-          "data" : "customCollections"
+          "data" : "customCollectionsFU"
         },          
         {
           "visible": false,
           "selected": false,
-          "data": "customCollectionsVisible"
+          "data": "customCollectionsFUVisible"
         }     
       ]
     },
@@ -313,8 +313,8 @@
   "iconSize" : [22, 22],
   
   
-  "customCollectionsTitle": "Custom Collections",
-  "customCollections": [
+  "customCollectionsFUTitle": "Custom FU Collections",
+  "customCollectionsFU": [
     "fu_shoggothart",
     "fu_chemist",
     "fu_geology",


### PR DESCRIPTION
This is to make it easier for mods to check whether or not FU has modified/added to the collectionsgui.config.

Instead of having to check whether the FU collections button has been added via the image it uses, a patch file can check for the customCollectionsFU to have been added.

Since FU changes the size of the collectionsgui.config window and the button locations, this will make it easier to provide compatibility for FU without messing up the UI Frackin' Universe uses, but also allow mods to support the old collections window size/positions for those users not using Frackin' Universe.

(It is possible to do without these changes, these changes simply make it easier, although I haven't accounted for any of the FU addons)