### PR TITLE
Reverts the SAIL not showing boot up text fix

### DIFF
--- a/quests/scripts/story/bootship.lua
+++ b/quests/scripts/story/bootship.lua
@@ -69,10 +69,7 @@ function wakeSail()
 
     local shipUpgrades = player.shipUpgrades()
     if shipUpgrades.shipLevel > 0 or player.hasQuest("fu_byos") then
-	  promises:add(world.sendEntityMessage(self.techstationUid, "activateShip"), function()
-        quest.complete()
-	  end, function()
-	  end)
+	  world.sendEntityMessage(self.techstationUid, "activateShip")
     end
     coroutine.yield()
   end


### PR DESCRIPTION
Reverts the "activate ship" entity message in bootship.lua back to just a message instead of a promise due to issues with mods like Avali when choicing the default ship (will make it so that the SAIL text that appears after bootup won't always appear on BYOS ships again)