### PR TITLE
Removed clutter

### DIFF
--- a/scripts/fu_player_init.lua
+++ b/scripts/fu_player_init.lua
@@ -55,21 +55,4 @@ function uninit()
 			player.giveItem({name = "fu_lootbox", parameters = {level = threatLevel}})
 		end
 	end
-	
-	sb.logError("")
-	sb.logError("Uninit found %s untiered lootboxes.", untieredLootboxes)
-	sb.logError("")
-	
-	--[[
-	local goods = {"foodgoods", "medicalgoods", "electronicgoods", "militarygoods"}
-	for _, g in ipairs(goods) do
-		local amount = player.hasCountOfItem({name = g})
-		if amount > 0 then
-			player.consumeItem({name = g, count = amount})
-			player.addCurrency("fu"..g, amount)
-			
-			sb.logInfo("converted %s '%s' into '%s' currency", amount, g, "fu"..g)
-		end
-	end
-	--]]
 end


### PR DESCRIPTION
No more `Uninit found 0 untiered lootboxes.` prints, and removed a copy of the previously commented script for converting trade goods into their currency variants