### PR TITLE
Fix Capture Gun to be properly one-handed

### DIFF
--- a/items/active/weapons/ranged/unrand/capturegun/capturegun.activeitem
+++ b/items/active/weapons/ranged/unrand/capturegun/capturegun.activeitem
@@ -10,7 +10,7 @@
   "category" : "assaultrifle",
   "itemTags" : ["weapon","ranged","assaultrifle"],
   "tooltipKind" : "gun2",
-  "twoHanded" : false,
+  "twoHanded" : true,
   "animation" : "/items/active/weapons/ranged/gun.animation",
   "animationParts" : {
     "butt" : "",
@@ -47,7 +47,7 @@
       "idle" : {
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : false,
+        "twoHanded" : true,
 
         "allowRotate" : true,
         "allowFlip" : true
@@ -56,7 +56,7 @@
         "duration" : 0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : false,
+        "twoHanded" : true,
 
         "allowRotate" : false,
         "allowFlip" : false
@@ -65,7 +65,7 @@
         "duration" : 0.0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : false,
+        "twoHanded" : true,
 
         "allowRotate" : false,
         "allowFlip" : false

--- a/items/active/weapons/ranged/unrand/capturegun/capturegun.activeitem
+++ b/items/active/weapons/ranged/unrand/capturegun/capturegun.activeitem
@@ -17,10 +17,10 @@
     "middle" : "capturegun.png",
     "barrel" : "",
     "muzzleFlash" : ""
-  },      
+  },
   "animationCustom" : {
     "sounds" : { "fire" : [ "/sfx/gun/pumpgun_blast1.ogg" ] },
-    "lights" : { "muzzleFlash" : {"color" : [22, 124, 84] } }  
+    "lights" : { "muzzleFlash" : {"color" : [22, 124, 84] } }
   },
 
   "baseOffset" : [0.8, 0.34],
@@ -40,14 +40,14 @@
     "fireType" : "auto",
     "projectileCount" : 1,
     "projectileType" : "capturepodgun",
-        
-    
-    
+
+
+
     "stances" : {
       "idle" : {
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : true,
         "allowFlip" : true
@@ -56,7 +56,7 @@
         "duration" : 0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false
@@ -65,7 +65,7 @@
         "duration" : 0.0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false


### PR DESCRIPTION
The Capture Gun's stances had the `twoHanded` attribute set to `true`, causing it to hide items in the other hand. Easy fix :)