### PR TITLE
Shield Fixes, and Recipe Changes

### DIFF
--- a/items/active/shields/durasteelshield.activeitem
+++ b/items/active/shields/durasteelshield.activeitem
@@ -2,9 +2,9 @@
   "itemName" : "durasteelshield",
   "price" : 150,
   "maxStack" : 1,
-  "level" : 1,
-  "rarity" : "common",
-  "tooltipKind" : "shieldnew", 
+  "level" : 4,
+  "rarity" : "uncommon",
+  "tooltipKind" : "shieldnew",
   "description" : "^green;Crit Chance +3%, Crit Damage +5^reset;",
   "shortdescription" : "Durasteel Shield",
   "category" : "shield",
@@ -36,7 +36,7 @@
   "shieldEnergyBonus" : 0,
   "shieldProtection" : 0,
   "shieldStamina" : 0.10,
-  "shieldFalling" : 0, 
+  "shieldFalling" : 0,
   "shieldCritChance" : 3,
   "shieldCritBonus" : 5,
   "protectionBee" : 0,
@@ -53,11 +53,11 @@
   "protectionXCold" : 0,
   "protectionXHeat" : 0,
   "protectionXRads" : 0,
-  "protectionInsanity" : 0, 
+  "protectionInsanity" : 0,
   "protectionShock" : 0,
   "protectionSlime" : 0,
   "shieldBash" : 4,
-  "shieldBashPush" : 4,    
+  "shieldBashPush" : 4,
   // end FU shield properties
 
   "minActiveTime" : 0.2,
@@ -68,7 +68,7 @@
 
   "perfectBlockDirectives" : "?border=2;AACCFFFF;00000000",
   "perfectBlockTime" : 0.3,
-  
+
   "stances" : {
     "idle" : {
       "armRotation" : -90,

--- a/items/active/shields/titaniumshield.activeitem
+++ b/items/active/shields/titaniumshield.activeitem
@@ -2,9 +2,9 @@
   "itemName" : "titaniumshield",
   "price" : 150,
   "maxStack" : 1,
-  "level" : 1,
-  "rarity" : "common",
-  "tooltipKind" : "shieldnew", 
+  "level" : 3,
+  "rarity" : "uncommon",
+  "tooltipKind" : "shieldnew",
   "description" : "^green;Acid Protection, +5 Shieldbash Push^reset;",
   "shortdescription" : "Titanium Shield",
   "category" : "shield",
@@ -35,10 +35,10 @@
   "shieldHealthBonus" : 0,
   "shieldEnergyBonus" : 0,
   "shieldBash" : 2,
-  "shieldBashPush" : 5,  
+  "shieldBashPush" : 5,
   "shieldProtection" : 0,
   "shieldStamina" : 0.60,
-  "shieldFalling" : 0, 
+  "shieldFalling" : 0,
   "shieldCritChance" : 0,
   "shieldCritBonus" : 0,
   "protectionBee" : 0,
@@ -55,7 +55,7 @@
   "protectionXCold" : 0,
   "protectionXHeat" : 0,
   "protectionXRads" : 0,
-  "protectionInsanity" : 0, 
+  "protectionInsanity" : 0,
   "protectionShock" : 0,
   "protectionSlime" : 0,
   // end FU shield properties
@@ -68,7 +68,7 @@
 
   "perfectBlockDirectives" : "?border=2;AACCFFFF;00000000",
   "perfectBlockTime" : 0.3,
-  
+
   "stances" : {
     "idle" : {
       "armRotation" : -90,

--- a/items/active/shields/tungstenshield.activeitem
+++ b/items/active/shields/tungstenshield.activeitem
@@ -2,9 +2,9 @@
   "itemName" : "tungstenshield",
   "price" : 150,
   "maxStack" : 1,
-  "level" : 1,
+  "level" : 2,
   "rarity" : "common",
-  "tooltipKind" : "shieldnew", 
+  "tooltipKind" : "shieldnew",
   "description" : "^green;+0.08% HP Regen^reset;",
   "shortdescription" : "Tungsten Shield",
   "category" : "shield",
@@ -35,10 +35,10 @@
   "shieldHealthBonus" : 0.02,
   "shieldEnergyBonus" : 0,
   "shieldBash" : 2,
-  "shieldBashPush" : 4,  
+  "shieldBashPush" : 4,
   "shieldProtection" : 0,
   "shieldStamina" : 0.2,
-  "shieldFalling" : 0, 
+  "shieldFalling" : 0,
   "shieldCritChance" : 0,
   "shieldCritBonus" : 2,
   "protectionBee" : 0,
@@ -55,7 +55,7 @@
   "protectionXCold" : 0,
   "protectionXHeat" : 0,
   "protectionXRads" : 0,
-  "protectionInsanity" : 0, 
+  "protectionInsanity" : 0,
   "protectionShock" : 0,
   "protectionSlime" : 0,
   // end FU shield properties
@@ -68,7 +68,7 @@
 
   "perfectBlockDirectives" : "?border=2;AACCFFFF;00000000",
   "perfectBlockTime" : 0.3,
-  
+
   "stances" : {
     "idle" : {
       "armRotation" : -90,

--- a/recipes/anvil1/weapons/tier1/ironshield.recipe
+++ b/recipes/anvil1/weapons/tier1/ironshield.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "ironbar", "count" : 3 },
-    { "item" : "leather", "count" : 1 }
+    { "item" : "fabric", "count" : 1 }
   ],
   "output" : {
     "item" : "ironshield",

--- a/recipes/anvil1/weapons/tier2/tungstenshield.recipe
+++ b/recipes/anvil1/weapons/tier2/tungstenshield.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
-    { "item" : "leather", "count" : 1 },
     { "item" : "tungstenbar", "count" : 4 }
+    { "item" : "cottonwool", "count" : 1 },
   ],
   "output" : {
     "item" : "tungstenshield",

--- a/recipes/anvil2/weapons/tier3/titaniumshield.recipe
+++ b/recipes/anvil2/weapons/tier3/titaniumshield.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "titaniumbar", "count" : 4 },
-    { "item" : "canvas", "count" : 1 }
+    { "item" : "silk", "count" : 1 }
   ],
   "output" : {
     "item" : "titaniumshield",

--- a/recipes/anvil3/weapons/tier4/durasteelshield.recipe
+++ b/recipes/anvil3/weapons/tier4/durasteelshield.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "durasteelbar", "count" : 5 },
-    { "item" : "leather", "count" : 2 }
+    { "item" : "syntheticmaterial", "count" : 2 }
   ],
   "output" : {
     "item" : "durasteelshield",

--- a/recipes/anvil3/weapons/tier4/durasteelshield.recipe
+++ b/recipes/anvil3/weapons/tier4/durasteelshield.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "durasteelbar", "count" : 5 },
-    { "item" : "syntheticmaterial", "count" : 2 }
+    { "item" : "leather", "count" : 2 }
   ],
   "output" : {
     "item" : "durasteelshield",

--- a/recipes/armory/prismatic/weapons/cuteboomerang.recipe
+++ b/recipes/armory/prismatic/weapons/cuteboomerang.recipe
@@ -8,5 +8,5 @@
     "item" : "cuteboomerang",
     "count" : 1
   },
-  "groups" : [ "craftinganvil", "weapons", "armory1", "all", "misc" ]
+  "groups" : [ "armory3", "all", "misc" ]
 }

--- a/recipes/armory/prismatic/weapons/cutechakram.recipe
+++ b/recipes/armory/prismatic/weapons/cutechakram.recipe
@@ -8,5 +8,5 @@
     "item" : "cutechakram",
     "count" : 1
   },
-  "groups" : [ "armory3", "weapons", "ranged", "all", "misc" ]
+  "groups" : [ "armory3", "all", "misc" ]
 }

--- a/recipes/armory/ranged/bow/carnagebow.recipe
+++ b/recipes/armory/ranged/bow/carnagebow.recipe
@@ -8,5 +8,5 @@
     "item" : "carnagebow",
     "count" : 1
   },
-  "groups" : [ "armory1", "bow", "all" ]
+  "groups" : [ "armory3", "bow", "all" ]
 }


### PR DESCRIPTION
3 Commits here. 
First: I changed the levels and tier as appropriate for vanilla shields.
Second: I moved the prismatic boomerang and chakram, so they're only available at the armory. As well as the Carnage Bow (requires quietus which is T5 I believe)
Third: I altered the vanilla shield recipes so the required cloth matches the armor as well as to add a little variety to the recipes.

If their are any issues let me know. I'll go ahead and fix them.