### PR TITLE
unhandled token fix

### DIFF
--- a/items/generic/crafting/siliconboard.item.patch
+++ b/items/generic/crafting/siliconboard.item.patch
@@ -16,6 +16,7 @@
 		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_grabber" },
 		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_terminal" },
 		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_router" },
-		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_moneyrouter" }
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_moneyrouter" },
+		{ "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "network_unhandledtoken" }
 	]
 ]

--- a/objects/kheAA/kheAA_unhandledToken/kheAA_unhandledToken.item
+++ b/objects/kheAA/kheAA_unhandledToken/kheAA_unhandledToken.item
@@ -1,5 +1,5 @@
 {
-  "itemName" : "kheAA_unhandledToken",
+  "itemName" : "network_unhandledtoken",
   "price" : 50,
   "rarity" : "Uncommon",
   "category" : "Unhandled",


### PR DESCRIPTION
Fixed ITD Unhandled Handler using the wrong item ID.

The token a placeholder for filtering unrecognized ITD categories. Example: Handleguns from the webber mod. They are guns, but there is no relation between that category and the weapon ITD category.

Insert grumbling about special snowflakes here.