### PR TITLE
manufacturing station update

### DIFF
--- a/objects/power/manufacturing/mfgstation.lua
+++ b/objects/power/manufacturing/mfgstation.lua
@@ -141,7 +141,7 @@ function scanRecipes(sample)
 					if recipeExclusionList.groups then
 						for _,group in pairs(recipe.groups) do
 							if recipeExclusionList.groups[group] then
-								groupfail=true
+								groupFail=true
 								break
 							end
 						end

--- a/objects/power/manufacturing/mfgstation.object
+++ b/objects/power/manufacturing/mfgstation.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "machines" ],
   "printable" : false,
   "rarity" : "rare",
-  "description" : "An assembly line for processing raw materials into finished products.\nRequires ^orange;40W ^cyan;power.^reset;",
+  "description" : "An assembly line for processing raw materials into finished products.\nRequires about ^orange;40W ^cyan;power.^reset;",
   "shortdescription" : "^cyan;Manufacturing Station^reset;",
   "subtitle" : "",
   "race" : "generic",
@@ -58,7 +58,7 @@
 
 
   "scripts" : [ "/scripts/power.lua", "mfgstation.lua", "/scripts/npcToyObject.lua"],
-  "scriptDelta" : 30,
+  "scriptDelta" : 5,
   "recipeGroup" : "mfgstation",
   "openSounds" : [ "/sfx/objects/locker_open.ogg" ],
   "slotCount" : 16,

--- a/recipes/chemlab/explosive/blastingdynamite.recipe
+++ b/recipes/chemlab/explosive/blastingdynamite.recipe
@@ -1,13 +1,13 @@
 {
   "input" : [
-    { "item" : "ammoniumsulfate", "count" : 10 },
-    { "item" : "volatilepowder", "count" : 10 },
-    { "item" : "ff_plastic", "count" : 5 }
+    { "item" : "ammoniumsulfate", "count" : 4 },
+    { "item" : "volatilepowder", "count" : 4 },
+    { "item" : "ff_plastic", "count" : 2 }
   ],
   "output" : {
     "item" : "blastingdynamite",
-    "count" : 10
+    "count" : 4
   },
   "groups" : [ "chemlab2", "explosive", "all" ],
-  "duration" : 0.05
+  "duration" : 0.02
 }

--- a/recipes/chemlab/explosive/c4explosive.recipe
+++ b/recipes/chemlab/explosive/c4explosive.recipe
@@ -1,13 +1,14 @@
 {
   "input" : [
-    { "item" : "ammoniumsulfate", "count" : 15 },
-    { "item" : "volatilepowder", "count" : 15 },
-    { "item" : "ff_plastic", "count" : 10 },
-    { "item" : "fu_nitrogen", "count" : 50 }
+    { "item" : "ammoniumsulfate", "count" : 3 },
+    { "item" : "volatilepowder", "count" : 3 },
+    { "item" : "ff_plastic", "count" : 2 },
+    { "item" : "fu_nitrogen", "count" : 10 }
   ],
   "output" : {
     "item" : "c4explosive",
-    "count" : 10
+    "count" : 2
   },
-  "groups" : [ "chemlab3", "explosive", "all" ]
+  "groups" : [ "chemlab3", "explosive", "all" ],
+  "duration" : 0.2
 }

--- a/recipes/chemlab/explosive/chilibomb.recipe
+++ b/recipes/chemlab/explosive/chilibomb.recipe
@@ -1,13 +1,13 @@
 {
   "input" : [
-    { "item" : "ammoniumsulfate", "count" : 5 },
-    { "item" : "volatilepowder", "count" : 5 },
-    { "item" : "chili", "count" : 5 }
+    { "item" : "ammoniumsulfate", "count" : 2 },
+    { "item" : "volatilepowder", "count" : 2 },
+    { "item" : "chili", "count" : 2 }
   ],
   "output" : {
     "item" : "chilibomb",
-    "count" : 5
+    "count" : 2
   },
   "groups" : [ "chemlab1", "explosive", "all" ],
-  "duration" : 0.05
+  "duration" : 0.02
 }

--- a/recipes/chemlab/genetics/mutagen2.recipe
+++ b/recipes/chemlab/genetics/mutagen2.recipe
@@ -1,14 +1,14 @@
 {
   "input" : [
-    { "item" : "agaranichor", "count" : 2 },
-    { "item" : "liquidgravrain", "count" : 4},
-    { "item" : "fuscienceresource", "count" : 8},
-    { "item" : "fu_hydrogen", "count" : 4}
+    { "item" : "agaranichor", "count" : 1 },
+    { "item" : "liquidgravrain", "count" : 2},
+    { "item" : "fuscienceresource", "count" : 4},
+    { "item" : "fu_hydrogen", "count" : 2}
   ],
   "output" : {
     "item" : "mutagene2",
-    "count" : 2
+    "count" : 1
   },
   "groups" : [ "chemlab3", "genetics", "all" ],
-  "duration" : 0.25
+  "duration" : 0.125
 }

--- a/recipes/chemlab/genetics/mutagen3.recipe
+++ b/recipes/chemlab/genetics/mutagen3.recipe
@@ -1,14 +1,14 @@
 {
   "input" : [
-    { "item" : "blobbushjelly", "count" : 2 },
-    { "item" : "liquidorganicsoup", "count" : 4},
-    { "item" : "fuscienceresource", "count" : 6},
-    { "item" : "fu_oxygen", "count" : 4}
+    { "item" : "blobbushjelly", "count" : 1 },
+    { "item" : "liquidorganicsoup", "count" : 2},
+    { "item" : "fuscienceresource", "count" : 3},
+    { "item" : "fu_oxygen", "count" : 2}
   ],
   "output" : {
     "item" : "mutagene3",
-    "count" : 2
+    "count" : 1
   },
   "groups" : [ "chemlab2", "genetics", "all" ],
-  "duration" : 0.25
+  "duration" : 0.125
 }

--- a/recipes/chemlab/genetics/mutagen4.recipe
+++ b/recipes/chemlab/genetics/mutagen4.recipe
@@ -1,14 +1,14 @@
 {
   "input" : [
-    { "item" : "fu_nodule", "count" : 4 },
-    { "item" : "liquidbioooze", "count" : 4},
-    { "item" : "fuscienceresource", "count" : 12},
-    { "item" : "fu_salt", "count" : 8}
+    { "item" : "fu_nodule", "count" : 2 },
+    { "item" : "liquidbioooze", "count" : 2},
+    { "item" : "fuscienceresource", "count" : 6},
+    { "item" : "fu_salt", "count" : 4}
   ],
   "output" : {
     "item" : "mutagene4",
-    "count" : 2
+    "count" : 1
   },
   "groups" : [ "chemlab3", "genetics", "all" ],
-  "duration" : 0.25
+  "duration" : 0.125
 }

--- a/recipes/prototyper/resources/aichip.recipe
+++ b/recipes/prototyper/resources/aichip.recipe
@@ -1,12 +1,12 @@
 {
   "input" : [
-    { "item" : "siliconboard", "count" : 4 },
-    { "item" : "morphiteore", "count" : 2 }
+    { "item" : "siliconboard", "count" : 2 },
+    { "item" : "morphiteore", "count" : 1 }
   ],
   "output" : {
     "item" : "aichip",
-    "count" : 2
+    "count" : 1
   },
   "groups" : [ "prototyper3", "chemical", "all" ],
-  "duration" : 0.25
+  "duration" : 0.125
 }

--- a/recipes/prototyper/resources/cpu.recipe
+++ b/recipes/prototyper/resources/cpu.recipe
@@ -1,12 +1,12 @@
 {
   "input" : [
-    { "item" : "siliconboard", "count" : 2 },
-    { "item" : "goldbar", "count" : 2 }
+    { "item" : "siliconboard", "count" : 1 },
+    { "item" : "goldbar", "count" : 1 }
   ],
   "output" : {
     "item" : "cpu",
-    "count" : 2
+    "count" : 1
   },
   "groups" : [ "prototyper2", "chemical", "all" ],
-  "duration" : 0.25
+  "duration" : 0.125
 }

--- a/recipes/prototyper/resources/fuprocessor.recipe
+++ b/recipes/prototyper/resources/fuprocessor.recipe
@@ -1,12 +1,12 @@
 {
   "input" : [
-    { "item" : "siliconboard", "count" : 4 },
-    { "item" : "protocitebar", "count" : 2 }
+    { "item" : "siliconboard", "count" : 2 },
+    { "item" : "protocitebar", "count" : 1 }
   ],
   "output" : {
     "item" : "fuprocessor",
-    "count" : 2
+    "count" : 1
   },
   "groups" : [ "prototyper3", "chemical", "all" ],
-  "duration" : 0.25
+  "duration" : 0.125
 }


### PR DESCRIPTION
Manufacturing station now has a wider range of crafting time, and its animations match. 
Manufacturing station has been proofed against item loss.
Manufacturing station now supports exclusion of outputs by tags, inputs by tags, type, or individual item, and recipes by crafting groups. 
Added bee tags to excluded input tags. 
Added most vanilla and FU shops, and the terraforge,  to craftingGroups exclusion lists.
Reduced crafting time and material requirements in some item recipes, for proportionally less output.