### PR TITLE
Adds patches for all the techstations on the Steam workshop as of 2018/06/07

### DIFF
--- a/object/ship/avianapextechstation/avianapextechstation.object.patch
+++ b/object/ship/avianapextechstation/avianapextechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/object/ship/avianaviantechstation/avianaviantechstation.object.patch
+++ b/object/ship/avianaviantechstation/avianaviantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/object/ship/avianflorantechstation/avianflorantechstation.object.patch
+++ b/object/ship/avianflorantechstation/avianflorantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/object/ship/avianglitchtechstation/avianglitchtechstation.object.patch
+++ b/object/ship/avianglitchtechstation/avianglitchtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/object/ship/avianhumantechstation/avianhumantechstation.object.patch
+++ b/object/ship/avianhumantechstation/avianhumantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/object/ship/avianhylotltechstation/avianhylotltechstation.object.patch
+++ b/object/ship/avianhylotltechstation/avianhylotltechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/object/ship/aviannovakidtechstation/aviannovakidtechstation.object.patch
+++ b/object/ship/aviannovakidtechstation/aviannovakidtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/aryan/aryantechstation/aryantechstation.object.patch
+++ b/objects/aryan/aryantechstation/aryantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/aryan/aryantechstationtier0/aryantechstationtier0.object.patch
+++ b/objects/aryan/aryantechstationtier0/aryantechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/clorevelde/ship/cloreveldetechstation/cloreveldetechstation.object.patch
+++ b/objects/clorevelde/ship/cloreveldetechstation/cloreveldetechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/clorevelde/ship/cloreveldetechstationTier0/cloreveldetechstationTier0.object.patch
+++ b/objects/clorevelde/ship/cloreveldetechstationTier0/cloreveldetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/crafting/printpackship/bloodtechstation.object.patch
+++ b/objects/crafting/printpackship/bloodtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/crafting/printpackship/eviltechstation.object.patch
+++ b/objects/crafting/printpackship/eviltechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/crafting/printpackship/goldentechstation.object.patch
+++ b/objects/crafting/printpackship/goldentechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/crafting/printpackship/greedtechstation.object.patch
+++ b/objects/crafting/printpackship/greedtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/crafting/printpackship/nighttechstation.object.patch
+++ b/objects/crafting/printpackship/nighttechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/crafting/printpackship/oceantechstation.object.patch
+++ b/objects/crafting/printpackship/oceantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/felin/felintechstation/felintechstationtier0.object.patch
+++ b/objects/felin/felintechstation/felintechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/gyrusentechstationTier0/gyrusentechstationtier0.object.patch
+++ b/objects/gyrusentechstationTier0/gyrusentechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/neko/nekotechstation/nekotechstationtier0.object.patch
+++ b/objects/neko/nekotechstation/nekotechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/neko/nekotechstationTier0/nekotechstationtier0.object.patch
+++ b/objects/neko/nekotechstationTier0/nekotechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/sergal/noncollectable/sergaltechstationtier0/sergaltechstationtier0.object.patch
+++ b/objects/sergal/noncollectable/sergaltechstationtier0/sergaltechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Androidtechstation/Androidtechstation.object.patch
+++ b/objects/ship/Androidtechstation/Androidtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/AndroidtechstationTier0/AndroidtechstationTier0.object.patch
+++ b/objects/ship/AndroidtechstationTier0/AndroidtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Attarrantechstation/Attarrantechstation.object.patch
+++ b/objects/ship/Attarrantechstation/Attarrantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/AttarrantechstationTier0/AttarrantechstationTier0.object.patch
+++ b/objects/ship/AttarrantechstationTier0/AttarrantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Boss Monstertechstation/Boss Monstertechstation.object.patch
+++ b/objects/ship/Boss Monstertechstation/Boss Monstertechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Boss MonstertechstationTier0/Boss MonstertechstationTier0.object.patch
+++ b/objects/ship/Boss MonstertechstationTier0/Boss MonstertechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Breadnauttechstation/Breadnauttechstation.object.patch
+++ b/objects/ship/Breadnauttechstation/Breadnauttechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/BreadnauttechstationTier0/BreadnauttechstationTier0.object.patch
+++ b/objects/ship/BreadnauttechstationTier0/BreadnauttechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Canidstechstation/Canidstechstation.object.patch
+++ b/objects/ship/Canidstechstation/Canidstechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/CanidstechstationTier0/CanidstechstationTier0.object.patch
+++ b/objects/ship/CanidstechstationTier0/CanidstechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Cuttlefishtechstation/Cuttlefishtechstation.object.patch
+++ b/objects/ship/Cuttlefishtechstation/Cuttlefishtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/CuttlefishtechstationTier0/CuttlefishtechstationTier0.object.patch
+++ b/objects/ship/CuttlefishtechstationTier0/CuttlefishtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Dingalingtechstation/Dingalingtechstation.object.patch
+++ b/objects/ship/Dingalingtechstation/Dingalingtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/DingalingtechstationTier0/DingalingtechstationTier0.object.patch
+++ b/objects/ship/DingalingtechstationTier0/DingalingtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Dunsparcetechstation/Dunsparcetechstation.object.patch
+++ b/objects/ship/Dunsparcetechstation/Dunsparcetechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/DunsparcetechstationTier0/DunsparcetechstationTier0.object.patch
+++ b/objects/ship/DunsparcetechstationTier0/DunsparcetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Ectonuritetechstation/Ectonuritetechstation.object.patch
+++ b/objects/ship/Ectonuritetechstation/Ectonuritetechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/EctonuritetechstationTier0/EctonuritetechstationTier0.object.patch
+++ b/objects/ship/EctonuritetechstationTier0/EctonuritetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Froggtechstation/Froggtechstation.object.patch
+++ b/objects/ship/Froggtechstation/Froggtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/FroggtechstationTier0/FroggtechstationTier0.object.patch
+++ b/objects/ship/FroggtechstationTier0/FroggtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/GoatPersontechstation/GoatPersontechstation.object.patch
+++ b/objects/ship/GoatPersontechstation/GoatPersontechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/GoatPersontechstationTier0/GoatPersontechstationTier0.object.patch
+++ b/objects/ship/GoatPersontechstationTier0/GoatPersontechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Greytechstation/Greytechstation.object.patch
+++ b/objects/ship/Greytechstation/Greytechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/GreytechstationTier0/GreytechstationTier0.object.patch
+++ b/objects/ship/GreytechstationTier0/GreytechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Hocotatiantechstation/Hocotatiantechstation.object.patch
+++ b/objects/ship/Hocotatiantechstation/Hocotatiantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/HocotatiantechstationTier0/HocotatiantechstationTier0.object.patch
+++ b/objects/ship/HocotatiantechstationTier0/HocotatiantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Jacrispitechstation/Jacrispitechstation.object.patch
+++ b/objects/ship/Jacrispitechstation/Jacrispitechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/JacrispitechstationTier0/JacrispitechstationTier0.object.patch
+++ b/objects/ship/JacrispitechstationTier0/JacrispitechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Krandoniantechstation/Krandoniantechstation.object.patch
+++ b/objects/ship/Krandoniantechstation/Krandoniantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/KrandoniantechstationTier0/KrandoniantechstationTier0.object.patch
+++ b/objects/ship/KrandoniantechstationTier0/KrandoniantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Mimigatechstation/Mimigatechstation.object.patch
+++ b/objects/ship/Mimigatechstation/Mimigatechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/MimigatechstationTier0/MimigatechstationTier0.object.patch
+++ b/objects/ship/MimigatechstationTier0/MimigatechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/NamekiantechstationTier0/NamekiantechstationTier0.object.patch
+++ b/objects/ship/NamekiantechstationTier0/NamekiantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/PryotechstationTier0/PryotechstationTier0.object.patch
+++ b/objects/ship/PryotechstationTier0/PryotechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/SaiyantechstationTier0/SaiyantechstationTier0.object.patch
+++ b/objects/ship/SaiyantechstationTier0/SaiyantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ToastbottechstationTier0/ToastbottechstationTier0.object.patch
+++ b/objects/ship/ToastbottechstationTier0/ToastbottechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Virorbtechstation/Virorbtechstation.object.patch
+++ b/objects/ship/Virorbtechstation/Virorbtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/VirorbtechstationTier0/VirorbtechstationTier0.object.patch
+++ b/objects/ship/VirorbtechstationTier0/VirorbtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/XenomorphtechstationTier0/XenomorphtechstationTier0.object.patch
+++ b/objects/ship/XenomorphtechstationTier0/XenomorphtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/Zoroarktechstation/Zoroarktechstation.object.patch
+++ b/objects/ship/Zoroarktechstation/Zoroarktechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ZoroarktechstationTier0/ZoroarktechstationTier0.object.patch
+++ b/objects/ship/ZoroarktechstationTier0/ZoroarktechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/aegisalt/aegisalttechstation/HPB_aegisalttechstation.object.patch
+++ b/objects/ship/aegisalt/aegisalttechstation/HPB_aegisalttechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/agarantechstation/agarantechstation.object.patch
+++ b/objects/ship/agarantechstation/agarantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/agarantechstationTier0/agarantechstationTier0.object.patch
+++ b/objects/ship/agarantechstationTier0/agarantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/alaratechstationTier0/alaratechstationTier0.object.patch
+++ b/objects/ship/alaratechstationTier0/alaratechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/alpacatechstation/alpacatechstation.object.patch
+++ b/objects/ship/alpacatechstation/alpacatechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/alpacatechstationTier0/alpacatechstationTier0.object.patch
+++ b/objects/ship/alpacatechstationTier0/alpacatechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/animatronicstechstation/animatronicstechstation.object.patch
+++ b/objects/ship/animatronicstechstation/animatronicstechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/animatronicstechstationTier0/animatronicstechstationTier0.object.patch
+++ b/objects/ship/animatronicstechstationTier0/animatronicstechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/arachnetechstationTier0/arachnetechstationTier0.object.patch
+++ b/objects/ship/arachnetechstationTier0/arachnetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/araneantechstation/araneantechstation.object.patch
+++ b/objects/ship/araneantechstation/araneantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/araneantechstationTier0/araneantechstationTier0.object.patch
+++ b/objects/ship/araneantechstationTier0/araneantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/argoniantechstation/argoniantechstation.object.patch
+++ b/objects/ship/argoniantechstation/argoniantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/argoniantechstationtier0/argoniantechstationTier0.object.patch
+++ b/objects/ship/argoniantechstationtier0/argoniantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/avalitechstationtier0/avalitechstationtier0.object.patch
+++ b/objects/ship/avalitechstationtier0/avalitechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/aviantechstationtier0/aviantechstationtier0.object.patch
+++ b/objects/ship/aviantechstationtier0/aviantechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/avoniantechstation/avoniantechstation.object.patch
+++ b/objects/ship/avoniantechstation/avoniantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/avoniantechstationTier0/avoniantechstationTier0.object.patch
+++ b/objects/ship/avoniantechstationTier0/avoniantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/birdfolktechstation/birdfolktechstation.object.patch
+++ b/objects/ship/birdfolktechstation/birdfolktechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/birdfolktechstationTier0/birdfolktechstationTier0.object.patch
+++ b/objects/ship/birdfolktechstationTier0/birdfolktechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/blazikentechstation/blazikentechstation.object.patch
+++ b/objects/ship/blazikentechstation/blazikentechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/blazikentechstationTier0/blazikentechstationTier0.object.patch
+++ b/objects/ship/blazikentechstationTier0/blazikentechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/buneratechstation/buneratechstation.object.patch
+++ b/objects/ship/buneratechstation/buneratechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/buneratechstationTier0/buneratechstationTier0.object.patch
+++ b/objects/ship/buneratechstationTier0/buneratechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/bunnykintechstation/bunnykintechstation.object.patch
+++ b/objects/ship/bunnykintechstation/bunnykintechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/bunnykintechstationTier0/bunnykintechstationTier0.object.patch
+++ b/objects/ship/bunnykintechstationTier0/bunnykintechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/carbonfiber/carbonfibertechstation/HPB_carbonfibertechstation.object.patch
+++ b/objects/ship/carbonfiber/carbonfibertechstation/HPB_carbonfibertechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cardboard/cardboardtechstation/HPB_cardboardtechstation.object.patch
+++ b/objects/ship/cardboard/cardboardtechstation/HPB_cardboardtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cattechstation/cattechstation.object.patch
+++ b/objects/ship/cattechstation/cattechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cattechstationTier0/cattechstationTier0.object.patch
+++ b/objects/ship/cattechstationTier0/cattechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/catustechstation/catustechstation.object.patch
+++ b/objects/ship/catustechstation/catustechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/catustechstationTier0/catustechstationTier0.object.patch
+++ b/objects/ship/catustechstationTier0/catustechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cerulium/ceruliumtechstation/HPB_ceruliumtechstation.object.patch
+++ b/objects/ship/cerulium/ceruliumtechstation/HPB_ceruliumtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cherubimtechstation/cherubimtechstation.object.patch
+++ b/objects/ship/cherubimtechstation/cherubimtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cherubimtechstationTier0/cherubimtechstationTier0.object.patch
+++ b/objects/ship/cherubimtechstationTier0/cherubimtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/clownkintechstation/clownkintechstation.object.patch
+++ b/objects/ship/clownkintechstation/clownkintechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/clownkintechstationTier0/clownkintechstationTier0.object.patch
+++ b/objects/ship/clownkintechstationTier0/clownkintechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/copper/coppertechstation/HPB_coppertechstation.object.patch
+++ b/objects/ship/copper/coppertechstation/HPB_coppertechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/core/coretechstation/HPB_coretechstation.object.patch
+++ b/objects/ship/core/coretechstation/HPB_coretechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cubustechstation/cubustechstation.object.patch
+++ b/objects/ship/cubustechstation/cubustechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cubustechstationTier0/cubustechstationTier0.object.patch
+++ b/objects/ship/cubustechstationTier0/cubustechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/customglitchtechstation/customglitchltechstation.object.patch
+++ b/objects/ship/customglitchtechstation/customglitchltechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/customglitchtechstationTier0/customglitchtechstationTier0.object.patch
+++ b/objects/ship/customglitchtechstationTier0/customglitchtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/customhumantechstation/customhumanltechstation.object.patch
+++ b/objects/ship/customhumantechstation/customhumanltechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/customhumantechstationTier0/customhumantechstationTier0.object.patch
+++ b/objects/ship/customhumantechstationTier0/customhumantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/customhylotltechstation/customhylotltechstation.object.patch
+++ b/objects/ship/customhylotltechstation/customhylotltechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/customhylotltechstationTier0/customhylotltechstationTier0.object.patch
+++ b/objects/ship/customhylotltechstationTier0/customhylotltechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cutstone/cutstonetechstation/HPB_cutstonetechstation.object.patch
+++ b/objects/ship/cutstone/cutstonetechstation/HPB_cutstonetechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cybermantechstation/cybermantechstation.object.patch
+++ b/objects/ship/cybermantechstation/cybermantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/cylontechstation/cylontechstation.object.patch
+++ b/objects/ship/cylontechstation/cylontechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/darktechstation/darktechstation.object.patch
+++ b/objects/ship/darktechstation/darktechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/darktechstationTier0/darktechstationTier0.object.patch
+++ b/objects/ship/darktechstationTier0/darktechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/decoratechstation/decoratechstation.object.patch
+++ b/objects/ship/decoratechstation/decoratechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/decoratechstationTier0/decoratechstationTier0.object.patch
+++ b/objects/ship/decoratechstationTier0/decoratechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/dominiontechstation/dominiontechstation.object.patch
+++ b/objects/ship/dominiontechstation/dominiontechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/dominiontechstationTier0/dominiontechstationTier0.object.patch
+++ b/objects/ship/dominiontechstationTier0/dominiontechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/droidtechstation/droidtechstation.object.patch
+++ b/objects/ship/droidtechstation/droidtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/droidtechstationTier0/droidtechstationTier0.object.patch
+++ b/objects/ship/droidtechstationTier0/droidtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/durasteel/durasteeltechstation/HPB_durasteeltechstation.object.patch
+++ b/objects/ship/durasteel/durasteeltechstation/HPB_durasteeltechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/eclipsedwanderrertechstation/eclipsedwanderrertechstation.object.patch
+++ b/objects/ship/eclipsedwanderrertechstation/eclipsedwanderrertechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/eclipsedwanderrertechstationTier0/eclipsedwanderrertechstationTier0.object.patch
+++ b/objects/ship/eclipsedwanderrertechstationTier0/eclipsedwanderrertechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/eeveetwotechstation/eeveetwotechstation.object.patch
+++ b/objects/ship/eeveetwotechstation/eeveetwotechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/eeveetwotechstationTier0/eeveetwotechstationTier0.object.patch
+++ b/objects/ship/eeveetwotechstationTier0/eeveetwotechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/elunitetechstation/elunitetechstation.object.patch
+++ b/objects/ship/elunitetechstation/elunitetechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/elystechstation/elystechstation.object.patch
+++ b/objects/ship/elystechstation/elystechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/elystechstationTier0/elystechstationTier0.object.patch
+++ b/objects/ship/elystechstationTier0/elystechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/espeontechstation/espeontechstation.object.patch
+++ b/objects/ship/espeontechstation/espeontechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/espeontechstationTier0/espeontechstationTier0.object.patch
+++ b/objects/ship/espeontechstationTier0/espeontechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/everistechstation/everistechstation.object.patch
+++ b/objects/ship/everistechstation/everistechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/everistechstationTier0/everistechstationTier0.object.patch
+++ b/objects/ship/everistechstationTier0/everistechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/exbitechstation/exbitechstation.object.patch
+++ b/objects/ship/exbitechstation/exbitechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/exbitechstationTier0/exbitechstationTier0.object.patch
+++ b/objects/ship/exbitechstationTier0/exbitechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/feneroxtechstation/feneroxtechstation.object.patch
+++ b/objects/ship/feneroxtechstation/feneroxtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/feneroxtechstationtier0/feneroxtechstationtier0.object.patch
+++ b/objects/ship/feneroxtechstationtier0/feneroxtechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/fennixracetechstation/fennixracetechstation.object.patch
+++ b/objects/ship/fennixracetechstation/fennixracetechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/fennixracetechstationTier0/fennixracetechstationTier0.object.patch
+++ b/objects/ship/fennixracetechstationTier0/fennixracetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ferozium/feroziumtechstation/HPB_feroziumtechstation.object.patch
+++ b/objects/ship/ferozium/feroziumtechstation/HPB_feroziumtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/fish/fishtechstation/HPB_fishtechstation.object.patch
+++ b/objects/ship/fish/fishtechstation/HPB_fishtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/fishpeopletechstation/fishpeopletechstation.object.patch
+++ b/objects/ship/fishpeopletechstation/fishpeopletechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/fishpeopletechstationTier0/fishpeopletechstationTier0.object.patch
+++ b/objects/ship/fishpeopletechstationTier0/fishpeopletechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/floran/darkflorantechstation/HPB_darkflorantechstation.object.patch
+++ b/objects/ship/floran/darkflorantechstation/HPB_darkflorantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/florantechstation/florantechstation.object.patch
+++ b/objects/ship/florantechstation/florantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/florantechstationtier0/florantechstationtier0.object.patch
+++ b/objects/ship/florantechstationtier0/florantechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/forcefield/forcefieldtechstation/HPB_forcefieldtechstation.object.patch
+++ b/objects/ship/forcefield/forcefieldtechstation/HPB_forcefieldtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/frogtechstation/frogtechstation.object.patch
+++ b/objects/ship/frogtechstation/frogtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/frogtechstationTier0/frogtechstationTier0.object.patch
+++ b/objects/ship/frogtechstationTier0/frogtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/galecostechstation/galecostechstation.object.patch
+++ b/objects/ship/galecostechstation/galecostechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/galecostechstationTier0/galecostechstationTier0.object.patch
+++ b/objects/ship/galecostechstationTier0/galecostechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/gandorintechstation/gandorintechstation.object.patch
+++ b/objects/ship/gandorintechstation/gandorintechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/gandorintechstationTier0/gandorintechstationTier0.object.patch
+++ b/objects/ship/gandorintechstationTier0/gandorintechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/glass/glasstechstation/HPB_glasstechstation.object.patch
+++ b/objects/ship/glass/glasstechstation/HPB_glasstechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/glitchtechstation/glitchtechstation.object.patch
+++ b/objects/ship/glitchtechstation/glitchtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/glitchtechstationtier0/glitchtechstationtier0.object.patch
+++ b/objects/ship/glitchtechstationtier0/glitchtechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/gold/goldtechstation/HPB_goldtechstation.object.patch
+++ b/objects/ship/gold/goldtechstation/HPB_goldtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/greckantechstation/greckantechstation.object.patch
+++ b/objects/ship/greckantechstation/greckantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/greckantechstationtier0/greckantechstationtier0.object.patch
+++ b/objects/ship/greckantechstationtier0/greckantechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/hatheetechstation/hatheetechstation.object.patch
+++ b/objects/ship/hatheetechstation/hatheetechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/hatheetechstationTier0/hatheetechstationTier0.object.patch
+++ b/objects/ship/hatheetechstationTier0/hatheetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/hawgtechstation/hawgtechstation.object.patch
+++ b/objects/ship/hawgtechstation/hawgtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/hawgtechstationTier0/hawgtechstationTier0.object.patch
+++ b/objects/ship/hawgtechstationTier0/hawgtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/hoovertechstation/hoovertechstation.object.patch
+++ b/objects/ship/hoovertechstation/hoovertechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/humantechstation/hotdogtechstation.object.patch
+++ b/objects/ship/humantechstation/hotdogtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/humantechstationTier0/hotdogtechstationTier0.object.patch
+++ b/objects/ship/humantechstationTier0/hotdogtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/humantechstationtier0/humantechstationTier0.object.patch
+++ b/objects/ship/humantechstationtier0/humantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/humantechstationtier0/humantechstationtier0.object.patch
+++ b/objects/ship/humantechstationtier0/humantechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/hybridtechstation/hybridtechstation.object.patch
+++ b/objects/ship/hybridtechstation/hybridtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/hybridtechstationTier0/hybridtechstationTier0.object.patch
+++ b/objects/ship/hybridtechstationTier0/hybridtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/hylotltechstation/kitsunetechstation.object.patch
+++ b/objects/ship/hylotltechstation/kitsunetechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/hylotltechstationtier0/hylotltechstationtier0.object.patch
+++ b/objects/ship/hylotltechstationtier0/hylotltechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ikuultechstation/ikuultechstation.object.patch
+++ b/objects/ship/ikuultechstation/ikuultechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ikuultechstationTier0/ikuultechstationTier0.object.patch
+++ b/objects/ship/ikuultechstationTier0/ikuultechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/impervium/imperviumtechstation/HPB_imperviumtechstation.object.patch
+++ b/objects/ship/impervium/imperviumtechstation/HPB_imperviumtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/inklingtechstation/inklingtechstation.object.patch
+++ b/objects/ship/inklingtechstation/inklingtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/inklingtechstationTier0/inklingtechstationtier0.object.patch
+++ b/objects/ship/inklingtechstationTier0/inklingtechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/insectoidtechstation/insectoidtechstation.object.patch
+++ b/objects/ship/insectoidtechstation/insectoidtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/insectoidtechstationTier0/insectoidtechstationTier0.object.patch
+++ b/objects/ship/insectoidtechstationTier0/insectoidtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/irkentechstation/irkentechstation.object.patch
+++ b/objects/ship/irkentechstation/irkentechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/irkentechstationTier0/irkentechstationTier0.object.patch
+++ b/objects/ship/irkentechstationTier0/irkentechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/iron/irontechstation/HPB_irontechstation.object.patch
+++ b/objects/ship/iron/irontechstation/HPB_irontechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/kazdratechstation/kazdratechstation.object.patch
+++ b/objects/ship/kazdratechstation/kazdratechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/kemonotechstation/kemonotechstation.object.patch
+++ b/objects/ship/kemonotechstation/kemonotechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/kirhostechstation/kirhostechstation.object.patch
+++ b/objects/ship/kirhostechstation/kirhostechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/kirhostechstationtier0/kirhostechstationtier0.object.patch
+++ b/objects/ship/kirhostechstationtier0/kirhostechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/koboldtechstation/koboldtechstation.object.patch
+++ b/objects/ship/koboldtechstation/koboldtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/koboldtechstationTier0/koboldtechstationTier0.object.patch
+++ b/objects/ship/koboldtechstationTier0/koboldtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/kybintechstation/kybintechstation.object.patch
+++ b/objects/ship/kybintechstation/kybintechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/kybintechstationTier0/kybintechstationTier0.object.patch
+++ b/objects/ship/kybintechstationTier0/kybintechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/lagitechstation/lagitechstation.object.patch
+++ b/objects/ship/lagitechstation/lagitechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/lagitechstationTier0/lagitechstationTier0.object.patch
+++ b/objects/ship/lagitechstationTier0/lagitechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/lamiatechstation/lamiatechstation.object.patch
+++ b/objects/ship/lamiatechstation/lamiatechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/lamiatechstationTier0/lamiatechstationTier0.object.patch
+++ b/objects/ship/lamiatechstationTier0/lamiatechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/leontechstation/leontechstation.object.patch
+++ b/objects/ship/leontechstation/leontechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/leontechstationTier0/leontechstationTier0.object.patch
+++ b/objects/ship/leontechstationTier0/leontechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/lombax_pointedtechstation/lombax_pointedtechstation.object.patch
+++ b/objects/ship/lombax_pointedtechstation/lombax_pointedtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/lombax_pointedtechstationTier0/lombax_pointedtechstationTier0.object.patch
+++ b/objects/ship/lombax_pointedtechstationTier0/lombax_pointedtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/lombax_stripedtechstation/lombax_stripedtechstation.object.patch
+++ b/objects/ship/lombax_stripedtechstation/lombax_stripedtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/mantizitechstationtier0/mantizitechstationtier0.object.patch
+++ b/objects/ship/mantizitechstationtier0/mantizitechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/mewtutechstationTier0/mewtutechstationTier0.object.patch
+++ b/objects/ship/mewtutechstationTier0/mewtutechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/minecraftstevetechstation/minecraftstevetechstation.object.patch
+++ b/objects/ship/minecraftstevetechstation/minecraftstevetechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/minecraftstevetechstationTier0/minecraftstevetechstationTier0.object.patch
+++ b/objects/ship/minecraftstevetechstationTier0/minecraftstevetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/mobiantechstation/mobiantechstation.object.patch
+++ b/objects/ship/mobiantechstation/mobiantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/mobiantechstationTier0/mobiantechstationTier0.object.patch
+++ b/objects/ship/mobiantechstationTier0/mobiantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/modernsonictechstation/modernsonictechstation.object.patch
+++ b/objects/ship/modernsonictechstation/modernsonictechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/modernsonictechstationTier0/modernsonictechstationTier0.object.patch
+++ b/objects/ship/modernsonictechstationTier0/modernsonictechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/monstechstation/monstechstation.object.patch
+++ b/objects/ship/monstechstation/monstechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/monstechstationTier0/monstechstationTier0.object.patch
+++ b/objects/ship/monstechstationTier0/monstechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/monster/monstertechstation/HPB_monstertechstation.object.patch
+++ b/objects/ship/monster/monstertechstation/HPB_monstertechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/munarishiptechstationtier0/munarishiptechstationtier0.object.patch
+++ b/objects/ship/munarishiptechstationtier0/munarishiptechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ningentechstation/ningentechstation.object.patch
+++ b/objects/ship/ningentechstation/ningentechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/novakid/novakidbrasstechstation/HPB_novakidbrasstechstation.object.patch
+++ b/objects/ship/novakid/novakidbrasstechstation/HPB_novakidbrasstechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/novakid/novakidcreamtechstation/HPB_novakidcreamtechstation.object.patch
+++ b/objects/ship/novakid/novakidcreamtechstation/HPB_novakidcreamtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/novakid/novakidcyantechstation/HPB_novakidcyantechstation.object.patch
+++ b/objects/ship/novakid/novakidcyantechstation/HPB_novakidcyantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/novakid/novakidredtechstation/HPB_novakidredtechstation.object.patch
+++ b/objects/ship/novakid/novakidredtechstation/HPB_novakidredtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/novakidtechstationtier0/novakidtechstationtier0.object.patch
+++ b/objects/ship/novakidtechstationtier0/novakidtechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/oozetechstationTier0/oozetechstationTier0.object.patch
+++ b/objects/ship/oozetechstationTier0/oozetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/orcanatechstationtier0/orcanatechstationtier0.object.patch
+++ b/objects/ship/orcanatechstationtier0/orcanatechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/pegalacitechstation/techstation.object.patch
+++ b/objects/ship/pegalacitechstation/techstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/penguintechstationTier0/penguintechstationTier0.object.patch
+++ b/objects/ship/penguintechstationTier0/penguintechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/phantasmtechstationtier0/phantasmtechstationtier0.object.patch
+++ b/objects/ship/phantasmtechstationtier0/phantasmtechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/plastic/plastictechstation/HPB_plastictechstation.object.patch
+++ b/objects/ship/plastic/plastictechstation/HPB_plastictechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/platinum/platinumtechstation/HPB_techstation.object.patch
+++ b/objects/ship/platinum/platinumtechstation/HPB_techstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ponytechstation/humantechstation.object.patch
+++ b/objects/ship/ponytechstation/humantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ponytechstationTier0/humantechstationTier0.object.patch
+++ b/objects/ship/ponytechstationTier0/humantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/protectoratetechstationTier0/protectoratetechstationTier0.object.patch
+++ b/objects/ship/protectoratetechstationTier0/protectoratetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/protogentechstation/protogentechstation.object.patch
+++ b/objects/ship/protogentechstation/protogentechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/protogentechstationTier0/protogentechstationTier0.object.patch
+++ b/objects/ship/protogentechstationTier0/protogentechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/rockotechstation/rockotechstation.object.patch
+++ b/objects/ship/rockotechstation/rockotechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/rockotechstationTier0/rockotechstationTier0.object.patch
+++ b/objects/ship/rockotechstationTier0/rockotechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/rubium/rubiumtechstation/HPB_rubiumtechstation.object.patch
+++ b/objects/ship/rubium/rubiumtechstation/HPB_rubiumtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/rusty/rustytechstation/HPB_rustytechstation.object.patch
+++ b/objects/ship/rusty/rustytechstation/HPB_rustytechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/salloktechstationTier0/salloktechstationTier0.object.patch
+++ b/objects/ship/salloktechstationTier0/salloktechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/sanglartechstation/sanglartechstation.object.patch
+++ b/objects/ship/sanglartechstation/sanglartechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/sanglartechstationTier0/sanglartechstationTier0.object.patch
+++ b/objects/ship/sanglartechstationTier0/sanglartechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/saturntechstationTier0/saturntechstationTier0.object.patch
+++ b/objects/ship/saturntechstationTier0/saturntechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/sevtopiantechstation/sevtopiantechstation.object.patch
+++ b/objects/ship/sevtopiantechstation/sevtopiantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/sevtopiantechstationTier0/sevtopiantechstationTier0.object.patch
+++ b/objects/ship/sevtopiantechstationTier0/sevtopiantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/shadetechstationTier0/shadetechstationTier0.object.patch
+++ b/objects/ship/shadetechstationTier0/shadetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/silver/silvertechstation/HPB_silvertechstation.object.patch
+++ b/objects/ship/silver/silvertechstation/HPB_silvertechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/skathtechstationTier0/skathtechstationTier0.object.patch
+++ b/objects/ship/skathtechstationTier0/skathtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/skelekintechstationTier0/skelekintechstationTier0.object.patch
+++ b/objects/ship/skelekintechstationTier0/skelekintechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/sktesttechstationTier0/sktesttechstationTier0.object.patch
+++ b/objects/ship/sktesttechstationTier0/sktesttechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/slimepersontechstationTier0/slimepersontechstationTier0.object.patch
+++ b/objects/ship/slimepersontechstationTier0/slimepersontechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/snowmantechstation/snowmantechstation.object.patch
+++ b/objects/ship/snowmantechstation/snowmantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/snowmantechstationTier0/snowmantechstationTier0.object.patch
+++ b/objects/ship/snowmantechstationTier0/snowmantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/snuggettechstationTier0/snuggettechstationTier0.object.patch
+++ b/objects/ship/snuggettechstationTier0/snuggettechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/spaghetttechstation/spaghetttechstation.object.patch
+++ b/objects/ship/spaghetttechstation/spaghetttechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/spaghetttechstationTier0/spaghetttechstationTier0.object.patch
+++ b/objects/ship/spaghetttechstationTier0/spaghetttechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/spring/springtechstation/HPB_springtechstation.object.patch
+++ b/objects/ship/spring/springtechstation/HPB_springtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/steel/steeltechstation/HPB_steeltechstation.object.patch
+++ b/objects/ship/steel/steeltechstation/HPB_steeltechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/sticktechstationTier0/techstationTier0.object.patch
+++ b/objects/ship/sticktechstationTier0/techstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/sugnirtechstation/sugnirtechstation.object.patch
+++ b/objects/ship/sugnirtechstation/sugnirtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/sugnirtechstationTier0/sugnirtechstationTier0.object.patch
+++ b/objects/ship/sugnirtechstationTier0/sugnirtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/tardisviewscreen/tardisviewscreen.object.patch
+++ b/objects/ship/tardisviewscreen/tardisviewscreen.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/tardisviewscreen/tardisviewscreenmk4.object.patch
+++ b/objects/ship/tardisviewscreen/tardisviewscreenmk4.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/tardisviewscreen/tardisviewscreentier0.object.patch
+++ b/objects/ship/tardisviewscreen/tardisviewscreentier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/techstation/customtechstation.object.patch
+++ b/objects/ship/techstation/customtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/techstation/gallavoirtechstation.object.patch
+++ b/objects/ship/techstation/gallavoirtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/techstation/pygstechstation.object.patch
+++ b/objects/ship/techstation/pygstechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/techstationTier0/pygstechstationTier0.object.patch
+++ b/objects/ship/techstationTier0/pygstechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/techstationTier0/techstationTier0.object.patch
+++ b/objects/ship/techstationTier0/techstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/techstationtier0/gallavoirtechstationtier0.object.patch
+++ b/objects/ship/techstationtier0/gallavoirtechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/titanium/titaniumtechstation/HPB_titaniumtechstation.object.patch
+++ b/objects/ship/titanium/titaniumtechstation/HPB_titaniumtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/toeisonictechstation/toeisonictechstation.object.patch
+++ b/objects/ship/toeisonictechstation/toeisonictechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/toeisonictechstationTier0/toeisonictechstationTier0.object.patch
+++ b/objects/ship/toeisonictechstationTier0/toeisonictechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/trolltechstationTier0/trolltechstationTier0.object.patch
+++ b/objects/ship/trolltechstationTier0/trolltechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/turtletechstation/turtletechstation.object.patch
+++ b/objects/ship/turtletechstation/turtletechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/turtletechstationTier0/turtletechstationTier0.object.patch
+++ b/objects/ship/turtletechstationTier0/turtletechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ufo/ufotechstation/HPB_ufotechstation.object.patch
+++ b/objects/ship/ufo/ufotechstation/HPB_ufotechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ununique_aviantechstation/ununique_aviantechstation.object.patch
+++ b/objects/ship/ununique_aviantechstation/ununique_aviantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ununique_florantechstation/ununique_florantechstation.object.patch
+++ b/objects/ship/ununique_florantechstation/ununique_florantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ununique_glitchtechstation/ununique_glitchtechstation.object.patch
+++ b/objects/ship/ununique_glitchtechstation/ununique_glitchtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ununique_humantechstation/ununique_humantechstation.object.patch
+++ b/objects/ship/ununique_humantechstation/ununique_humantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ununique_hylotltechstation/ununique_hylotltechstation.object.patch
+++ b/objects/ship/ununique_hylotltechstation/ununique_hylotltechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ununique_novakidtechstation/ununique_novakidtechstation.object.patch
+++ b/objects/ship/ununique_novakidtechstation/ununique_novakidtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/ununique_techstation/ununique_techstation.object.patch
+++ b/objects/ship/ununique_techstation/ununique_techstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/uscmtechstationTier0/uscmtechstationTier0.object.patch
+++ b/objects/ship/uscmtechstationTier0/uscmtechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/violium/violiumtechstation/HPB_violiumtechstation.object.patch
+++ b/objects/ship/violium/violiumtechstation/HPB_violiumtechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/vortiantechstation/vortiantechstation.object.patch
+++ b/objects/ship/vortiantechstation/vortiantechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/vortiantechstationTier0/vortiantechstationTier0.object.patch
+++ b/objects/ship/vortiantechstationTier0/vortiantechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/wasphivetechstationTier0/wasphivetechstationTier0.object.patch
+++ b/objects/ship/wasphivetechstationTier0/wasphivetechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/wompzlestechstation/wompzlestechstation.object.patch
+++ b/objects/ship/wompzlestechstation/wompzlestechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/wompzlestechstationTier0/wompzlestechstationTier0.object.patch
+++ b/objects/ship/wompzlestechstationTier0/wompzlestechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/xikaitechstationTier0/xikaitechstationTier0.object.patch
+++ b/objects/ship/xikaitechstationTier0/xikaitechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ship/zombietechstationTier0/zombietechstationTier0.object.patch
+++ b/objects/ship/zombietechstationTier0/zombietechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/ships/crysilontechstationTier0/crysilontechstationTier0.object.patch
+++ b/objects/ships/crysilontechstationTier0/crysilontechstationTier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/su_gem/su_gemtechstation/su_gemtechstationtier0.object.patch
+++ b/objects/su_gem/su_gemtechstation/su_gemtechstationtier0.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/objects/vepr/vepr_uninique_techstation/vepr_uninique_techstation.object.patch
+++ b/objects/vepr/vepr_uninique_techstation/vepr_uninique_techstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]

--- a/ships/yautjatechstation/yautjatechstation.object.patch
+++ b/ships/yautjatechstation/yautjatechstation.object.patch
@@ -1,0 +1,26 @@
+[
+    [
+    	{
+    		"op": "replace",
+    		"path": "/interactAction",
+    		"value": "ScriptPane"
+    	}
+	],
+	[
+		{ "op": "test", "path": "/interactData" },
+		{ "op": "replace", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	[
+		{ "op": "test", "path": "/interactData", "inverse": true },
+		{ "op": "add", "path": "/interactData", "value": "/interface/scripted/fu_sail/customSail.config" }
+	],
+	
+	[
+		{ "op": "test", "path": "/scripts" },
+		{ "op": "add", "path": "/scripts/-", "value": "/objects/scripts/customtechstation.lua" }
+	],
+	[
+		{ "op": "test", "path": "/scripts", "inverse": true },
+		{ "op": "add", "path": "/scripts", "value": [ "/objects/scripts/customtechstation.lua" ] }
+	]
+]


### PR DESCRIPTION
Ran some scripts to parse the whole workshop and make patches for all the missing techstation objects for S.A.I.L.'s interface. Should have every one of them unless I messed something up.

Since all of those patches are automatically created, and that probably most of the mods who add them are not-really-used species (meme mods etc.), this might not be worth adding. Still, I doubt they'd cause any problems, and it won't hurt to have more compatibility.

(Also, because FU has a default priority, Starbound doesn't have any reason to load it after the mods who add those techstations, so patches might not be applied consistently.)