### PR TITLE
Added dynamic inspection to trays akin to batteries.

### DIFF
--- a/objects/crafting/fu_growingtray/fu_growingtray.object
+++ b/objects/crafting/fu_growingtray/fu_growingtray.object
@@ -3,7 +3,7 @@
     "printable" : false,
     "colonyTags" : [ "science", "farming", "plants", "farm" ],
     "rarity" : "Common",
-    "description" : "Grows crops more quickly and efficiently via fertilizers and controlled conditions. Requires 3 seeds and water.",
+    "description" : "Grows crops more quickly and efficiently via fertilizers and controlled conditions. Requires seeds and water.",
     "shortdescription" : "^cyan;Growing Tray^reset;",
     "race" : "generic",
     "category" : "wire",

--- a/objects/power/isn_hydroponicstray/isn_hydroponicstray.object
+++ b/objects/power/isn_hydroponicstray/isn_hydroponicstray.object
@@ -3,19 +3,12 @@
     "printable" : false,
     "colonyTags" : [ "science" ],
     "rarity" : "rare",
-    "description" : "An hydroponic powered growing tray. ^cyan;Requires ^orange;2W ^cyan;power^reset;, 3 seeds and water.",
+    "description" : "An hydroponic powered growing tray. ^cyan;Requires ^orange;2W ^cyan;power^reset;, seeds and water.",
     "shortdescription" : "^cyan;Hydro Tray^reset;",
     "race" : "generic",
     "category" : "wire",
     "objectType" : "container",
     "price" : 1000,
-
-    "apexDescription" : "Machines like these could help end famines.",
-    "avianDescription" : "Most Avians prefer to farm the old fashioned way.",
-    "floranDescription" : "Machine makesss plant? Floran... kinda ssskeeved out a bit.",
-    "glitchDescription" : "Daydreaming. I'd love to grow a nice crop of diodia.",
-    "humanDescription" : "Oh jeez, this isn't one of those grow houses is it?",
-    "hylotlDescription" : "A noble endeavour to be sure, but.. such sterile form.",
 
     "inventoryIcon" : "isn_hydroponicstray_inv.png",
     "orientations" : [


### PR DESCRIPTION
The information is based on what is CURRENTLY in the tray slots, not what it's growing.  So you can pick out the right fertilizer and liquid THEN insert your seed of choice.

Also removed racial descriptions from hydroponics trays as that was hiding useful information from players (ie power draw) using the stock Starbound races.

Modified description on both trays to remove the explicit number of seeds.