### PR TITLE
recipes

### DIFF
--- a/items/generic/crafting/circuitboard.item
+++ b/items/generic/crafting/circuitboard.item
@@ -12,14 +12,7 @@
   "crewcontract_engineer",
   "advcircuit", 
   "cpu", 
-  "fulabscreen",
-  "network_containerlink", 
-  "network_pump",
-  "network_quarry",
-  "network_repeater",
-  "network_router",
-  "network_spout",
-  "network_terminal"
+  "fulabscreen"
   ],
   "itemTags" : [ "reagent" ]
 }

--- a/items/generic/crafting/ironbar.item.patch
+++ b/items/generic/crafting/ironbar.item.patch
@@ -1,23 +1,24 @@
 [
-  [
-    { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
-    { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
-  ],
-  [
-    { "op" : "replace", "path" : "/price", "value" : 42 },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "armoredsnowpants" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1bed" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1chair" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1door" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1light" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1switch" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1table" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mininghathead" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "beestation" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "wiretoolfu" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "irongrating" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "blacksteelblock" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucolonydeed" },
-    { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucolonydeedinvis" }
-  ]
+	[
+		{ "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+		{ "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+	],
+	[
+		{ "op" : "replace", "path" : "/price", "value" : 42 },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "armoredsnowpants" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1bed" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1chair" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1door" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1light" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1switch" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "tier1table" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "mininghathead" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "beestation" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "wiretoolfu" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "irongrating" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "blacksteelblock" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucolonydeed" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fucolonydeedinvis" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_spout" }
+	]
 ]

--- a/items/generic/crafting/siliconboard.item.patch
+++ b/items/generic/crafting/siliconboard.item.patch
@@ -1,21 +1,22 @@
 [
-  {
-    "op": "add",
-    "path": "/learnBlueprintsOnPickup",
-    "value": [
-      "crewcontract_engineer",
-      "advcircuit",
-      "cpu",
-      "fulabscreen",
-      "network_containerlink",
-      "network_containerlink2",
-      "network_pump",
-      "network_quarry",
-      "network_repeater",
-      "network_router",
-      "network_spout",
-      "network_capacitySensor",
-      "network_terminal"
-    ]
-  }
+	[
+		{ "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
+		{ "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] }
+	],
+	[
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "crewcontract_engineer" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "advcircuit" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "cpu" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "fulabscreen" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_containerlink" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_repeater" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_capacitySensor" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_quarry" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_pump" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_grabber" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_terminal" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_unhandledtoken" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_router" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_moneyrouter" }
+	]
 ]

--- a/objects/crafting/matterassembler/prototyper.object
+++ b/objects/crafting/matterassembler/prototyper.object
@@ -94,7 +94,7 @@
           }
         },
         "filter" : [ "prototyper1", "prototyper2" ],
-        "initialRecipeUnlocks" : [ "labcomputer2", "labcomputer3","fu_autobeamer3farmbeasts","mechassemblystation", "fusubcontroller", "fu_byoscaptainschair", "fu_byosfuelhatch", "fu_byosshipdoor", "fu_byosshiphatch", "fu_byosshiplocker", "fu_byostechstationdeco", "fu_byosteleporterdeco", "powerstation", "mechcraftingtable", "mechrepairpod", "miningbench", "checkpoint", "petpicrepair", "servitorloader", "bothealingstation", "genecabinet", "genestorage", "polymer", "laserdiode", "wiretoolfu", "fu_alternatorgenerator", "fu_woodensifter", "siliconboard", "electromagnet", "wire", "microscope", "handmill", "nanofabricator", "armory", "designlab", "sproutingtable", "fu_growingtray", "farmwell", "eggincubator", "heavypipe", "fulabpipe", "labtechpanel", "fu_autobeamer3bugs", "portablelight", "fulabhoverplatform", "fulabhoverpanel", "labvendingmachine", "techconsole", "xenostation", "apexcoolshelf2",  "apexpod2", "electronmicroscope", "titaniumwallblockmaterial", "speedblockmaterial", "jumpblockmaterial", "extractionlab", "manipulatormodule", "upgrademodule", "techcard", "crewcontract_gas", "crewcontract_sciencedrug", "crewcontract_scuba", "fm_musicplayer", "network_moneyrouter", "fu_byospethouse", "fu_racialiser", "fu_shipcraftingtable", "fu_ftldrivedeco", "fu_byoscaptainschairdeco" ],
+        "initialRecipeUnlocks" : [ "labcomputer2", "labcomputer3","fu_autobeamer3farmbeasts","mechassemblystation", "fusubcontroller", "fu_byoscaptainschair", "fu_byosfuelhatch", "fu_byosshipdoor", "fu_byosshiphatch", "fu_byosshiplocker", "fu_byostechstationdeco", "fu_byosteleporterdeco", "powerstation", "mechcraftingtable", "mechrepairpod", "miningbench", "checkpoint", "petpicrepair", "servitorloader", "bothealingstation", "genecabinet", "genestorage", "polymer", "laserdiode", "wiretoolfu", "fu_alternatorgenerator", "fu_woodensifter", "siliconboard", "electromagnet", "wire", "microscope", "handmill", "nanofabricator", "armory", "designlab", "sproutingtable", "fu_growingtray", "farmwell", "eggincubator", "heavypipe", "fulabpipe", "labtechpanel", "fu_autobeamer3bugs", "portablelight", "fulabhoverplatform", "fulabhoverpanel", "labvendingmachine", "techconsole", "xenostation", "apexcoolshelf2",  "apexpod2", "electronmicroscope", "titaniumwallblockmaterial", "speedblockmaterial", "jumpblockmaterial", "extractionlab", "manipulatormodule", "upgrademodule", "techcard", "crewcontract_gas", "crewcontract_sciencedrug", "crewcontract_scuba", "fm_musicplayer", "fu_byospethouse", "fu_racialiser", "fu_shipcraftingtable", "fu_ftldrivedeco", "fu_byoscaptainschairdeco" ],
         "upgradeMaterials" : [
           { "item" : "titaniumbar", "count" : 6 },
           { "item" : "cpu", "count" : 2 },
@@ -139,7 +139,6 @@
         "mechassemblystation", "fusubcontroller", "fu_autobeamer3farmbeasts",
         "fu_byoscaptainschair", "fu_byosfuelhatch", "fu_byosshipdoor", "fu_byosshiphatch", "fu_byosshiplocker", "fu_byostechstationdeco", "fu_byosteleporterdeco",
         "mechcraftingtable",
-        "network_moneyrouter",
         "mechrepairpod",
         "miningbench",
         "checkpoint",

--- a/objects/crafting/powerstation/powerstation.object
+++ b/objects/crafting/powerstation/powerstation.object
@@ -57,7 +57,7 @@
 
         "filter" : [ "powerstation1" ],
 
-        "initialRecipeUnlocks" : [ "network_containerlink2", "smartbox_halver", "configurable3statecycler", "smartbox_singular", "smartbox_splitter", "isn_incinerator", "fu_watcher", "isn_powersensor","isn_solarpanel","isn_hydroponicstray","isn_battery_t1","fu_powersensorlarge","isn_powersensor","fu_liquidcondenser", "fu_conduit", "fu_liquidmixer" ],
+        "initialRecipeUnlocks" : [ "smartbox_halver", "configurable3statecycler", "smartbox_singular", "smartbox_splitter", "isn_incinerator", "fu_watcher", "isn_powersensor","isn_solarpanel","isn_hydroponicstray","isn_battery_t1","fu_powersensorlarge","isn_powersensor","fu_liquidcondenser", "fu_conduit", "fu_liquidmixer" ],
 
         "upgradeMaterials" : [
           { "item" : "carbonplate", "count" : 6 },
@@ -96,7 +96,7 @@
           }
         },
         "filter" : [ "powerstation1", "powerstation2" ],
-        "initialRecipeUnlocks" : [ "network_containerlink2", "smartbox_halver", "configurable3statecycler", "smartbox_singular", "fu_cripplerturret", "smartbox_splitter", "isn_incinerator", "fu_watcher", "isn_powersensor","isn_solarpanel","isn_hydroponicstray","isn_battery_t1","fu_powersensorlarge","isn_powersensor","fu_liquidcondenser", "fu_conduit", "fu_atmosfilter", "fu_liquidmixer" ]
+        "initialRecipeUnlocks" : [ "smartbox_halver", "configurable3statecycler", "smartbox_singular", "fu_cripplerturret", "smartbox_splitter", "isn_incinerator", "fu_watcher", "isn_powersensor","isn_solarpanel","isn_hydroponicstray","isn_battery_t1","fu_powersensorlarge","isn_powersensor","fu_liquidcondenser", "fu_conduit", "fu_atmosfilter", "fu_liquidmixer" ]
       },
 
       "craftingSound" : "/sfx/interface/crafting_tech1.ogg",

--- a/objects/kheAA/kheAA_capacitySensor/kheAA_capacitySensor.object
+++ b/objects/kheAA/kheAA_capacitySensor/kheAA_capacitySensor.object
@@ -10,6 +10,7 @@
 	"shortdescription" : "Capacity Sensor",
 	"race" : "generic",
 
+	"learnBlueprintsOnPickup":["network_containerlink2"],
 	"inventoryIcon" : "kheAA_capacitysensoricon.png",
 	"orientations" : [
 		{

--- a/objects/kheAA/kheAA_containerLink/kheAA_containerLink.object
+++ b/objects/kheAA/kheAA_containerLink/kheAA_containerLink.object
@@ -5,7 +5,7 @@
 	"description" : "Marks containers for use by an item network. Place near object placement point. Scan for more info.",
 	"shortdescription" : "Storage Bridge",
 	"race" : "generic",
-
+	"learnBlueprintsOnPickup":["network_containerlink2"],
 	"category" : "wire",
 	"price" : 75,
 

--- a/objects/kheAA/kheAA_grabber/kheAA_grabber.object
+++ b/objects/kheAA/kheAA_grabber/kheAA_grabber.object
@@ -11,6 +11,7 @@
 	"tooltipKind" : "container",
 	"race" : "generic",
 
+	"learnBlueprintsOnPickup":["network_grabber2"],
 	"category" : "wire",
 	"price" : 15,
 

--- a/objects/kheAA/kheAA_grabber/kheAA_grabber2.object
+++ b/objects/kheAA/kheAA_grabber/kheAA_grabber2.object
@@ -11,6 +11,7 @@
 	"tooltipKind" : "container",
 	"race" : "generic",
 
+	"learnBlueprintsOnPickup":["network_grabber3"],
 	"category" : "wire",
 	"price" : 64,
 

--- a/player.config.patch
+++ b/player.config.patch
@@ -400,9 +400,6 @@
 	{ "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "iceaxe"} },
 
 	//Kherae's turrets
-	{ "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "network_grabber"} },
-	{ "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "network_grabber2"} },
-	{ "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "network_grabber3"} },
 	{ "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "fu_autoBeamer"} },
 
 

--- a/recipes/kheAA/kheAA_capacitySensor.recipe
+++ b/recipes/kheAA/kheAA_capacitySensor.recipe
@@ -1,7 +1,8 @@
 {
 	"input" : [
 		{ "item" : "ironbar", "count" : 2 },
-		{ "item" : "copperbar", "count" : 1 },
+		{ "item" : "siliconboard", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 1 },
 		{ "item" : "laserdiode", "count" : 1 }
 	],
 	"output" : { "item" : "network_capacitySensor", "count" : 1 },

--- a/recipes/kheAA/kheAA_containerLink.recipe
+++ b/recipes/kheAA/kheAA_containerLink.recipe
@@ -1,8 +1,8 @@
 {
 	"input" : [
 		{ "item" : "ironbar", "count" : 2 },
-		{ "item" : "copperbar", "count" : 1 },
-		{ "item" : "laserdiode", "count" : 1 }
+		{ "item" : "laserdiode", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 1 }
 	],
 	"output" : { "item" : "network_containerlink", "count" : 1 },
         "groups" : [ "powerstation1", "network", "all" ]

--- a/recipes/kheAA/kheAA_grabber.recipe
+++ b/recipes/kheAA/kheAA_grabber.recipe
@@ -1,10 +1,10 @@
 {
 	"input" : [
 		{ "item" : "teleportercore", "count" : 1 },
+		{ "item" : "siliconboard", "count" : 1 },
 		{ "item" : "electromagnet", "count" : 1 },
-		{ "item" : "laserdiode", "count" : 2 },
-		{ "item" : "tungstenbar", "count" : 4 },
-		{ "item" : "copperbar", "count" : 3 }
+		{ "item" : "laserdiode", "count" : 1 },
+		{ "item" : "tungstenbar", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_grabber",

--- a/recipes/kheAA/kheAA_grabber2.recipe
+++ b/recipes/kheAA/kheAA_grabber2.recipe
@@ -1,10 +1,8 @@
 {
 	"input" : [
-		{ "item" : "teleportercore", "count" : 1 },
+		{ "item" : "network_grabber", "count" : 1 },
 		{ "item" : "electromagnet", "count" : 1 },
-		{ "item" : "laserdiode", "count" : 2 },
-		{ "item" : "titaniumbar", "count" : 4 },
-		{ "item" : "copperbar", "count" : 3 }
+		{ "item" : "titaniumbar", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_grabber2",

--- a/recipes/kheAA/kheAA_grabber3.recipe
+++ b/recipes/kheAA/kheAA_grabber3.recipe
@@ -1,10 +1,8 @@
 {
 	"input" : [
-		{ "item" : "teleportercore", "count" : 1 },
+		{ "item" : "network_grabber2", "count" : 1 },
 		{ "item" : "electromagnet", "count" : 1 },
-		{ "item" : "laserdiode", "count" : 2 },
-		{ "item" : "durasteelbar", "count" : 4 },
-		{ "item" : "copperbar", "count" : 3 }
+		{ "item" : "durasteelbar", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_grabber3",

--- a/recipes/kheAA/kheAA_pump.recipe
+++ b/recipes/kheAA/kheAA_pump.recipe
@@ -1,7 +1,8 @@
 {
 	"input" : [
 		{ "item" : "laserdiode", "count" : 2 },
-		{ "item" : "copperbar", "count" : 6 }
+		{ "item" : "copperbar", "count" : 6 },
+		{ "item" : "electromagnet", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_pump",

--- a/recipes/kheAA/kheAA_pumpdensinium.recipe
+++ b/recipes/kheAA/kheAA_pumpdensinium.recipe
@@ -1,7 +1,8 @@
 {
 	"input" : [
 		{ "item" : "densiniumbar", "count" : 6 },
-		{ "item" : "network_pump_titanium", "count" : 1 }
+		{ "item" : "network_pump_titanium", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_pump_densinium",

--- a/recipes/kheAA/kheAA_pumpiron.recipe
+++ b/recipes/kheAA/kheAA_pumpiron.recipe
@@ -1,7 +1,8 @@
 {
 	"input" : [
 		{ "item" : "ironbar", "count" : 6 },
-		{ "item" : "network_pump", "count" : 1 }
+		{ "item" : "network_pump", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_pump_iron",

--- a/recipes/kheAA/kheAA_pumptitanium.recipe
+++ b/recipes/kheAA/kheAA_pumptitanium.recipe
@@ -1,7 +1,8 @@
 {
 	"input" : [
 		{ "item" : "titaniumbar", "count" : 6 },
-		{ "item" : "network_pump_iron", "count" : 1 }
+		{ "item" : "network_pump_iron", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_pump_titanium",

--- a/recipes/kheAA/kheAA_quarry.recipe
+++ b/recipes/kheAA/kheAA_quarry.recipe
@@ -1,7 +1,8 @@
 {
 	"input" : [
-		{ "item" : "electromagnet", "count" : 1 },
-		{ "item" : "copperbar", "count" : 8 }
+		{ "item" : "siliconboard", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 4 },
+		{ "item" : "copperbar", "count" : 6 }
 	],
 	"output" : {
 		"item" : "network_quarry",

--- a/recipes/kheAA/kheAA_quarrydensinium.recipe
+++ b/recipes/kheAA/kheAA_quarrydensinium.recipe
@@ -1,7 +1,8 @@
 {
 	"input" : [
 		{ "item" : "densiniumbar", "count" : 6 },
-		{ "item" : "network_quarrytitanium", "count" : 1 }
+		{ "item" : "network_quarrytitanium", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_quarrydensinium",

--- a/recipes/kheAA/kheAA_quarryiron.recipe
+++ b/recipes/kheAA/kheAA_quarryiron.recipe
@@ -1,7 +1,8 @@
 {
 	"input" : [
 		{ "item" : "ironbar", "count" : 6 },
-		{ "item" : "network_quarry", "count" : 1 }
+		{ "item" : "network_quarry", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_quarryiron",

--- a/recipes/kheAA/kheAA_quarrytitanium.recipe
+++ b/recipes/kheAA/kheAA_quarrytitanium.recipe
@@ -1,7 +1,8 @@
 {
 	"input" : [
 		{ "item" : "titaniumbar", "count" : 6 },
-		{ "item" : "network_quarryiron", "count" : 1 }
+		{ "item" : "network_quarryiron", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_quarrytitanium",

--- a/recipes/kheAA/kheAA_repeater.recipe
+++ b/recipes/kheAA/kheAA_repeater.recipe
@@ -1,6 +1,7 @@
 {
 	"input" : [
-		{ "item" : "copperbar", "count" : 2 },
+		{ "item" : "electromagnet", "count" : 1 },
+		{ "item" : "siliconboard", "count" : 1 },
 		{ "item" : "ironbar", "count" : 1 }
 	],
 	"output" : { "item" : "network_repeater", "count" : 1 },

--- a/recipes/kheAA/kheAA_router.recipe
+++ b/recipes/kheAA/kheAA_router.recipe
@@ -1,10 +1,11 @@
 {
 	"input" : [
 		{ "item" : "teleportercore", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 1 },
+		{ "item" : "siliconboard", "count" : 1 },
 		{ "item" : "ironbar", "count" : 1 },
 		{ "item" : "laserdiode", "count" : 1 },
-		{ "item" : "glass", "count" : 1 },
-		{ "item" : "copperbar", "count" : 3 }
+		{ "item" : "glass", "count" : 1 }
 	],
 	"output" : {
 		"item" : "network_router",

--- a/recipes/kheAA/kheAA_routerMoney.recipe
+++ b/recipes/kheAA/kheAA_routerMoney.recipe
@@ -1,10 +1,11 @@
 {
 	"input" : [
 		{ "item" : "teleportercore", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 1 },
+		{ "item" : "siliconboard", "count" : 1 },
 		{ "item" : "ironbar", "count" : 1 },
 		{ "item" : "laserdiode", "count" : 1 },
-		{ "item" : "glass", "count" : 1 },
-		{ "item" : "copperbar", "count" : 3 }
+		{ "item" : "glass", "count" : 1 }
 	],
 	"output" : {
 		"item" : "network_moneyrouter",

--- a/recipes/kheAA/kheAA_spout.recipe
+++ b/recipes/kheAA/kheAA_spout.recipe
@@ -1,7 +1,7 @@
 {
 	"input" : [
-		{ "item" : "copperbar", "count" : 5 },
-		{ "item" : "ironbar", "count" : 2 }
+		{ "item" : "electromagnet", "count" : 1 },
+		{ "item" : "ironbar", "count" : 4 }
 	],
 	"output" : {
 		"item" : "network_spout",

--- a/recipes/kheAA/kheAA_terminal.recipe
+++ b/recipes/kheAA/kheAA_terminal.recipe
@@ -1,7 +1,9 @@
 {
 	"input" : [
+		{ "item" : "teleportercore", "count" : 1 },
+		{ "item" : "electromagnet", "count" : 1 },
 		{ "item" : "siliconboard", "count" : 4 },
-		{ "item" : "copperbar", "count" : 5 },
+		{ "item" : "ironbar", "count" : 2 },
 		{ "item" : "glass", "count" : 2 }
 	],
 	"output" : {

--- a/recipes/kheAA/kheAA_unhandled.recipe
+++ b/recipes/kheAA/kheAA_unhandled.recipe
@@ -1,0 +1,10 @@
+{
+	"input" : [
+		{ "item" : "siliconboard", "count" : 1 }
+	],
+	"output" : {
+		"item" : "network_unhandledtoken",
+		"count" : 1
+	},
+	"groups" : [ "powerstation1", "network", "all" ]
+}


### PR DESCRIPTION
moved network device unlocks to silicon boards, except for spouts which are unlocked from iron bars now.
terminals now take a teleporter core
several item network recipes adjusted to use fewer bars, and more electromagnets.
grabber recipes modified so that each is a component in the next version up.
fixed a potential compatibility issue in the silicon board patch.