### PR TITLE
fixes

### DIFF
--- a/monsters/unique/smallshroom/smallshroom.animation
+++ b/monsters/unique/smallshroom/smallshroom.animation
@@ -71,6 +71,26 @@
             "frames" : 1
           }
         }
+      },
+      "releaseParticles" : {
+        "default" : "off",
+        "states" : {
+          "off" : {
+            "frames" : 1,
+            "properties" : {
+              "particleEmittersOff" : [ "releaseParticles" ]
+            }
+          },
+          "on" : {
+            "frames" : 1,
+            "cycle" : 0.1,
+            "mode" : "transition",
+            "transition" : "off",
+            "properties" : {
+              "particleEmittersOn" : [ "releaseParticles" ]
+            }
+          }
+        }
       }
     },
 

--- a/objects/farmables/littlerascal/littlerascalseed.object
+++ b/objects/farmables/littlerascal/littlerascalseed.object
@@ -3,7 +3,7 @@
     "colonyTags" : [ "nature" ],
   "rarity" : "common",
   "category" : "seed",
-  "description" : "It's produce will restore health and energy.",
+  "description" : "Its produce will restore health and energy.",
   "shortdescription" : "Uri Seed",
   "objectType" : "farmable",
   "printable" : false,

--- a/quests/fu_questlines/outpost/bees/1beestation.questtemplate
+++ b/quests/fu_questlines/outpost/bees/1beestation.questtemplate
@@ -2,7 +2,7 @@
   "id" : "1beestation",
   "prerequisites" : [  ],
   "title" : "Beekeeping 101",
-  "text" : "Care to try a simpler life, ^green;breeding bees^white; and reaping the profits? Build a ^orange;Bee Station^white; and you can get started.",
+  "text" : "Care to try a simpler life, ^green;breeding bees^white; and reaping the profits? Build an ^orange;Apiary Crafting Station^white; and you can get started.",
   "completionText" : "With the ^orange;Bee Station^white;, you'll be able to craft a whole new array of goods you've likely not seen before!",
   "moneyRange" : [120, 220],
   "rewards" : [ ],


### PR DESCRIPTION
uri seed loses an unneeded apostraphe
small shrooms, which were uncapturable prior to a prior update, are now summonable!
Bee quest is now less confusing, no longer referencing the wrong item.