### PR TITLE
Change "Silicon Knight" quest to ask for 1 silicon

### DIFF
--- a/quests/fu_questlines/tutorial/extractor/create_silicon.questtemplate
+++ b/quests/fu_questlines/tutorial/extractor/create_silicon.questtemplate
@@ -2,7 +2,7 @@
   "id" : "create_silicon",
   "prerequisites" : [ ],
   "title" : "Silicon Knight",
-  "text" : "With a ^orange;Hand Mill^reset; you can start cutting your teeth on all sorts of new creations. Try getting at least 50 ^green;sand^reset; and extracting it to get ^orange;10 silicon^reset;.",
+  "text" : "With a ^orange;Hand Mill^reset; you can start cutting your teeth on all sorts of new creations. Try getting at least 50 ^green;sand^reset; and extracting it to get ^orange;1 silicon^reset;.",
   "completionText" : "Encouraging results! Try the same thing with other materials such as wood, dirt, stone...heck, almost anything really. You'll find all sorts of things if you just give it a try!",
   "moneyRange" : [120, 220],
   "rewards" : [ ],

--- a/quests/fu_questlines/tutorial/extractor/create_silicon.questtemplate
+++ b/quests/fu_questlines/tutorial/extractor/create_silicon.questtemplate
@@ -29,7 +29,7 @@
       {
         "type" : "gatherItem",
         "itemName" : "ff_silicon",
-        "count" : 10,
+        "count" : 1,
         "consume" : false
       }
     ]


### PR DESCRIPTION
Since Sand was nerfed to provide 1 silicon per 50 sand, this too should be changed.