### PR TITLE
Tricorder Check Improvement

### DIFF
--- a/scripts/fu_player_init.lua
+++ b/scripts/fu_player_init.lua
@@ -27,6 +27,13 @@ function init()
 		if player.hasItem(requiredItem) then
 			return true
 		end
+		local essentialSlots = {"beamaxe", "wiretool", "painttool", "inspectiontool"}
+		for _,slot in pairs (essentialSlots) do
+			local essentialItem = player.essentialItem(slot)
+			if essentialItem and essentialItem.name == requiredItem then
+				return true
+			end
+		end
 		return false
 	end)
 	


### PR DESCRIPTION
- The poptop cavern gate can now detect your tricorder if it's in an essential item slot