### PR TITLE
Big balance change, smaller balance changes, some cleanup and a little optimization.

### DIFF
--- a/objects/crafting/fu_growingtray/fu_growingtray.object
+++ b/objects/crafting/fu_growingtray/fu_growingtray.object
@@ -41,7 +41,7 @@
     "outputNodes" : [ [1, 0] ],
 
     // Base rate of growth. (1 is vanilla speed)
-    "baseGrowthPerSecond" : 5,
+    "baseGrowthPerSecond" : 100,
     "defaultWaterUse" : 3,
     "defaultSeedUse" : 3,
     "baseYields" : 2,
@@ -56,9 +56,9 @@
         "liquidblood" : { "value" : 2 },
         "pus" : { "value" : 2 },
         "liquidalienjuice" : { "value" : 3 },
-        "liquidorganicsoup" : { "value" : 4 },
+        "liquidorganicsoup" : { "value" : 4, "growthRate" : 1.375 },
         "liquidaether" : { "value" : 5 },
-        "liquidhealing" : { "value" : 6 }
+        "liquidhealing" : { "value" : 6, "growthRate" : 1.225 }
     },
 
     "fertInputs" : {

--- a/objects/power/isn_hydroponicstray/isn_hydroponicstray.object
+++ b/objects/power/isn_hydroponicstray/isn_hydroponicstray.object
@@ -43,10 +43,12 @@
     "isn_requiredPower" : 2,
 
     //Amount of growth per second for this table.
-    "baseGrowthPerSecond" : 5,
+    "baseGrowthPerSecond" : 6,
 
     //Rate (as in multiplier) applied to growth when the tray is unpowered.
-    "unpoweredGrowthRate" : 0.434782609,
+	//Should be roughly fu_growingtray.baseGrowthPerSecond / isn_hydroponicstray.baseGrowthPerSecond
+	//Should err on being worse than the growing tray but not by much.
+    "unpoweredGrowthRate" : 0.666666666,
 
     "defaultWaterUse" : 2,
     "defaultseedMod" : 3,
@@ -62,9 +64,9 @@
         "liquidblood" : { "value" : 2 },
         "pus" : { "value" : 2 },
         "liquidalienjuice" : { "value" : 3 },
-        "liquidorganicsoup" : { "value" : 4 },
+        "liquidorganicsoup" : { "value" : 4, "growthRate" : 1.375 },
         "liquidaether" : { "value" : 5 },
-        "liquidhealing" : { "value" : 6 }
+        "liquidhealing" : { "value" : 6, "growthRate" : 1.225 }
     },
 
     "fertInputs" : {


### PR DESCRIPTION
* Trays balance changes and feedback improvements.
  - Fixed a bug causing perennial seed loss when improving fertilizer.
  - Trays are no longer set and forget with perennial plants.  Should think of "Yield Count" as the number of plants being grown.  With poor fertilizer choices one should expect seed loss now.
  - Perennial growth bonus sticks around from growth ending to the next starting if the same seed.  So can pause growth and resume later to still get the bonus (if any defined in seed).
  - Hydroponics tray, when powered, is faster than Growing Tray.  About the same speed unpowered.
  - Some liquid items in the water slot slightly improve growing speed.
  - Invalid water/fertilizer items in said slots will be 'rejected' into tray storage if there is room.
  - Can interrupt perennial plants starting their next growth cycle the same way as annual plants, by placing any non-seed item in the seed slot.