### PR TITLE
Unlinking of Tenebraeh Respawn from Novakid's

### DIFF
--- a/cinematics/respawn/shadow/respawncasual.cinematic
+++ b/cinematics/respawn/shadow/respawncasual.cinematic
@@ -125,7 +125,7 @@
     {
       "drawables" : [
         {
-          "image" : "/cinematics/respawn/novakid/layer2.png:<frame>"
+          "image" : "/cinematics/respawn/shadow/layer2.png:<frame>"
         }
       ],
       "keyframes" : [

--- a/cinematics/respawn/shadow/respawnsurvival.cinematic
+++ b/cinematics/respawn/shadow/respawnsurvival.cinematic
@@ -125,7 +125,7 @@
     {
       "drawables" : [
         {
-          "image" : "/cinematics/respawn/novakid/layer2.png:<frame>"
+          "image" : "/cinematics/respawn/shadow/layer2.png:<frame>"
         }
       ],
       "keyframes" : [


### PR DESCRIPTION
The layer2.png image was already copied in the folder but never linked to, respawn files pointed to the novakid's layer2.png still. Anything overwriting that file could cause issues.