### PR TITLE
tags

### DIFF
--- a/items/active/weapons/melee/broadsword/precursorblade/precursorbroadsword.activeitem
+++ b/items/active/weapons/melee/broadsword/precursorblade/precursorbroadsword.activeitem
@@ -10,7 +10,7 @@
   "tooltipKind" : "sword2",
   "category" : "broadsword",
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee","broadsword","xithricite", "upgradeableWeapon"],
+  "itemTags" : ["weapon","melee","broadsword","xithricite","precursor","energy", "upgradeableWeapon"],
   "inventoryIcon" : "precursorbroadsword.png",
   "collectablesOnPickup" : { "fu_weaponbroadsword" : "precursorbroadsword" },
   "animation" : "/items/active/weapons/melee/broadsword/combobroadswordglow.animation",

--- a/items/active/weapons/melee/spear/precursorspear/precursorspear.activeitem
+++ b/items/active/weapons/melee/spear/precursorspear/precursorspear.activeitem
@@ -10,7 +10,7 @@
   "tooltipKind" : "swordunique",
   "category" : "spear",
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee","spear","energy", "upgradeableWeapon"],
+  "itemTags" : ["weapon","melee","spear","energy","precursor", "upgradeableWeapon"],
 
   "inventoryIcon" : "precursorspear.png",
 

--- a/objects/minibiome/metallic/pipes1.object
+++ b/objects/minibiome/metallic/pipes1.object
@@ -2,7 +2,7 @@
   "objectName" : "pipes1",
   "colonyTags" : [ "metallic", "precursor" ],
   "rarity" : "Common",
-  "category" : "pot",
+  "category" : "decorative",
   "price" : 400,
   "printable" : false,  
   "description" : "What were these used for? Energy transfer?",

--- a/objects/minibiome/metallic/pipes2.object
+++ b/objects/minibiome/metallic/pipes2.object
@@ -2,7 +2,7 @@
   "objectName" : "pipes2",
   "colonyTags" : [ "metallic", "precursor" ],
   "rarity" : "Common",
-  "category" : "pot",
+  "category" : "decorative",
   "price" : 400,
   "printable" : false,  
   "description" : "What were these used for? Energy transfer?",

--- a/objects/minibiome/metallic/pipes3.object
+++ b/objects/minibiome/metallic/pipes3.object
@@ -2,7 +2,7 @@
   "objectName" : "pipes3",
   "colonyTags" : [ "metallic", "precursor" ],
   "rarity" : "Common",
-  "category" : "pot",
+  "category" : "decorative",
   "price" : 400,
   "printable" : false,  
   "description" : "What were these used for? Energy transfer?",

--- a/objects/minibiome/metallic/pipes4.object
+++ b/objects/minibiome/metallic/pipes4.object
@@ -2,7 +2,7 @@
   "objectName" : "pipes4",
   "colonyTags" : [ "metallic", "precursor" ],
   "rarity" : "Common",
-  "category" : "pot",
+  "category" : "decorative",
   "price" : 400,
   "printable" : false,  
   "description" : "What were these used for? Energy transfer?",


### PR DESCRIPTION
precursor broadsword and spear were missing precursor tag.  precursor broadsword was missing energy tag. Some pipes were categorized as 'pot', and are now decorative