### PR TITLE
Marvin and fixes

### DIFF
--- a/items/active/weapons/other/skittlegun/skittlegun.lua
+++ b/items/active/weapons/other/skittlegun/skittlegun.lua
@@ -79,7 +79,7 @@ function update(dt, fireMode, shiftHeld)
 	
 	local worldType=world.type()
 
-	if  not shipwarning and world.getProperty("ship.fuel") then
+	if not shipwarning and world.getProperty("ship.fuel") then
 		if storage.fireTimer <= 0 then
 			effectUtil.say("Greg? Greg greg? GREG?!?")
 			storage.fireTimer = 1
@@ -157,7 +157,7 @@ function fire(ability,fireMode,throttle)
 	local baseProjectileCount=totalProjectileTypes[fireMode]
 	local projectileCount = throttle and 1 or math.max(1,math.floor(math.random(1,baseProjectileCount*baseProjectileCount)/baseProjectileCount))
 	local params = {power = damagePerShot(ability,projectileCount), powerMultiplier = activeItem.ownerPowerMultiplier()}
-	
+
 	if fireMode=="alt" then
 		params.controlForce=140
 		params.ignoreTerrain=false
@@ -166,15 +166,18 @@ function fire(ability,fireMode,throttle)
 	end
 	
 	if special == 1 then
-		--someone just drew the unluckiest card in the deck.
-		local message="Sayter."
-		local color={0,0,0}
-		effectUtil.messageParticle(firePosition(),message,color,0.6,nil,4,nil)
+		--someone just drew the second unluckiest card in the deck.
+		effectUtil.messageParticle(firePosition(),"Sayter.",{0,0,0},0.6,nil,4,nil)
 		if sayterE then
 			sayterE=sayterE/2.0
 		else
 			sayterE=4.0
 		end
+	elseif special == 111 and throttle and not world.getProperty("ship.fuel") then
+		--Marvin. Arguably worse than sayter. It will not end until the person dies.
+		--Since they will have no resistances and will be immune to most healing, death is pretty much guaranteed.
+		--effectUtil.messageParticle(firePosition(),"Marvin.",{0,1,0},0.6,nil,4,nil)
+		effectUtil.effectSelf("marvinSkittles")
 	elseif special == 3 or special == 33 or special == 333 then
 		message="Gregga greg. Donkey...RAINBOW RAINBOW RAINBOW!!!"
 		color={238,130,238}

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_10.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_10.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_10",
-  "effectConfig" : { "healPercent" : 0.07 },
+  "effectConfig" : { "energyrestore" : 0.07 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_15.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_15.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_15",
-  "effectConfig" : { "healPercent" : 0.125 },
+  "effectConfig" : { "energyrestore" : 0.125 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_20.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_20.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_20",
-  "effectConfig" : { "healPercent" : 0.18 },
+  "effectConfig" : { "energyrestore" : 0.18 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_25.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_25.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_25",
-  "effectConfig" : { "healPercent" : 0.23 },
+  "effectConfig" : { "energyrestore" : 0.23 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_40.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_40.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_40",
-  "effectConfig" : { "healPercent" : 0.36 },
+  "effectConfig" : { "energyrestore" : 0.36 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_5.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_5.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_5",
-  "effectConfig" : { "healPercent" : 0.03 },
+  "effectConfig" : { "energyrestore" : 0.03 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_50.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_50.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_50",
-  "effectConfig" : { "healPercent" : 0.46 },
+  "effectConfig" : { "energyrestore" : 0.46 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_75.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_75.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_75",
-  "effectConfig" : { "healPercent" : 0.725 },
+  "effectConfig" : { "energyrestore" : 0.725 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_80.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_80.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_80",
-  "effectConfig" : { "healPercent" : 0.8 },
+  "effectConfig" : { "energyrestore" : 0.8 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_armor_1.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_armor_1.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_armor_1",
-  "effectConfig" : { "healPercent" : 0.005 },
+  "effectConfig" : { "energyrestore" : 0.005 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_armor_2.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_armor_2.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_armor_2",
-  "effectConfig" : { "healPercent" : 0.009 },
+  "effectConfig" : { "energyrestore" : 0.009 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_armor_3.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_armor_3.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_armor_3",
-  "effectConfig" : { "healPercent" : 0.01 },
+  "effectConfig" : { "energyrestore" : 0.01 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_armor_4.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_armor_4.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_armor_4",
-  "effectConfig" : { "healPercent" : 0.05 },
+  "effectConfig" : { "energyrestore" : 0.05 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_negative_100_hidden.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_negative_100_hidden.statuseffect
@@ -1,0 +1,10 @@
+{
+  "name" : "energy_negative_100_hidden",
+  "effectConfig" : { "energyrestore" : -1.0,"displayVFX":false },
+  "defaultDuration" : 0.1,
+
+  "scripts" : [
+    "energyrestorepercentage.lua"
+  ]
+  
+}

--- a/stats/effects/fu_effects/energyrestorepercentage/energyrestorepercentage.lua
+++ b/stats/effects/fu_effects/energyrestorepercentage/energyrestorepercentage.lua
@@ -1,10 +1,10 @@
 function init()
 	-- Heal percent is the configParameter in the json statuseffects file
 	vfx=config.getParameter("displayVFX",true)
-	flat = config.getParameter("flat")--healPercent is per second if this is true
-	self.healingRate = config.getParameter("healPercent", 0)
+	flat = config.getParameter("flat")--value is per second if this is true
+	self.regen = config.getParameter("energyrestore", 0)
 	if not flat then
-		self.healingRate=self.healingRate / effect.duration()
+		self.regen=self.regen / effect.duration()
 	end
 	script.setUpdateDelta(5)
 end
@@ -12,7 +12,8 @@ end
 
 function update(dt)
 	if status.isResource("energy") then
-		status.modifyResourcePercentage("energy", self.healingRate * dt)
+		status.modifyResourcePercentage("energy", self.regen * dt)
+		sb.logInfo("energyrestorepercentage.lua effect value per tick: %s",self.regen*dt)
 		if vfx then
 			effect.setParentDirectives("fade=005500="..0.4)
 		end

--- a/stats/effects/fu_effects/energyrestorepercentage/energyrestorepercentage.lua
+++ b/stats/effects/fu_effects/energyrestorepercentage/energyrestorepercentage.lua
@@ -13,7 +13,7 @@ end
 function update(dt)
 	if status.isResource("energy") then
 		status.modifyResourcePercentage("energy", self.regen * dt)
-		sb.logInfo("energyrestorepercentage.lua effect value per tick: %s",self.regen*dt)
+		--sb.logInfo("energyrestorepercentage.lua effect value per tick: %s",self.regen*dt)
 		if vfx then
 			effect.setParentDirectives("fade=005500="..0.4)
 		end

--- a/stats/effects/fu_genericStatusApplier.lua
+++ b/stats/effects/fu_genericStatusApplier.lua
@@ -4,6 +4,27 @@ local oldInitStatusApplier=init
 local oldUninitStatusApplier=uninit
 local oldUpdateStatusApplier=update
 
+--[[sample table, pretend it is a 7 second duration effect. this is a doom poison with microstuns every second and ends with a 3 second stun.
+{
+	"statusApplierValues":
+	{
+		"init":[
+			["weakpoison",7]
+			["l6doomed",7]
+		],
+		--update rate is in seconds
+		"updateRate":1
+		--update has no effect unless updateRate is set
+		"update":[
+			["paralysis",0.1]
+		],
+		--careful with uninit, it can be iffy, as dying entities can unload before it is fully called.
+		"uninit":[
+			["paralysis",3]
+		]
+	}
+]]
+
 function init()
 	statusApplierValues=config.getParameter("statusApplierValues",{})
 	if oldInitStatusApplier then oldInitStatusApplier() end

--- a/stats/effects/fu_weaponeffects/Skittles/marvinSkittles.lua
+++ b/stats/effects/fu_weaponeffects/Skittles/marvinSkittles.lua
@@ -1,0 +1,90 @@
+require "/scripts/effectUtil.lua"
+
+gregese={words={"@#$@$#@","marvin"},punct={" ","...","?!","?!?","!!!","!","?","!!","!?"}}
+
+
+function init()
+	if world.getProperty("ship.fuel") then
+		effect.expire()
+		return
+	end
+	self.tickDamagePercentage = 0.025
+	self.tickTime = 1.0
+	self.tickTimer = self.tickTime
+	spaz(1)
+end
+
+function update(dt)
+	if world.getProperty("ship.fuel") then
+		effect.expire()
+		return
+	else
+		effect.modifyDuration(dt)
+		if status.resourcePercentage("health") < self.tickDamagePercentage then
+			status.setResourcePercentage("health",0.0)
+		else
+			self.tickTimer = self.tickTimer - dt
+			if self.tickTimer <= 0 then
+				self.tickTimer = self.tickTime
+				spaz(math.floor(math.random(1,81)/9))
+				--status.overConsumeResource("energy",math.huge)
+				status.applySelfDamageRequest({
+					damageType = "IgnoresDef",
+					damage = math.floor(status.resourceMax("health") * self.tickDamagePercentage) + 1,
+					damageSourceKind = "default",
+					sourceEntityId = entity.id()
+				})
+			end
+		end
+	end
+end
+
+function spaz(wordCount)
+	local sentence=""
+	local caps=1
+	
+	for x=0,wordCount do
+		if caps==1 then
+			if math.random(0,1) > 0.67 then
+				caps=2
+			else
+				caps=1
+			end
+		else
+			if math.random(0,1) > 0.67 then
+				caps=2
+			else
+				caps=0
+			end
+		end
+		
+		local rWord=gregese.words[math.floor(math.random(1,#gregese.words))]
+		
+		if caps==2 then
+			rWord=string.upper(rWord)
+		elseif caps==1 then
+			rWord=firstToUpper(rWord)
+		end
+		
+		local punctIndex=math.floor(math.max(math.random(1,#gregese.punct+6)-6,1))
+		caps=(punctIndex>1 and 1) or 0
+
+		local rPunct=gregese.punct[punctIndex] or " "
+		if x<wordCount and rPunct~=" " then
+			rPunct=rPunct.." "
+		elseif x==wordCount and rPunct==" " then
+			while rPunct==" " do
+				punctIndex=math.floor(math.max(math.random(1,#gregese.punct+6)-6,1))
+				rPunct=gregese.punct[punctIndex] or "."
+			end
+		end
+		
+		sentence=sentence..rWord..rPunct
+	end
+	effectUtil.say(sentence)
+end
+
+
+function firstToUpper(str)
+    return (str:gsub("^%l", string.upper))
+end

--- a/stats/effects/fu_weaponeffects/Skittles/marvinSkittles.statuseffect
+++ b/stats/effects/fu_weaponeffects/Skittles/marvinSkittles.statuseffect
@@ -1,0 +1,65 @@
+{
+	"name": "marvinSkittles",
+	"effectConfig": {
+		"stats": [
+			{
+				"stat": "damageMultiplier",
+				"effectiveMultiplier": 0
+			}
+		],
+		"statusApplierValues": {
+			"init": [
+				[
+					"vulnerability",1.1
+				],
+				[
+					"l6doomed",1.1
+				],
+				[
+					"paralysis",1.1
+				],
+				[
+					"activemovementdummy",1.1
+				],
+				[
+					"negativemiasma",1.1
+				],
+				[
+					"energy_negative_100_hidden",1.1
+				]
+			],
+			"update": [
+				[
+					"vulnerability",1.1
+				],
+				[
+					"l6doomed",1.1
+				],
+				[
+					"paralysis",1.1
+				],
+				[
+					"activemovementdummy",1.1
+				],
+				[
+					"negativemiasma",1.1
+				],
+				[
+					"energy_negative_100_hidden",1.1
+				]
+			],
+			"updateRate":1
+		}
+	},
+	"defaultDuration": 4,
+
+	"scripts": [
+		"marvinSkittles.lua",
+		"/stats/effects/fu_genericStatApplier.lua",
+		"/stats/effects/fu_genericStatusApplier.lua"
+	],
+
+	"label": "Marvin",
+	"icon": "/interface/statuses/timefreeze.png"
+
+}

--- a/stats/effects/fu_weaponeffects/Skittles/timefreezeSkittles.lua
+++ b/stats/effects/fu_weaponeffects/Skittles/timefreezeSkittles.lua
@@ -137,5 +137,5 @@ function stun(duration)
 end
 
 function skittleSay(sentence)
-	skittleSay(isGreg and string.reverse(sentence) or sentence)
+	effectUtil.say(isGreg and string.reverse(sentence) or sentence)
 end


### PR DESCRIPTION
energyrestorepercentage.lua using effects have been corrected, they should now properly restore energy, instead of doing nothing. (They were using healPercent as a config value when the lua uses energyrestore)
fixed a recursion issue in a Skittles special. Oops. Well, one in a thousand chance anyway...
Added an example template in /scripts/effects/fu_genericStatusApplier.lua. Doom Poison. Poison Doom?
Skittles learned a new curse word: Marvin. Be wary.