### PR TITLE
shiny

### DIFF
--- a/stats/effects/fu_armoreffects/set_bonuses/bearsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/bearsetbonuseffect.lua
@@ -27,9 +27,9 @@ function update(dt)
 	end
 end
 
-function checkArmor()
+--[[function checkArmor()--commented out because if it gets called, it will error. level needs to be set in the update block, before calling this function
 	effect.setStatModifierGroup( effectHandlerList.armorBonusHandle,setBonusMultiply(armorBonus,level))
-end
+end]]
 
 function checkWeapons()
 	local weaponSword=weaponCheck({"axe", "hammer", "broadsword", "spear" })

--- a/stats/effects/fu_armoreffects/set_bonuses/bearsetbonuseffect2.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/bearsetbonuseffect2.lua
@@ -27,9 +27,9 @@ function update(dt)
 	end
 end
 
-function checkArmor()
+--[[function checkArmor()--commented out because if it gets called, it will error. level needs to be set in the update block, before calling this function
 	effect.setStatModifierGroup( effectHandlerList.armorBonusHandle,setBonusMultiply(armorBonus,level))
-end
+end]]
 
 function checkWeapons()
 local weaponSword=weaponCheck({ "axe", "hammer", "broadsword", "spear" })

--- a/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.lua
@@ -53,7 +53,8 @@ function update(dt)
 end
 
 function checkArmor()
-	effect.setStatModifierGroup( effectHandlerList.armorBonusHandle,setBonusMultiply(armorBonus,level))
+	--effect.setStatModifierGroup( effectHandlerList.armorBonusHandle,setBonusMultiply(armorBonus,level))--currently just a waste of cpu time. they're blocking stats in this set.
+	effect.setStatModifierGroup( effectHandlerList.armorBonusHandle,armorBonus)
 end
 
 function getLevel()

--- a/stats/effects/fu_armoreffects/setbonuses_common.lua
+++ b/stats/effects/fu_armoreffects/setbonuses_common.lua
@@ -85,6 +85,7 @@ function setBonusMultiply(effectBase,mult)
 		local v=copy(vOld)
 		v["amount"]=(v["amount"] and (v["amount"]*mult)) or nil
 		v["baseMultiplier"]=(v["baseMultiplier"] and (1.0+(v["baseMultiplier"]-1.0)*mult)) or nil
+		v["effectiveMultiplier"]=(v["effectiveMultiplier"] and (1.0+(v["effectiveMultiplier"]-1.0)*mult)) or nil
 		table.insert(temp,v)
 	end
 	return temp


### PR DESCRIPTION
commented out unused checkArmor in bear sets. using it woulda caused an error due to lack of level variable.

elder set bonus no longer uses set bonus multiplier function, as there is was intention of making it relevant.

setbonuses_common now correctly handles effectiveMultiplier, instead of ignoring it. Result...enforcer OP with increased 40% total output, instead of 20%. suggest nerf. same follows for most sets using effectiveMultiplier now. They need retuning to more manageable numbers.