### PR TITLE
small fixes

### DIFF
--- a/items/active/weapons/melee/hammer/uraniumhammer.activeitem
+++ b/items/active/weapons/melee/hammer/uraniumhammer.activeitem
@@ -3,7 +3,7 @@
   "price" : 1600,
   "maxStack" : 1,
   "rarity" : "Rare",
-  "description" : "Forged from lead and uranium. Quite radioactive.",
+  "description" : "Forged from uranium and advanced alloy. Quite radioactive.",
   "shortdescription" : "Uranium Hammer",
   "tooltipKind" : "hammer",
   "category" : "hammer",
@@ -82,6 +82,6 @@
   "critChance" : 3,
   "critBonus" : 5,
   "builder" : "/items/buildscripts/buildunrandweapon.lua",
-  
+
   "stunChance" : 5
 }

--- a/objects/minibiome/elder/cthulhuplush.object
+++ b/objects/minibiome/elder/cthulhuplush.object
@@ -19,9 +19,7 @@
       "animationCycle" : 1.0,
 
       "spaceScan" : 0.1,
-      "anchors" : [ "bottom" ],
-      "collision" : "platform"
-
+      "anchors" : [ "bottom" ]
     }
   ]
 }


### PR DESCRIPTION
- uranium hammer description no longer references lead, which was not in its recipe
- can no longer stand on My Little Cthulhu