### PR TITLE
Recycler/Universal Uncrafter Patch

### DIFF
--- a/recipes/bees/beerefuge/adaptivequeen.recipe
+++ b/recipes/bees/beerefuge/adaptivequeen.recipe
@@ -6,6 +6,6 @@
     "item" : "irradiumbar",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/aggressivequeen.recipe
+++ b/recipes/bees/beerefuge/aggressivequeen.recipe
@@ -6,6 +6,6 @@
     "item" : "zerchesiumbar",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/arcticqueen.recipe
+++ b/recipes/bees/beerefuge/arcticqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "icecrystal",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/aridqueen.recipe
+++ b/recipes/bees/beerefuge/aridqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "volatilepowder",
     "count" : 2
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/elderqueen.recipe
+++ b/recipes/bees/beerefuge/elderqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "liquidelderfluid",
     "count" : 6
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/exceptionalqueen.recipe
+++ b/recipes/bees/beerefuge/exceptionalqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "feroziumore",
     "count" : 2
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/flowerqueen.recipe
+++ b/recipes/bees/beerefuge/flowerqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "livingroot",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/flowerqueen.recipe
+++ b/recipes/bees/beerefuge/flowerqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "livingroot",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/flowerqueen.recipe
+++ b/recipes/bees/beerefuge/flowerqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "livingroot",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting", "nouncrafting" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/forestqueen.recipe
+++ b/recipes/bees/beerefuge/forestqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "plantfibre",
     "count" : 6
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/godlyqueen.recipe
+++ b/recipes/bees/beerefuge/godlyqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "tritaniumbar",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/hardyqueen.recipe
+++ b/recipes/bees/beerefuge/hardyqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "aegisaltore",
     "count" : 2
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/hunterqueen.recipe
+++ b/recipes/bees/beerefuge/hunterqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "carbonplate",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/junglequeen.recipe
+++ b/recipes/bees/beerefuge/junglequeen.recipe
@@ -6,6 +6,6 @@
     "item" : "blooddiamond",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/magmaqueen.recipe
+++ b/recipes/bees/beerefuge/magmaqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "pyreiteore",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/metalqueen.recipe
+++ b/recipes/bees/beerefuge/metalqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "durasteelore",
     "count" : 5
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/minerqueen.recipe
+++ b/recipes/bees/beerefuge/minerqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "titaniumbar",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/moonqueen.recipe
+++ b/recipes/bees/beerefuge/moonqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "moonstoneore",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/morbidqueen.recipe
+++ b/recipes/bees/beerefuge/morbidqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "quietusbar",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/mythicalqueen.recipe
+++ b/recipes/bees/beerefuge/mythicalqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "graphene",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/nocturnalqueen.recipe
+++ b/recipes/bees/beerefuge/nocturnalqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "corruptionore",
     "count" : 2
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/normalqueen.recipe
+++ b/recipes/bees/beerefuge/normalqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "laboil",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/plutoniumqueen.recipe
+++ b/recipes/bees/beerefuge/plutoniumqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "plutoniumore",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/radioactivequeen.recipe
+++ b/recipes/bees/beerefuge/radioactivequeen.recipe
@@ -6,6 +6,6 @@
     "item" : "uraniumore",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/redqueen.recipe
+++ b/recipes/bees/beerefuge/redqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "bandage",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/solariumqueen.recipe
+++ b/recipes/bees/beerefuge/solariumqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "solariumore",
     "count" : 1
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/sunqueen.recipe
+++ b/recipes/bees/beerefuge/sunqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "scorchedcore",
     "count" : 5
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/bees/beerefuge/volcanicqueen.recipe
+++ b/recipes/bees/beerefuge/volcanicqueen.recipe
@@ -6,6 +6,6 @@
     "item" : "cinnabarore",
     "count" : 6
   },
-  "groups" : [ "beerefuge", "refuge", "all", "queen" ],
+  "groups" : [ "beerefuge", "refuge", "all", "queen", "nouncrafting" ],
   "duration" : 0
 }

--- a/recipes/crewcontracts/crewcontract_hobo.recipe
+++ b/recipes/crewcontracts/crewcontract_hobo.recipe
@@ -9,6 +9,6 @@
     "count" : 1 
   },
   
-  "groups" : [ "crewcontract","bars", "all" ],
+  "groups" : [ "crewcontract","bars", "all", "nouncrafting" ],
   "duration" : 0.2
 }

--- a/recipes/crewcontracts/crewcontract_plur.recipe
+++ b/recipes/crewcontracts/crewcontract_plur.recipe
@@ -8,6 +8,6 @@
     "count" : 1 
   },
   
-  "groups" : [ "crewcontract","bars", "all" ],
+  "groups" : [ "crewcontract","bars", "all", "nouncrafting" ],
   "duration" : 0.2
 }

--- a/recipes/radienshop/artifact/honedlunari.recipe
+++ b/recipes/radienshop/artifact/honedlunari.recipe
@@ -6,5 +6,5 @@
     "item" : "solaricrystal",
     "count" : 40
   },
-  "groups" : [ "radienshop", "artifacts" ]
+  "groups" : [ "radienshop", "artifacts", "nouncrafting" ]
 }

--- a/recipes/radienshop/fu_carbon.recipe
+++ b/recipes/radienshop/fu_carbon.recipe
@@ -6,5 +6,5 @@
     "item" : "fu_carbon",
     "count" : 8
   },
-  "groups" : [ "radienshop", "all", "items" ]
+  "groups" : [ "radienshop", "all", "items", "nouncrafting" ]
 }

--- a/recipes/radienshop/lunari.recipe
+++ b/recipes/radienshop/lunari.recipe
@@ -6,5 +6,5 @@
     "item" : "solarishard",
     "count" : 5
   },
-  "groups" : [ "radienshop", "all", "items" ]
+  "groups" : [ "radienshop", "all", "items", "nouncrafting" ]
 }

--- a/recipes/radienshop/neptunium.recipe
+++ b/recipes/radienshop/neptunium.recipe
@@ -6,5 +6,5 @@
     "item" : "neptuniumore",
     "count" : 7
   },
-  "groups" : [ "radienshop", "all", "items" ]
+  "groups" : [ "radienshop", "all", "items", "nouncrafting" ]
 }

--- a/recipes/radienshop/plutonium.recipe
+++ b/recipes/radienshop/plutonium.recipe
@@ -6,5 +6,5 @@
     "item" : "plutoniumore",
     "count" : 6
   },
-  "groups" : [ "radienshop", "all", "items" ]
+  "groups" : [ "radienshop", "all", "items", "nouncrafting" ]
 }

--- a/recipes/radienshop/thorium.recipe
+++ b/recipes/radienshop/thorium.recipe
@@ -6,5 +6,5 @@
     "item" : "thoriumore",
     "count" : 7
   },
-  "groups" : [ "radienshop", "all", "items" ]
+  "groups" : [ "radienshop", "all", "items", "nouncrafting" ]
 }

--- a/recipes/radienshop/titanium.recipe
+++ b/recipes/radienshop/titanium.recipe
@@ -6,5 +6,5 @@
     "item" : "titaniumore",
     "count" : 10
   },
-  "groups" : [ "radienshop", "all", "items" ]
+  "groups" : [ "radienshop", "all", "items", "nouncrafting" ]
 }

--- a/recipes/radienshop/uranium.recipe
+++ b/recipes/radienshop/uranium.recipe
@@ -6,5 +6,5 @@
     "item" : "uraniumore",
     "count" : 6
   },
-  "groups" : [ "radienshop", "all", "items" ]
+  "groups" : [ "radienshop", "all", "items", "nouncrafting" ]
 }

--- a/recipes/radienshop/zerchesium.recipe
+++ b/recipes/radienshop/zerchesium.recipe
@@ -6,5 +6,5 @@
     "item" : "zerchesiumore",
     "count" : 7
   },
-  "groups" : [ "radienshop", "all", "items" ]
+  "groups" : [ "radienshop", "all", "items", "nouncrafting" ]
 }

--- a/recipes/radienshopdrug/devilsbargain.recipe
+++ b/recipes/radienshopdrug/devilsbargain.recipe
@@ -6,5 +6,5 @@
     "item" : "devilsbargain",
     "count" : 1
   },
-  "groups" : [ "radienshopdrug", "all", "genes" ]
+  "groups" : [ "radienshopdrug", "all", "genes", "nouncrafting" ]
 }

--- a/recipes/radienshopdrug/myphisinjector.recipe
+++ b/recipes/radienshopdrug/myphisinjector.recipe
@@ -6,5 +6,5 @@
     "item" : "myphisinjector",
     "count" : 1
   },
-  "groups" : [ "radienshopdrug", "all", "genes" ]
+  "groups" : [ "radienshopdrug", "all", "genes", "nouncrafting" ]
 }

--- a/recipes/radienshopdrug/powderednarcotics.recipe
+++ b/recipes/radienshopdrug/powderednarcotics.recipe
@@ -6,5 +6,5 @@
     "item" : "powderednarcotics",
     "count" : 1
   },
-  "groups" : [ "radienshopdrug", "all", "genes" ]
+  "groups" : [ "radienshopdrug", "all", "genes", "nouncrafting" ]
 }

--- a/recipes/radienshopdrug/thesauce.recipe
+++ b/recipes/radienshopdrug/thesauce.recipe
@@ -6,5 +6,5 @@
     "item" : "thesauce",
     "count" : 1
   },
-  "groups" : [ "radienshopdrug", "all", "genes" ]
+  "groups" : [ "radienshopdrug", "all", "genes", "nouncrafting" ]
 }


### PR DESCRIPTION
Adds "nouncrafting" to the groups in the recipes for items through "shops". This change can be made to literally any recipe, to blacklist it from the Universal Uncrafter/Recycler. However, it will fall back to other recipes (perhaps even vanilla), so keep that in mind.