### PR TITLE
Some tweaks

### DIFF
--- a/objects/isn_unifiedgrowingtray.lua
+++ b/objects/isn_unifiedgrowingtray.lua
@@ -59,14 +59,19 @@ function update(dt)
 	-- Check tray inputs/update description
 	checkTrayInputs()
 
-	if self.requiredPower then power.update(dt) end
-
 	storage.activeConsumption = false
 
 	--Try to start growing if data indicates we aren't.
 	if not storage.currentseed then
-		if not doSeedIntake() then return end
+		if not doSeedIntake() then
+			-- Player feedback, when not growing, turn off the lights.
+			if self.requiredPower then animator.setAnimationState("powlight", "off") end
+			return
+		end
 	end
+	
+	--Only consume power when ACTUALLY growing.
+	if self.requiredPower then power.update(dt) end
 
 	local growthmod = consumePower(dt) and 1 or self.unpoweredGrowthRate
 	growPlant(growthmod, dt)

--- a/scripts/kheAA/excavatorCommon.lua
+++ b/scripts/kheAA/excavatorCommon.lua
@@ -131,8 +131,10 @@ function states.start(dt)
 end
 
 function states.vacuum(dt)
-	excavatorCommon.grab(entity.position())
-	storage.state="start"
+	if transferUtil.powerLevel(storage.logicNode) then
+		excavatorCommon.grab(entity.position())
+		storage.state="start"
+	end
 end
 
 function states.moveDrillBar(dt)


### PR DESCRIPTION
* Hydroponics tray turns out the lights when not growing.
* Hydroponics tray doesn't draw power when it's not growing.
* Item Grabbers are no longer 'always on'.  The power switch pin (first input) can turn them off.