### PR TITLE
fix typos and clarify org soup interaction

### DIFF
--- a/objects/ship/humanshipparts/SIV_shipHumanWingBend/SIV_shipHumanWingBend.object
+++ b/objects/ship/humanshipparts/SIV_shipHumanWingBend/SIV_shipHumanWingBend.object
@@ -1,8 +1,8 @@
 {
   "objectName" : "SIV_shipHumanWingBend",
   "rarity" : "Common",
-  "description" : "A Bend Wing for a human spaceship.",
-  "shortdescription" : "Human Bend Wing",
+  "description" : "A curved wing for a human spaceship.",
+  "shortdescription" : "Human Curved Wing",
   "race" : "generic",
   "category" : "decorative",
   "price" : 10,

--- a/objects/ship/humanshipparts/SIV_shipHumanWingStrait/SIV_shipHumanWingStrait.object
+++ b/objects/ship/humanshipparts/SIV_shipHumanWingStrait/SIV_shipHumanWingStrait.object
@@ -1,8 +1,8 @@
 {
   "objectName" : "SIV_shipHumanWingStrait",
   "rarity" : "Common",
-  "description" : "A Strait Wing for a human spaceship.",
-  "shortdescription" : "Human Strait Wing",
+  "description" : "A straight wing for a human spaceship.",
+  "shortdescription" : "Human Straight Wing",
   "race" : "generic",
   "category" : "decorative",
   "price" : 10,

--- a/stats/effects/fu_tileeffects/specialty_effects/organicsoupeffect/organicsoupeffect.statuseffect
+++ b/stats/effects/fu_tileeffects/specialty_effects/organicsoupeffect/organicsoupeffect.statuseffect
@@ -9,6 +9,6 @@
     "organicsoupeffect.lua"
   ],
   
-  "label" : "Organic Soup - Restores food",
+  "label" : "Organic Soup - Restores hunger",
   "icon" : "/interface/statuses/hungerplus.png"
 }


### PR DESCRIPTION
"Strait" is a typo.
"Curved" sounds more natural than "Bend" in the middle of a sentence.
The org soup interaction is more descriptive using "hunger" instead of "food". "Restoring food" can be misunderstood as "this soup is undoing food spoilage", which it does not (according to my understanding). It only replenishes the player's hunger meter.