### PR TITLE
shinies

### DIFF
--- a/objects/crafting/sproutingtable/sproutingtable.object
+++ b/objects/crafting/sproutingtable/sproutingtable.object
@@ -53,6 +53,7 @@
   "frameCooldown" : 67,
   "autoCloseCooldown" : 3600,
 
+  "inputNodes" : [ [1, 1] ],
   "outputNodes" : [ [2, 1] ],
 
   "npcToy" : {

--- a/objects/crafting/xenostation/xenolab.object
+++ b/objects/crafting/xenostation/xenolab.object
@@ -53,6 +53,7 @@
   "frameCooldown" : 67,
   "autoCloseCooldown" : 3600,
 
+  "inputNodes" : [ [1, 1] ],
   "outputNodes" : [ [2, 1] ],
 
   "npcToy" : {

--- a/objects/crafting/xenostationadvnew/xenostationadvnew.object
+++ b/objects/crafting/xenostationadvnew/xenostationadvnew.object
@@ -69,6 +69,7 @@
   "frameCooldown" : 67,
   "autoCloseCooldown" : 3600,
   
+  "inputNodes" : [ [1, 1] ],
   "outputNodes" : [ [2, 1] ],
 
   "npcToy" : {

--- a/objects/kheAA/kheAA_terminal/kheAA_terminal.lua
+++ b/objects/kheAA/kheAA_terminal/kheAA_terminal.lua
@@ -28,12 +28,12 @@ function transferItem(_, _, itemData)
 	local targetPos=itemData[5]
 	local slot = itemData[1][2];
 	local count= itemData[2].count
-	local awake,ping=transferUtil.containerAwake(source,sourcePos)
+	local awake,newId=transferUtil.containerAwake(source,sourcePos)
 	if not awake==true then
 		return
 	else
-		if ping~=nil then
-			source=ping
+		if newId~=nil then
+			source=newId
 		end
 		local item = world.containerTakeNumItemsAt(source, slot - 1,count);
 		if item ~= nil then
@@ -43,6 +43,15 @@ function transferItem(_, _, itemData)
 end
 
 function transferUtil.sendConfig()
+	local buffer={}
+	for id,pos in pairs(storage.inContainers) do
+		local awake,newId=transferUtil.containerAwake(id,pos)
+		if awake then
+			id=newId or id
+			buffer[id]=pos
+		end
+	end
+	storage.inContainers=buffer
 	return storage;
 end
 

--- a/objects/kheAA/kheAA_terminal/kheAA_terminal.object
+++ b/objects/kheAA/kheAA_terminal/kheAA_terminal.object
@@ -6,8 +6,8 @@
 
 	"category" : "wire",
 	"price" : 500,
-	"description" : "Provides access to the contents of all connected storage containers. 
-^blue;Input: ^white;item network^reset;",
+	"description" : "Provides access to the contents of connected storage containers. 
+^blue;Input: ^white;item network^reset; ^red;UNRELIABLE AT RANGE!^reset;",
 	"shortdescription" : "Terminal",
 	"race" : "generic",
 


### PR DESCRIPTION
TENTATIVE fix to terminal loading issue implemented.  If issues arrive, hit the refresh button, it should work. If not, oh well. Also stuck a big red warning label on the terminal.

Added input nodes to sprouting table and xeno labs. They can now be used as outputs for an ITD, instead of just inputs.