### PR TITLE
Updated questline loot box rewards + small fix

### DIFF
--- a/interface/scripted/fu_lootbox/lootboxData.config
+++ b/interface/scripted/fu_lootbox/lootboxData.config
@@ -203,33 +203,33 @@
 				"rare" : [
 					{"treasurePool" : "fu_lootboxCommonWeapon",		"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
 					{"treasurePool" : "fu_lootboxUncommonWeapon",	"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
-					{"treasurePool" : "fu_lootboxRareWeapon",		},
+					{"treasurePool" : "fu_lootboxRareWeapon"		},
 					{"treasurePool" : "fu_lootboxCommonWeapon",		"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
 					{"treasurePool" : "fu_lootboxUncommonWeapon",	"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
-					{"treasurePool" : "fu_lootboxRareWeapon",		},
+					{"treasurePool" : "fu_lootboxRareWeapon"		},
 					{"func" : "spawnMonsters" }
 				],
 				"epic" : [
 					{"treasurePool" : "fu_lootboxUncommonWeapon",	"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
 					{"treasurePool" : "fu_lootboxRareWeapon",		"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
-					{"treasurePool" : "fu_lootboxEpicWeapon",		},
+					{"treasurePool" : "fu_lootboxEpicWeapon"		},
 					{"treasurePool" : "fu_lootboxUncommonWeapon",	"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
 					{"treasurePool" : "fu_lootboxRareWeapon",		"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
-					{"treasurePool" : "fu_lootboxEpicWeapon",		},
+					{"treasurePool" : "fu_lootboxEpicWeapon"		},
 					{"treasurePool" : "fu_lootboxUncommonWeapon",	"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
 					{"treasurePool" : "fu_lootboxRareWeapon",		"func" : "levelMod",	"params" : {"itemLevelMod" : 1}},
-					{"treasurePool" : "fu_lootboxEpicWeapon",		},
+					{"treasurePool" : "fu_lootboxEpicWeapon"		},
 					{"func" : "spawnMonsters" }
 				],
 				"legendary" : [
 					{"treasurePool" : "fu_lootboxUncommonWeapon",	"func" : "levelMod",	"params" : {"itemLevelMod" : 2}},
-					{"treasurePool" : "fu_lootboxLegendaryWeapon",	},
+					{"treasurePool" : "fu_lootboxLegendaryWeapon"	},
 					{"treasurePool" : "fu_lootboxUncommonWeapon",	"func" : "levelMod",	"params" : {"itemLevelMod" : 2}},
-					{"treasurePool" : "fu_lootboxLegendaryWeapon",	},
+					{"treasurePool" : "fu_lootboxLegendaryWeapon"	},
 					{"treasurePool" : "fu_lootboxUncommonWeapon",	"func" : "levelMod",	"params" : {"itemLevelMod" : 2}},
-					{"treasurePool" : "fu_lootboxLegendaryWeapon",	},
+					{"treasurePool" : "fu_lootboxLegendaryWeapon"	},
 					{"treasurePool" : "fu_lootboxUncommonWeapon",	"func" : "levelMod",	"params" : {"itemLevelMod" : 2}},
-					{"treasurePool" : "fu_lootboxLegendaryWeapon",	},
+					{"treasurePool" : "fu_lootboxLegendaryWeapon"	},
 					{"func" : "spawnMonsters" }
 				]
 			},

--- a/interface/scripted/fu_tutorialQuestList/fu_tutorialQuestList.lua
+++ b/interface/scripted/fu_tutorialQuestList/fu_tutorialQuestList.lua
@@ -1,6 +1,11 @@
+
+
 function init()
 	self.GD = root.assetJson("/interface/scripted/fu_tutorialQuestList/fu_tutorialQuestList.config")
 	self.QD = root.assetJson("/interface/scripted/fu_tutorialQuestList/questData.config")
+	
+	local defaultItemParams = root.assetJson("/items/defaultParameters.config")
+	self.defaultMaxStack = defaultItemParams.defaultMaxStack
 	
 	questlineButton()
 	widget.setText("questTitle",	self.QD.strings.instructions.title )
@@ -89,13 +94,40 @@ function populateQueslineList()
 						if type(tbl.moneyRange) == "table" then
 							player.addCurrency("money", math.random(tbl.moneyRange[1], tbl.moneyRange[2]))
 						else
-							player.addCurrency("money", math.random(tbl.moneyRange[1], tbl.moneyRange[2]))
+							player.addCurrency("money", tbl.moneyRange)
 						end
 					end
 					
 					if tbl.rewards then
 						for _, rewardTbl in ipairs(tbl.rewards) do
-							player.giveItem({ name = rewardTbl[1], count = rewardTbl[2] })
+							local item = root.itemConfig(rewardTbl[1])
+							local maxStack = item.config.maxStack or self.defaultMaxStack
+							
+							if rewardTbl[2] <= maxStack then
+								if rewardTbl[3] then
+									player.giveItem({ name = rewardTbl[1], count = rewardTbl[2], parameters = rewardTbl[3]})
+								else
+									player.giveItem({ name = rewardTbl[1], count = rewardTbl[2]})
+								end
+							else
+								local overflow = rewardTbl[2] % maxStack
+								local iterations = math.floor(rewardTbl[2] / maxStack)
+								for i = 1, iterations do
+									if rewardTbl[3] then
+										player.giveItem({ name = rewardTbl[1], count = maxStack, parameters = rewardTbl[3]})
+									else
+										player.giveItem({ name = rewardTbl[1], count = maxStack})
+									end
+									
+									if i == iterations then
+										if rewardTbl[3] then
+											player.giveItem({ name = rewardTbl[1], count = overflow, parameters = rewardTbl[3]})
+										else
+											player.giveItem({ name = rewardTbl[1], count = overflow})
+										end
+									end
+								end
+							end
 						end
 					end
 				end
@@ -107,7 +139,7 @@ function populateQueslineList()
 		end
 	end
 	
-	status.setStatusProperty("fuQuestlinesComplete", questlineStatuses)
+	-- status.setStatusProperty("fuQuestlinesComplete", questlineStatuses)
 end
 
 function questlineSelected()

--- a/interface/scripted/fu_tutorialQuestList/fu_tutorialQuestList.lua
+++ b/interface/scripted/fu_tutorialQuestList/fu_tutorialQuestList.lua
@@ -139,7 +139,7 @@ function populateQueslineList()
 		end
 	end
 	
-	-- status.setStatusProperty("fuQuestlinesComplete", questlineStatuses)
+	status.setStatusProperty("fuQuestlinesComplete", questlineStatuses)
 end
 
 function questlineSelected()

--- a/interface/scripted/fu_tutorialQuestList/fu_tutorialQuestList.lua
+++ b/interface/scripted/fu_tutorialQuestList/fu_tutorialQuestList.lua
@@ -119,7 +119,7 @@ function populateQueslineList()
 										player.giveItem({ name = rewardTbl[1], count = maxStack})
 									end
 									
-									if i == iterations then
+									if i == iterations and overflow > 0 then
 										if rewardTbl[3] then
 											player.giveItem({ name = rewardTbl[1], count = overflow, parameters = rewardTbl[3]})
 										else
@@ -211,8 +211,29 @@ function questlineSelected()
 						end
 						
 						if self.QD.lines[loc].rewards then
+							local rewards = {}
 							path = ""
-							for count, reward in ipairs(self.QD.lines[loc].rewards) do
+							
+							for _, rewardTbl in ipairs(self.QD.lines[loc].rewards) do
+								local item = root.itemConfig(rewardTbl[1])
+								local maxStack = item.config.maxStack or self.defaultMaxStack
+								
+								if rewardTbl[2] <= maxStack then
+									table.insert(rewards, rewardTbl)
+								else
+									local overflow = rewardTbl[2] % maxStack
+									local iterations = math.floor(rewardTbl[2] / maxStack)
+									for i = 1, iterations do
+										table.insert(rewards, {rewardTbl[1], maxStack, rewardTbl[3]})
+										
+										if i == iterations and overflow > 0 then
+											table.insert(rewards, {rewardTbl[1], overflow, rewardTbl[3]})
+										end
+									end
+								end
+							end
+							
+							for count, reward in ipairs(rewards) do
 								if count % self.GD.rewardItemSlotCount == 1 then
 									path = "textScrollArea.rewardList."..widget.addListItem("textScrollArea.rewardList")
 									widget.setVisible(path..".reward1", true)

--- a/interface/scripted/fu_tutorialQuestList/questData.config
+++ b/interface/scripted/fu_tutorialQuestList/questData.config
@@ -5,6 +5,9 @@
 //- do "sublines" : ... and replace the ... with an array of subline names (sublines covered later).
 //- do "requirements" : ... and replace the ... with an array of quests the player must complete before they can access this quest line.
 //- do "secret" : ... and replace the ... with either true or false. If set to true, the quest line will not be visible to the player until its unlocked.
+//- do "moneyRange" : ... and replace the ... with either a money range [10, 30] or a single value to reward the player with pixels upon completing the questline
+//- do "rewards" : ... and replace the ... with an array holding arrays of rewarded items upon completing the questline
+//-		"rewards" : [ [itemname, amount], [itemname, amount, {parameter : value}] ]
 
 //Images for quest lines and sublines?
 //- For quest lines, add a two frame image to the "banners" folder with the quest lines name, where one frame shows the unlocked image, and the other 
@@ -17,10 +20,11 @@
 	"lines" : [
 		{ 
 			"id" : "tutorial",	
-			"sublines" : [ "vinj", "extractor" ],	
+//			"sublines" : [ "vinj", "extractor" ],
+			"sublines" : [ "extractor" ],	
 			"requirements" : [ "create_matterassembler" ],
 			"moneyRange" : [100, 150],
-			"rewards" : [ [ "aegisaltpistol3", 1 ], ["salvagebody", 5],["salvagetier4", 5], ["fu_lootbox",3] ],			
+			"rewards" : [ [ "aegisaltpistol3", 1 ], ["salvagebody", 5],["salvagetier4", 5], ["fu_lootbox", 3, {"level" : 3}]],			
 			"secret" : false	
 		},
 		{ 
@@ -28,7 +32,7 @@
 			"sublines" : [ "byosbasics" ],	
 			"requirements" : [ "fu_byos" ],
 			"moneyRange" : [0, 0],
-			"rewards" : [ ["salvagebody", 5],["salvagebooster", 5],["salvagetier4", 5], ["fu_lootbox",3] ],			
+			"rewards" : [ ["salvagebody", 5],["salvagebooster", 5],["salvagetier4", 5], ["fu_lootbox", 3, {"level" : 2}] ],			
 			"secret" : true	
 		},
 		{ 
@@ -36,7 +40,7 @@
 			"sublines" : [ "physics", "chemistry", "electronics", "genetics", "mechanical" ],	
 			"requirements" : [ "create_tinkertable"  ],
 			"moneyRange" : [400, 600],
-			"rewards" : [ [ "fu_pickuprangeaugment1", 1 ], ["fu_lootbox",3] ],					
+			"rewards" : [ [ "fu_pickuprangeaugment1", 1 ], ["fu_lootbox", 3, {"level" : 4}] ],					
 			"secret" : false	
 		},			
 		{ 
@@ -44,7 +48,7 @@
 			"sublines" : [ "kevin", "bees", "booze" ],	
 			"requirements" : [ "1boozekit",	"1beestation", 	"create_clothingfabricator"  ],
 			"moneyRange" : [200, 300],
-			"rewards" : [ [ "8bitpowerup", 1 ], ["fu_lootbox",1] ],					
+			"rewards" : [ [ "8bitpowerup", 1 ], ["fu_lootbox", 3, {"level" : 4}] ],					
 			"secret" : false	
 		},
 		{ 
@@ -52,7 +56,7 @@
 			"sublines" : [ "gear", "monsters" ],	
 			"requirements" : [ "create_matterassembler" ],
 			"moneyRange" : [0, 0],
-			"rewards" : [ [ "mecharmsentrygun-recipe", 1 ], ["fu_lootbox",10] ],					
+			"rewards" : [ [ "mecharmsentrygun-recipe", 1 ], ["fu_lootbox", 3, {"level" : 6}] ],					
 			"secret" : false	
 		}
 	],
@@ -80,7 +84,7 @@
 		],
 		
 		"extractor" : [ 
-			"create_silicon",		
+			"create_silicon",	
 			"extractor1",
 			"extractor6"
 		],

--- a/interface/scripted/spaceStation/spaceStation.lua
+++ b/interface/scripted/spaceStation/spaceStation.lua
@@ -19,6 +19,7 @@ function init()
 	objectData = nil
 	objectID = nil
 	stationType = ""
+	defaultMaxStack = 0
 	
 	-- Find closest object and use it
 	-- There should only be one object in the stations world anyways
@@ -66,6 +67,10 @@ function init()
 	else
 		widget.setText("text", "ERROR - No station object found")
 	end
+	
+	-- Get default max size for use in shop
+	local defaultItemParams = root.assetJson("/items/defaultParameters.config")
+	defaultMaxStack = defaultItemParams.defaultMaxStack
 end
 
 function firstTimeInit()
@@ -872,7 +877,7 @@ function populateShopList()
 				local listItem = "shopScrollList.itemList."..widget.addListItem("shopScrollList.itemList")
 				local isWeapon = false
 				local basePrice = math.max(config.config.price or 1, 1)
-				local maxStack = config.config.maxStack or 1000
+				local maxStack = config.config.maxStack or defaultMaxStack
 				
 				local price = calculateShopPrice(basePrice, true)
 				


### PR DESCRIPTION
- Fixed bug which crashed quest GUI if a questlines pixel reward was a single value instead of a range
- Fixed a bug where you'd get only [maxStack] of an item if the should be rewarded amount is higher
- Fixed the reward display (same reason as above, same fix)
- Questlines can now apply parameters to items
- Gave loot box rewards from questlines levels

- Space station shop max buy amount is now either items maxStack, or defaultMaxStack since it can be changed via other mods