### PR TITLE
Sets CSAILoldInit as local to avoid stack overflow

### DIFF
--- a/objects/scripts/customtechstation.lua
+++ b/objects/scripts/customtechstation.lua
@@ -1,4 +1,4 @@
-CSAILoldInit = init
+local CSAILoldInit = init
 
 function init()
 	if CSAILoldInit then CSAILoldInit() end


### PR DESCRIPTION
Prevents stack overflow on the S.A.I.L. interface when using vanilla ships.
I never thought this would be called more than once.