### PR TITLE
FU weather fixes

### DIFF
--- a/stats/effects/fu_weathereffects/new/aether/aetherweathernew.lua
+++ b/stats/effects/fu_weathereffects/new/aether/aetherweathernew.lua
@@ -193,25 +193,22 @@ function update(dt)
 	end
 
 	if isEntityAffected() then
-		self.biomeTimer = self.biomeTimer - dt
-		if (self.biomeTimer <= 0) then
-			-- Aether effects are worse at night (while above ground).
-			if not (daytime or underground) then
-				setNightPenalty()
-				if (self.timerRadioMessage <= 0) then
-					if not self.usedNight then
-						world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomeaethernight", 1.0) -- send player a warning
-						self.timerRadioMessage = 10
-						self.usedNight = 1
-					end
+		-- Aether effects are worse at night (while above ground).
+		if not (daytime or underground) then
+			setNightPenalty()
+			if (self.timerRadioMessage <= 0) then
+				if not self.usedNight then
+					world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomeaethernight", 1.0) -- send player a warning
+					self.timerRadioMessage = 10
+					self.usedNight = 1
 				end
 			end
-			-- Don't reset biome timer yet (done later in function).
 		end
 		-- Set damage totals (accounting for modifiers).
 		self.damageApply = setEffectDamage()
 		self.debuffApply = setEffectDebuff()
 		-- Apply effects.
+		self.biomeTimer = self.biomeTimer - dt
 		if (self.biomeTimer <= 0) then
 			-- Aether effects initially reduce the player's max energy.
 			if (status.stat("maxEnergy",0) > 0) then

--- a/stats/effects/fu_weathereffects/new/aether/aetherweathernew.lua
+++ b/stats/effects/fu_weathereffects/new/aether/aetherweathernew.lua
@@ -31,27 +31,35 @@ function init()
 	script.setUpdateDelta(5)
 end
 
+--[[ Helper function to determine if weather effect applies to an entity ]]--
+function isEntityAffected()
+	-- if not a player, or world type is "unknown" (???) then return false --
+	if ((world.entityType(entity.id()) ~= "player") or
+	world.type()=="unknown") then
+		return false
+	end
+	-- if player has immunity stat or sufficient resistance, return false --
+	if (status.statPositive("aetherImmunity") or
+	(status.stat("cosmicResistance",0)  >= self.effectCutoffValue)) then
+		return false
+	end
+	-- otherwise, return true
+	return true
+end
 
---******* check effect and cancel ************
+--[[ Check if weather effect is still applicable, and handle visual effects ]]--
 function checkEffectValid()
-	if world.entityType(entity.id()) ~= "player" then
+	-- remove visual effect if no longer affected
+	if not isEntityAffected() then
 		deactivateVisualEffects()
 		effect.expire()
-	end
-	if status.statPositive("aetherImmunity") or world.type()=="unknown" then
-		effect.expire()
-	end
-
-	-- checks strength of effect vs resistance
-	if ( status.stat("cosmicResistance",0)  >= self.effectCutoffValue ) then
-		deactivateVisualEffects()
-		effect.expire()
+	-- add visual effect and display warning (if not yet shown)
 	else
-		-- activate visuals and check stats
+		activateVisualEffects()
 		if not self.usedIntro then
-			-- activate visuals and check stats
-			world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomeaether", 1.0) -- send player a warning
+			world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomeaether", 1.0)
 			self.usedIntro = 1
+			self.timerRadioMessage = 220
 		end
 	end
 end
@@ -118,12 +126,9 @@ function undergroundCheck()
 	return world.underground(mcontroller.position())
 end
 
-
 function isDry()
 local mouthPosition = vec2.add(mcontroller.position(), status.statusProperty("mouthPosition"))
-	if not world.liquidAt(mouthPosition) then
-		inWater = 0
-	end
+	return not world.liquidAt(mouthPosition)
 end
 
 function hungerLevel()
@@ -159,8 +164,7 @@ end
 
 function update(dt)
 	checkEffectValid()
-	self.biomeTimer = self.biomeTimer - dt
-	self.biomeTimer2 = self.biomeTimer2 - dt
+	-- self.biomeTimer2 = self.biomeTimer2 - dt
 	self.timerRadioMessage = self.timerRadioMessage - dt
 
 --set the base stats
@@ -175,6 +179,12 @@ function update(dt)
 
 	self.baseRate = setEffectTime()
 
+	-- environment checks
+	local daytime = daytimeCheck()
+	local underground = undergroundCheck()
+	local lightLevel = getLight()
+	local dry = isDry()
+
 	if status.isResource("food") then
 		setSituationPenalty()
 		self.baseDmg = ( self.baseDmg * (status.resource("food")/40) )
@@ -182,39 +192,47 @@ function update(dt)
 		self.baseRate = ( self.baseRate * (status.resource("food")/40) )
 	end
 
-	-- is it nighttime or above ground?
-	if not daytime then
-		setNightPenalty()
-		if (self.timerRadioMessage <= 0) then
-			if not self.usedNight then
-				world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomeaethernight", 1.0) -- send player a warning
-				self.timerRadioMessage = 10
-				self.usedNight = 1
+	if isEntityAffected() then
+		self.biomeTimer = self.biomeTimer - dt
+		if (self.biomeTimer <= 0) then
+			-- Aether effects are worse at night (while above ground).
+			if not (daytime or underground) then
+				setNightPenalty()
+				if (self.timerRadioMessage <= 0) then
+					if not self.usedNight then
+						world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomeaethernight", 1.0) -- send player a warning
+						self.timerRadioMessage = 10
+						self.usedNight = 1
+					end
+				end
+			end
+			-- Don't reset biome timer yet (done later in function).
+		end
+		-- Set damage totals (accounting for modifiers).
+		self.damageApply = setEffectDamage()
+		self.debuffApply = setEffectDebuff()
+		-- Apply effects.
+		if (self.biomeTimer <= 0) then
+			-- Aether effects initially reduce the player's max energy.
+			if (status.stat("maxEnergy",0) > 0) then
+				effect.addStatModifierGroup({
+					{stat = "energyRegenPercentageRate", amount = status.stat("energyRegenPercentageRate") * (1 * -status.stat("cosmicResistance",0))  },
+					{stat = "energyRegenBlockTime", amount = status.stat("energyRegenBlockTime") * (1 * -status.stat("cosmicResistance",0))  },
+					{stat = "maxEnergy", amount = util.round(-self.debuffApply)  }
+				})
+				makeAlert()
+			end
+			-- Reset the biome timer.
+			self.biomeTimer = self.baseRate
+		end
+		-- Once player's energy gets low, Aether rapidly drains HP and energy.
+		if (status.stat("maxEnergy",0) < 20) then
+			status.modifyResource("health", -self.damageApply * dt)
+			if status.isResource("energy") then
+				status.modifyResource("energy", -self.damageApply * dt)
 			end
 		end
-	end
-
-	--apply damage totals
-	self.damageApply = setEffectDamage()
-	self.debuffApply = setEffectDebuff()
-
-	if (self.biomeTimer <= 0) and (status.stat("maxEnergy",0) > 0) then
-		effect.addStatModifierGroup({
-			{stat = "energyRegenPercentageRate", amount = status.stat("energyRegenPercentageRate") * (1 * -status.stat("cosmicResistance",0))  },
-			{stat = "energyRegenBlockTime", amount = status.stat("energyRegenBlockTime") * (1 * -status.stat("cosmicResistance",0))  },
-			{stat = "maxEnergy", amount = util.round(-self.debuffApply)  }
-		})
-		makeAlert()
-		activateVisualEffects()
-		self.biomeTimer = self.baseRate
-	end
-
-	if (status.stat("maxEnergy",0) < 20) then
-		status.modifyResource("health", -self.damageApply * dt)
-		if status.isResource("energy") then
-			status.modifyResource("energy", -self.damageApply * dt)
-		end
-	end
+	end -- isEntityAffected()
 end
 
 function uninit()

--- a/stats/effects/fu_weathereffects/new/cold/coldweathernew.lua
+++ b/stats/effects/fu_weathereffects/new/cold/coldweathernew.lua
@@ -184,43 +184,44 @@ function update(dt)
 	local dry = isDry()
 
 	if isEntityAffected() then
-		self.biomeTimer = self.biomeTimer - dt
-		if (self.biomeTimer <= 0) then
-			-- Cold weather is worse when windy.
-			if not (self.windLevel < 40 or underground) then
-				setWindPenalty()
-				if (self.timerRadioMessage <=0) then
-					if not self.usedWind then
-						world.sendEntityMessage(entity.id(), "queueRadioMessage", "fubiomecoldwind", 1.0) -- send player a warning
-						self.timerRadioMessage = 10
-						self.usedWind = 1
-					end
+		-- Cold weather is worse when windy.
+		if not (self.windLevel < 40 or underground) then
+			setWindPenalty()
+			if (self.timerRadioMessage <=0) then
+				if not self.usedWind then
+					world.sendEntityMessage(entity.id(), "queueRadioMessage", "fubiomecoldwind", 1.0) -- send player a warning
+					self.timerRadioMessage = 10
+					self.usedWind = 1
 				end
 			end
-			-- Cold weather is worse when in liquid.
-			if not dry then
-				setLiquidPenalty()
-				if (self.timerRadioMessage <= 0) then
-						if not self.usedWater then
-							world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomecoldwater", 1.0) -- send player a warning
-							self.timerRadioMessage = 10
-							self.usedWater = 1
-						end
-				end
-			end
-			-- Cold weather is worse at night.
-			if not (daytime or underground) then
-				setNightPenalty()
-				if (self.timerRadioMessage <= 0) then
-					if not self.usedNight then
-						world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomecoldnight", 1.0) -- send player a warning
-						self.timerRadioMessage = 10
-						self.usedNight = 1
-					end
-				end
-			end
-			self.biomeTimer = self.baseRate
 		end
+		-- Cold weather is worse when in liquid.
+		if not dry then
+			setLiquidPenalty()
+			if (self.timerRadioMessage <= 0) then
+					if not self.usedWater then
+						world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomecoldwater", 1.0) -- send player a warning
+						self.timerRadioMessage = 10
+						self.usedWater = 1
+					end
+			end
+		end
+		-- Cold weather is worse at night.
+		if not (daytime or underground) then
+			setNightPenalty()
+			if (self.timerRadioMessage <= 0) then
+				if not self.usedNight then
+					world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomecoldnight", 1.0) -- send player a warning
+					self.timerRadioMessage = 10
+					self.usedNight = 1
+				end
+			end
+		end
+		-- self.biomeTimer = self.biomeTimer - dt
+		-- if (self.biomeTimer <= 0) then
+		--
+		-- 	self.biomeTimer = self.baseRate
+		-- end
 		-- Set damage totals.
 		self.damageApply = setEffectDamage()
 		self.debuffApply = setEffectDebuff()

--- a/stats/effects/fu_weathereffects/new/desert/desertweathernewdeadly.lua
+++ b/stats/effects/fu_weathereffects/new/desert/desertweathernewdeadly.lua
@@ -1,4 +1,9 @@
 require("/scripts/vec2.lua")
+
+--[[ TODO: This file is identical to desertweathernew.lua - it could be
+			removed. The .statuseffect file links to desertweathernew.lua instead.]]--
+
+
 function init()
 	self.timerRadioMessage = 0  -- initial delay for secondary radiomessages
 

--- a/stats/effects/fu_weathereffects/new/desert/desertweathernewdeadly.statuseffect
+++ b/stats/effects/fu_weathereffects/new/desert/desertweathernewdeadly.statuseffect
@@ -4,20 +4,20 @@
 
   "effectConfig" : {
           "effectCutoff" : "fireResistance",
-          "effectCutoffValue" : 0.6,    
-	  "biomeTemp" : 0.75, 
+          "effectCutoffValue" : 0.6,
+	  "biomeTemp" : 0.75,
 	  "biomeThreshold" : 0.75,
 	  "baseRate" : 6,
 	  "baseDebuffPerTick" : 3,
 	  "baseDmgPerTick" : 6,
 	  "situationPenalty" : 1,
 	  "liquidPenalty" : 0.45,
-	  "biomeNight" : 0.01	    
+	  "biomeNight" : 0.01
   },
   "defaultDuration" : 2,
 
   "scripts" : [
-    "desertweathernewdeadly.lua"
+    "desertweathernew.lua"
   ],
 
   "animationConfig" : "desertweathernew.animation",

--- a/stats/effects/fu_weathereffects/new/electric/electricweathernew.lua
+++ b/stats/effects/fu_weathereffects/new/electric/electricweathernew.lua
@@ -29,9 +29,29 @@ function init()
 	script.setUpdateDelta(5)
 end
 
---******* check effect and cancel ************
+--[[ Helper function to determine if weather effect applies to an entity ]]--
+function isEntityAffected()
+	-- if not a player, or world type is "unknown" (???) then return false --
+	if ((world.entityType(entity.id()) ~= "player") or
+	world.type()=="unknown") then
+		return false
+	end
+	-- if player does not have energy (for some reason), return false --
+	if not status.isResource("energy") then
+		return false
+	end
+	-- if player has immunity stat or sufficient resistance, return false --
+	if (status.statPositive("biomeelectricImmunity") or
+	(status.stat("electricResistance",0) >= self.effectCutoffValue)) then
+		return false
+	end
+	-- otherwise, return true
+	return true
+end
+
+--[[ Check if weather effect is still applicable (no visual effects) ]]--
 function checkEffectValid()
-	if not status.isResource("energy") or not entity.entityType("player") or entity.entityType("npc") or (status.stat("electricResistance",0)  >= self.effectCutoffValue) or status.statPositive("biomeelectricImmunity") or world.type()=="unknown" then
+	if not isEntityAffected() then
 		effect.expire()
 	end
 end
@@ -53,13 +73,10 @@ function isWet()
 	return entityPos and (world.liquidAt(vec2.add(entityPos, mouthPos)) and ((liquid==1) or (liquid==6) or (liquid==58) or (liquid==12)))
 end
 
-
-
 function update(dt)
 	checkEffectValid()
-
-	self.biomeTimer = self.biomeTimer - dt
-	self.biomeTimer2 = self.biomeTimer2 - dt
+	--self.biomeTimer = self.biomeTimer - dt
+	--self.biomeTimer2 = self.biomeTimer2 - dt
 
 	if not world.underground(mcontroller.position()) then
 		if status.isResource(warningResource1) then

--- a/stats/effects/fu_weathereffects/new/gasworldnew/gasworldnew.lua
+++ b/stats/effects/fu_weathereffects/new/gasworldnew/gasworldnew.lua
@@ -26,44 +26,48 @@ function init()
 	script.setUpdateDelta(5)
 end
 
+--[[ Helper function to determine if weather effect applies to an entity ]]--
+function isEntityAffected()
+	-- if not a player, or world type is "unknown" (???) then return false --
+	if ((world.entityType(entity.id()) ~= "player") or
+	world.type()=="unknown") then
+		return false
+	end
+	-- if player has immunity stat or sufficient resistance, return false --
+	if (status.statPositive("extremepressureProtection") or
+	(status.stat("physicalResistance",0) >= self.effectCutoffValue)) then
+		return false
+	end
+	-- otherwise, return true
+	return true
+end
 
-
---******* check effect and cancel ************
+--[[ Check if weather effect is still applicable and handle visual effects ]]--
 function checkEffectValid()
-	if world.entityType(entity.id()) ~= "player" then
+	-- remove effect if no longer affected
+	if not isEntityAffected() then
+		deactivateVisualEffects()
 		effect.expire()
-	end
-	if status.statPositive("extremepressureProtection") or world.type()=="unknown" then
-		effect.expire()
-	end
-
-	-- checks strength of effect vs resistance
-	if ( status.stat("physicalResistance",0)  >= self.effectCutoffValue ) then
-		effect.expire()
+	-- add visual effect and display warning (if not yet shown)
 	else
-		-- activate visuals and check stats
+		activateVisualEffects()
+		-- display a random warning
 		if (self.timerRadioMessage <= 0) and (self.usedIntro == 0) then
-			if math.random(3) == 3 then
+			local rand = math.random(4)
+			if rand == 1 then
 				world.sendEntityMessage(entity.id(), "queueRadioMessage", "fubiomepressure", 1.0) -- send player a warning
-				self.usedIntro = 1
-				self.timerRadioMessage = 20
-			elseif math.random == 2 then
+			elseif rand == 2 then
 				world.sendEntityMessage(entity.id(), "queueRadioMessage", "fubiomepressure2", 1.0) -- send player a warning
-				self.usedIntro = 1
-				self.timerRadioMessage = 20
-			elseif math.random == 1 then
+			elseif rand == 3 then
 				world.sendEntityMessage(entity.id(), "queueRadioMessage", "fubiomepressure3", 1.0) -- send player a warning
-				self.usedIntro = 1
-				self.timerRadioMessage = 20
-			else
+			else -- rand == 4, obviously
 				world.sendEntityMessage(entity.id(), "queueRadioMessage", "fubiomepressure4", 1.0) -- send player a warning
-				self.usedIntro = 1
-				self.timerRadioMessage = 20
 			end
+			self.usedIntro = 1
+			self.timerRadioMessage = 20
 		end
 	end
 end
-
 
 -- *******************Damage effects
 function setEffectDamage()
@@ -146,22 +150,25 @@ end
 
 function activateVisualEffects()
 	effect.setParentDirectives("fade=306630=0.8")
-	local statusTextRegion = { 0, 1, 0, 1 }
-	animator.setParticleEmitterOffsetRegion("statustext", statusTextRegion)
-	animator.burstParticleEmitter("statustext")
+end
+
+function deactivateVisualEffects()
+	effect.setParentDirectives("fade=306630=1.0")
 end
 
 
 function makeAlert()
 	world.spawnProjectile( "teslaboltsmall", mcontroller.position(), entity.id(),directionTo,false,{power = 0,damageTeam = sourceDamageTeam})
 	animator.playSound("bolt")
+	local statusTextRegion = { 0, 1, 0, 1 }
+	animator.setParticleEmitterOffsetRegion("statustext", statusTextRegion)
+	animator.burstParticleEmitter("statustext")
 end
 
 
 function update(dt)
 	checkEffectValid()
 
-	self.biomeTimer = self.biomeTimer - dt
 	self.timerRadioMessage = self.timerRadioMessage - dt
 
 	self.windLevel =  world.windLevel(mcontroller.position()) or 1
@@ -180,12 +187,14 @@ function update(dt)
 	self.debuffApply = setEffectDebuff()
 
 	-- environment checks
-	daytime = daytimeCheck()
-	underground = undergroundCheck()
+	local daytime = daytimeCheck()
+	local underground = undergroundCheck()
 	local lightLevel = getLight()
 
-	if ( self.biomeTimer <= 0 ) then
-		if (status.stat("physicalResistance") <=  self.effectCutoffValue ) then
+	if isEntityAffected() then
+		self.biomeTimer = self.biomeTimer - dt
+		if ( self.biomeTimer <= 0 ) then
+			-- Pressure is three times worse during the day. Not sure why.
 			if daytime then
 				if (self.timerRadioMessage <= 0) then
 					if not self.usedIntro2 then
@@ -194,9 +203,7 @@ function update(dt)
 						self.timerRadioMessage = 220
 					end
 				end
-				status.modifyResource("health", -((self.damageApply * self.situationPenalty)*3) * dt)
-				makeAlert()
-				activateVisualEffects()
+				status.modifyResource("health", -self.damageApply * self.situationPenalty * 3 * dt)
 			else
 				if (self.timerRadioMessage <= 0) then
 					if not self.usedIntro3 then
@@ -205,11 +212,10 @@ function update(dt)
 						self.timerRadioMessage = 220
 					end
 				end
-				status.modifyResource("health", -(self.damageApply * self.situationPenalty) * dt)
-				makeAlert()
-				activateVisualEffects()
+				status.modifyResource("health", -self.damageApply * self.situationPenalty * dt)
 			end
-				-- add wind modifiers
+			makeAlert()
+			-- add wind modifiers
 			if self.windLevel >= 40 then
 				self.biomeThreshold = self.biomeThreshold + (self.windLevel / 100)
 				if (self.timerRadioMessage <= 0) then
@@ -220,9 +226,9 @@ function update(dt)
 					end
 				end
 			end
-		end
-		self.biomeTimer = setEffectTime()
-	end
+			self.biomeTimer = setEffectTime()
+		end -- self.biomeTimer <= 0
+	end -- isEntityAffected()
 end
 
 function uninit()

--- a/stats/effects/fu_weathereffects/new/gasworldnew/gasworldnew.lua
+++ b/stats/effects/fu_weathereffects/new/gasworldnew/gasworldnew.lua
@@ -153,7 +153,7 @@ function activateVisualEffects()
 end
 
 function deactivateVisualEffects()
-	effect.setParentDirectives("fade=306630=1.0")
+	effect.setParentDirectives("fade=306630=0")
 end
 
 

--- a/stats/effects/fu_weathereffects/new/heat/heatweathernew.lua
+++ b/stats/effects/fu_weathereffects/new/heat/heatweathernew.lua
@@ -128,9 +128,7 @@ end
 
 function isDry()
 	local mouthPosition = vec2.add(mcontroller.position(), status.statusProperty("mouthPosition"))
-	if not world.liquidAt(mouthPosition) then
-		inWater = 0
-	end
+	return not world.liquidAt(mouthPosition)
 end
 
 function hungerLevel()
@@ -167,8 +165,7 @@ end
 
 function update(dt)
 	checkEffectValid()
-	self.biomeTimer = self.biomeTimer - dt
-	self.biomeTimer2 = self.biomeTimer2 - dt
+	--self.biomeTimer2 = self.biomeTimer2 - dt
 	self.timerRadioMessage = self.timerRadioMessage - dt
 
 	--set the base stats

--- a/stats/effects/fu_weathereffects/new/heat/heatweathernew.lua
+++ b/stats/effects/fu_weathereffects/new/heat/heatweathernew.lua
@@ -29,24 +29,33 @@ function init()
 	script.setUpdateDelta(5)
 end
 
+--[[ Helper function to determine if weather effect applies to an entity ]]--
+function isEntityAffected()
+	-- if not a player, or world type is "unknown" (???) then return false --
+	if ((world.entityType(entity.id()) ~= "player") or
+	world.type()=="unknown") then
+		return false
+	end
+	-- if player has immunity stat or sufficient resistance, return false --
+	if (status.statPositive("biomeheatImmunity") or
+	status.statPositive("ffextremeheatImmunity") or
+	(status.stat("fireResistance",0) >= self.effectCutoffValue)) then
+		return false
+	end
+	-- otherwise, return true
+	return true
+end
 
---******* check effect and cancel ************
+--[[ Check if weather effect is still applicable, and handle visual effects ]]--
 function checkEffectValid()
-	if world.entityType(entity.id()) ~= "player" then
+	-- remove visual effect if no longer affected
+	if not isEntityAffected() then
 		deactivateVisualEffects()
 		effect.expire()
-	end
-	if status.statPositive("biomeheatImmunity") or status.statPositive("ffextremeheatImmunity") or world.type()=="unknown" then
-		deactivateVisualEffects()
-		effect.expire()
-	end
-
-	if (status.stat("fireResistance",0)  >= self.effectCutoffValue) then
-		deactivateVisualEffects()
-		effect.expire()
+	-- add visual effect and display warning (if not yet shown)
 	else
-		-- activate visuals and check stats
-		if not self.usedIntro and self.timerRadioMessage == 0 then
+		activateVisualEffects()
+		if not self.usedIntro and self.timerRadioMessage <= 0 then
 			world.sendEntityMessage(entity.id(), "queueRadioMessage", "biomeheat", 1.0) -- send player a warning
 			self.usedIntro = 1
 			self.timerRadioMessage = 20
@@ -177,46 +186,43 @@ function update(dt)
 	self.debuffApply = setEffectDebuff()
 
 	-- environment checks
-	daytime = daytimeCheck()
-	underground = undergroundCheck()
+	local daytime = daytimeCheck()
+	local underground = undergroundCheck()
 	local lightLevel = getLight()
 
-	if underground then
-		if not self.usedCavern then
-			world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomeheatcavern", 1.0) -- send player a warning
-			self.timerRadioMessage = 10
-			self.usedCavern = 1
-		end
-		activateVisualEffects()
-		setSituationPenalty()
-	end
-
-	self.damageApply = setEffectDamage()
-	self.debuffApply = setEffectDebuff()
-
-	if (status.stat("fireResistance",0)) < (self.effectCutoffValue) then
-		activateVisualEffects()
+	if isEntityAffected() then
+		self.biomeTimer = self.biomeTimer - dt
+		if self.biomeTimer <= 0 then
+			-- Heat is worse underground.
+			if underground then
+				if not self.usedCavern then
+					self.setSituationPenalty()
+					world.sendEntityMessage(entity.id(), "queueRadioMessage", "ffbiomeheatcavern", 1.0) -- send player a warning
+					self.timerRadioMessage = 10
+					self.usedCavern = 1
+				end
+			end
+			self.biomeTimer = self.baseRate
+		end -- self.biomeTimer <= 0
+		-- Set total damage.
+		self.damageApply = setEffectDamage()
+		self.debuffApply = setEffectDebuff()
+		-- Set movement penalty.
+		self.modifier = math.max(status.stat("fireResistance",0), 0) + 0.3
+		-- Apply health drain.
 		status.modifyResource("health", -self.damageApply * dt)
+		-- Apply hunger drain (if not casual).
 		if status.isResource("food") then
 			if status.resource("food") >= 2 then
 				status.modifyResource("food", (-self.debuffApply /12) * dt )
 			end
 		end
-		if self.biomeTimer2 <= 0 and status.stat("fireResistance",0) < 1.0 then
-			--makeAlert()
-			self.biomeTimer2 = setEffectTime()
-			self.timerRadioMessage = self.timerRadioMessage - dt
-		end
-		self.modifier = status.stat("fireResistance",0)
-		if (status.stat("fireResistance",0) <= 0) then
-			self.modifier = 0
-		end
-		self.modifier = self.modifier + 0.3
+		-- Apply movement penalty.
 		mcontroller.controlModifiers({
 			airJumpModifier = self.modifier,
 			speedModifier = self.modifier
 		})
-	end
+	end -- isEntityAffected()
 end
 
 function uninit()

--- a/stats/effects/fu_weathereffects/new/poison/poisonweathernewbiome.lua
+++ b/stats/effects/fu_weathereffects/new/poison/poisonweathernewbiome.lua
@@ -1,5 +1,8 @@
 require("/scripts/vec2.lua")
 
+--[[ TODO: This file is identical to poisonweathernew.lua - it could be
+			removed. The .statuseffect file links to poisonweathernew.lua instead.]]--
+
 function init()
 
 	self.timerRadioMessage = 0  -- initial delay for secondary radiomessages

--- a/stats/effects/fu_weathereffects/new/poison/poisonweathernewbiome.statuseffect
+++ b/stats/effects/fu_weathereffects/new/poison/poisonweathernewbiome.statuseffect
@@ -4,8 +4,8 @@
 
   "effectConfig" : {
           "effectCutoff" : "poisonResistance",
-          "effectCutoffValue" : 0.35,   
-	  "biomeTemp" : 1, 
+          "effectCutoffValue" : 0.35,
+	  "biomeTemp" : 1,
 	  "biomeThreshold" : 1,
 	  "baseRate" : 5,
 	  "baseDebuffPerTick" : 2,
@@ -14,11 +14,11 @@
 	  "liquidPenalty" : 1.1,
 	  "biomeNight" : 1.1
   },
-  
+
   "defaultDuration" : 20,
 
   "scripts" : [
-    "poisonweathernewbiome.lua"
+    "poisonweathernew.lua"
   ],
 
   "animationConfig" : "poisonweathernew.animation",

--- a/stats/effects/fu_weathereffects/new/protoworld/protoweather.lua
+++ b/stats/effects/fu_weathereffects/new/protoworld/protoweather.lua
@@ -15,40 +15,49 @@ function init()
 
 	--timers
 	self.biomeTimer = self.baseRate
-	self.biomeTimer2 = (self.baseRate * (1 + status.stat("poisonResistance",0)) *10)
+	self.biomeTimer2 = self.baseRate * (1 + status.stat("poisonResistance",0)) * 10
+	--[[TODO: biomeTimer2 always seems to initialise at 20 times the base rate,
+			rather than 10... Not sure why.]]--
 
 	checkEffectValid()
 
 	script.setUpdateDelta(5)
 end
 
+--[[ Helper function to determine if weather effect applies to an entity ]]--
+function isEntityAffected()
+	-- if not a player, or world type is "unknown" (???) then return false --
+	if ((world.entityType(entity.id()) ~= "player") or
+	world.type()=="unknown") then
+		return false
+	end
+	-- if player has immunity stat or sufficient resistance, return false --
+	if (status.statPositive("protoImmunity") or
+	(status.stat("poisonResistance",0) >= self.effectCutoffValue)) then
+		return false
+	end
+	-- otherwise, return true
+	return true
+end
 
---******* check effect and cancel ************
+--[[ Check if weather effect is still applicable, and handle visual effects ]]--
 function checkEffectValid()
-	if world.entityType(entity.id()) ~= "player" then
+	-- remove visual effect if no longer affected
+	if not isEntityAffected() then
 		deactivateVisualEffects()
-		effect.expire()
-	end
-	if status.statPositive("protoImmunity") or world.type()=="unknown" then
-		deactivateVisualEffects()
-		effect.expire()
-	end
-
-	-- checks strength of effect vs resistance
-	if ( status.stat("poisonResistance",0)  >= self.effectCutoffValue ) then
 		deactivateVisualEffects2()
-		deactivateVisualEffects()
 		effect.expire()
+	-- add visual effect and display warning (if not yet shown)
 	else
-		-- activate visuals and check stats
-		if not self.usedIntro and (self.timerRadioMessage == 0) then
+		activateVisualEffects()
+		--activateVisualEffects2() is called on a timer.
+		if not self.usedIntro and self.timerRadioMessage <= 0 then
 			world.sendEntityMessage(entity.id(), "queueRadioMessage", "fubiomeproto", 1.0) -- send player a warning
 			self.usedIntro = 1
 			self.timerRadioMessage = 20
 		end
 	end
 end
-
 
 -- *******************Damage effects
 function setEffectDamage()
@@ -115,9 +124,7 @@ end
 
 function isDry()
 	local mouthPosition = vec2.add(mcontroller.position(), status.statusProperty("mouthPosition"))
-	if not world.liquidAt(mouthPosition) then
-		inWater = 0
-	end
+	return not world.liquidAt(mouthPosition)
 end
 
 function hungerLevel()
@@ -162,8 +169,6 @@ end
 
 function update(dt)
 	checkEffectValid()
-	self.biomeTimer = self.biomeTimer - dt
-	self.biomeTimer2 = self.biomeTimer2 - dt
 	self.timerRadioMessage = self.timerRadioMessage - dt
 
 --set the base stats
@@ -182,46 +187,49 @@ function update(dt)
 
 	-- environment checks
 	local lightLevel = getLight()
-	daytime = daytimeCheck()
-	underground = undergroundCheck()
+	local daytime = daytimeCheck()
+	local underground = undergroundCheck()
+	local dry = isDry()
 
-	if self.biomeTimer <= 0 and status.stat("poisonResistance",0) < self.effectCutoffValue then
+	if isEntityAffected() then
+		-- Proto poison is slightly worse during the night.
+		-- TODO: Why are we using setSituationPenalty instead of setNightPenalty?
 		if not daytime then
-				setSituationPenalty()
+			setSituationPenalty()
 		end
 		self.damageApply = setEffectDamage()
 		self.debuffApply = setEffectDebuff()
-		
-		configBombDrop = {}
-		world.spawnProjectile("maxhealthdown", mcontroller.position(), entity.id(), {0, 60}, false, configBombDrop)
-		
-		-- damage application per tick
-		status.applySelfDamageRequest ({
-			damageType = "IgnoresDef",
-			damage = self.damageApply,
-			damageSourceKind = "poison",
-			sourceEntityId = entity.id()
-		})
-
-		activateVisualEffects()
-
-		self.biomeTimer = self.baseRate
-	end
-	if self.biomeTimer2 <= 0 and status.stat("poisonResistance",0) < self.effectCutoffValue then
-		if status.stat("critChance",0) >=1 then
-			effect.addStatModifierGroup({
-				{stat = "maxHealth", amount = -self.debuffApply },
-				{stat = "critChance", amount = -self.debuffApply }
+		self.biomeTimer = self.biomeTimer - dt
+		if self.biomeTimer <= 0 then
+			-- Apply periodic damage
+			status.applySelfDamageRequest({
+				damageType = "IgnoresDef",
+				damage = self.damageApply,
+				damageSourceKind = "poison",
+				sourceEntityId = entity.id()
 			})
-		else
-			effect.addStatModifierGroup({
-				{stat = "maxHealth", amount = -self.debuffApply }
-			})
+			self.biomeTimer = self.baseRate
 		end
-		activateVisualEffects2()
-		self.biomeTimer2 = (self.biomeTimer * (1 + status.stat("poisonResistance",0))) * 2
-	end
-
+		self.biomeTimer2 = self.biomeTimer2 - dt
+		if self.biomeTimer2 <= 0 then
+			-- Extra "HP down" particle because people don't seem to notice
+			configBombDrop = {}
+			world.spawnProjectile("maxhealthdown", mcontroller.position(), entity.id(), {0, 60}, false, configBombDrop)
+			-- Periodically drain crit chance and max health.
+			if status.stat("critChance",0) >= 1 then
+				effect.addStatModifierGroup({
+					{stat = "maxHealth", amount = -self.debuffApply},
+					{stat = "critChance", amount = -self.debuffApply}
+				})
+			else
+				effect.addStatModifierGroup({
+					{stat = "maxHealth", amount = -self.debuffApply}
+				})
+			end
+			activateVisualEffects2()
+			self.biomeTimer2 = self.baseRate * (1 + status.stat("poisonResistance",0)) * 2
+		end
+	end --isEntityAffected()
 end
 
 function uninit()

--- a/stats/effects/fu_weathereffects/new/sulphuric/sulphuricweatherstorm.lua
+++ b/stats/effects/fu_weathereffects/new/sulphuric/sulphuricweatherstorm.lua
@@ -1,5 +1,8 @@
 require("/scripts/vec2.lua")
 
+--[[ TODO: This file is identical to sulphuricweathernew.lua - it could be
+			removed. The .statuseffect files link to sulphuricweathernew.lua instead.]]--
+
 function init()
 	self.timerRadioMessage = 0  -- initial delay for secondary radiomessages
 

--- a/stats/effects/fu_weathereffects/new/sulphuric/sulphuricweatherstorm.statuseffect
+++ b/stats/effects/fu_weathereffects/new/sulphuric/sulphuricweatherstorm.statuseffect
@@ -4,20 +4,20 @@
 
   "effectConfig" : {
           "effectCutoff" : "physicalResistance",
-          "effectCutoffValue" : 0.55,     
-	  "biomeTemp" : 1.05, 
+          "effectCutoffValue" : 0.55,
+	  "biomeTemp" : 1.05,
 	  "biomeThreshold" : 0.5,
 	  "baseRate" : 4,
 	  "baseDebuffPerTick" : 2,
 	  "baseDmgPerTick" : 1,
 	  "situationPenalty" : 1.1,
 	  "liquidPenalty" : 0.9,
-	  "biomeNight" : 1.0 
+	  "biomeNight" : 1.0
   },
   "defaultDuration" : 5,
 
   "scripts" : [
-    "sulphuricweatherstorm.lua"
+    "sulphuricweathernew.lua"
   ],
 
   "animationConfig" : "sulphuricweathernew.animation",

--- a/stats/effects/fu_weathereffects/new/sulphuric/sulphuricweatherstorm2.statuseffect
+++ b/stats/effects/fu_weathereffects/new/sulphuric/sulphuricweatherstorm2.statuseffect
@@ -4,20 +4,20 @@
 
   "effectConfig" : {
           "effectCutoff" : "physicalResistance",
-          "effectCutoffValue" : 0.7,     
-	  "biomeTemp" : 1.08, 
+          "effectCutoffValue" : 0.7,
+	  "biomeTemp" : 1.08,
 	  "biomeThreshold" : 0.7,
 	  "baseRate" : 4,
 	  "baseDebuffPerTick" : 2,
 	  "baseDmgPerTick" : 2,
 	  "situationPenalty" : 1.1,
 	  "liquidPenalty" : 0.9,
-	  "biomeNight" : 1.0 
+	  "biomeNight" : 1.0
   },
   "defaultDuration" : 5,
 
   "scripts" : [
-    "sulphuricweatherstorm.lua"
+    "sulphuricweathernew.lua"
   ],
 
   "animationConfig" : "sulphuricweathernew.animation",

--- a/stats/effects/fu_weathereffects/new/sulphuric/sulphuricweatherstorm3.statuseffect
+++ b/stats/effects/fu_weathereffects/new/sulphuric/sulphuricweatherstorm3.statuseffect
@@ -4,20 +4,20 @@
 
   "effectConfig" : {
           "effectCutoff" : "physicalResistance",
-          "effectCutoffValue" : 0.95,     
-	  "biomeTemp" : 1.3, 
+          "effectCutoffValue" : 0.95,
+	  "biomeTemp" : 1.3,
 	  "biomeThreshold" : 0.7,
 	  "baseRate" : 4,
 	  "baseDebuffPerTick" : 2,
 	  "baseDmgPerTick" : 3,
 	  "situationPenalty" : 1.1,
 	  "liquidPenalty" : 0.9,
-	  "biomeNight" : 1.0 
+	  "biomeNight" : 1.0
   },
   "defaultDuration" : 5,
 
   "scripts" : [
-    "sulphuricweatherstorm.lua"
+    "sulphuricweathernew.lua"
   ],
 
   "animationConfig" : "sulphuricweathernew.animation",


### PR DESCRIPTION
This is a somewhat extensive revamp and clean-up of the various FU weather .lua files. I've tried to make their behaviours a bit more consistent in preparation for a common library implementation. While doing the rework, I believe the following bugs/issues have been fixed:
* All relevant immunity stats should now protect against weather effects, even if they are not the selected blockingStat (previously, only the blockingStat or resistance threshold would work).
* Some of the issues with spamming the SAIL warnings should be fixed (for example Aether warnings when beaming back to ship).
* Weird behaviours where the weather or radio-message timers ticked down multiple times have been removed.
* Movement penalties when at low health in Desert (25% HP) and Jungle (33% HP) biome weathers are now correctly implemented.
* Fixed randomised messages for Insanity and Pressure weather effects.
* Internally, effects should hopefully no longer be expired and re-applied every tick.

The system in general would greatly benefit from the use of a common library file, since the .lua files are 70-80% repeated code. So consider this a short-term fix. I've tested each of the weather effects by beaming down to planets and testing debuffs, immunity stats and resistances. But I would of course recommend that you test it yourself before merging.