### PR TITLE
Exclusion List Edits

### DIFF
--- a/objects/power/manufacturing/mfgstation.lua
+++ b/objects/power/manufacturing/mfgstation.lua
@@ -36,13 +36,8 @@ local exclusionList = {
   pyreitebar=true,
   isogenbar=true,
   xithricitecrystal=true,
-  carbonplate=true,
   fuamberchunk=true,
-  advancealloy=true,
-  aetheriumalloy=true,
-  densealloy=true,
   nocxiumbar=true,
-  tritaniumbar=true,
 }
 
 


### PR DESCRIPTION
Removal of alloys from the exclusion list as they can't be processed in the Blast Furnace or Arc Smelter so wouldn't be redundant and would be able to be processed here