### PR TITLE
Changes to make requesting small amounts of items easier from terminal

### DIFF
--- a/interface/kheAA/kheAA_terminal/kheAA_terminalGui.config
+++ b/interface/kheAA/kheAA_terminal/kheAA_terminalGui.config
@@ -125,7 +125,7 @@
 			"textAlign": "center",
 			"maxWidth": 32,
 			"regex": "^\\d{0,6}$",
-			"hint": "------"
+			"hint": "1"
 		},
 		"refresh" : {
 			"type" : "button",

--- a/interface/kheAA/kheAA_terminal/kheAA_terminalGui.config
+++ b/interface/kheAA/kheAA_terminal/kheAA_terminalGui.config
@@ -124,7 +124,7 @@
 			"position": [16, 26],
 			"textAlign": "center",
 			"maxWidth": 32,
-			"regex": "\\d{0,6}",
+			"regex": "^\\d{0,6}$",
 			"hint": "------"
 		},
 		"refresh" : {

--- a/interface/kheAA/kheAA_terminal/kheAA_terminalGui.lua
+++ b/interface/kheAA/kheAA_terminal/kheAA_terminalGui.lua
@@ -163,6 +163,16 @@ function request()
 	end
 end
 
+function updateListItem(selectedItem, count)
+	if count > 0 then
+		widget.setText(itemList .. "." .. selectedItem .. ".amount", "x" .. count);
+		deltatime=0
+	else
+		deltatime=29.9
+		refreshList();
+	end
+end
+
 function requestAllButOne()
 	--pane.playerEntityId()
 	local selected = widget.getListSelected(itemList)
@@ -177,8 +187,7 @@ function requestAllButOne()
 				world.sendEntityMessage(pane.containerEntityId(), "transferItem",itemToSend)
 				--table.remove(items, i);
 				items[i][2].count=1
-				deltatime=29.9
-				refreshList();
+				updateListItem(selected, 1)
 				return;
 			end
 		end
@@ -205,16 +214,6 @@ end
 
 
 ]]
-
-function updateListItem(selectedItem, count)
-	if count > 0 then
-		widget.setText(itemList .. "." .. selectedItem .. ".amount", "x" .. count);
-		deltatime=0
-	else
-		deltatime=29.9
-		refreshList();
-	end
-end
 
 function requestOne()
 	local text = widget.getText("requestAmount")

--- a/interface/kheAA/kheAA_terminal/kheAA_terminalGui.lua
+++ b/interface/kheAA/kheAA_terminal/kheAA_terminalGui.lua
@@ -206,9 +206,22 @@ end
 
 ]]
 
+function updateListItem(selectedItem, count)
+	if count > 0 then
+		widget.setText(itemList .. "." .. selectedItem .. ".amount", "x" .. count);
+		deltatime=0
+	else
+		deltatime=29.9
+		refreshList();
+	end
+end
+
 function requestOne()
 	local text = widget.getText("requestAmount")
-	if text ~= "" and tonumber(text) >= 0 then
+	if text == "" then
+		text = "1"
+	end
+	if tonumber(text) >= 0 then
 		--pane.playerEntityId()
 		--itemData={containerID, index}, itemDescriptor, itemConfig,pos
 		local selected = widget.getListSelected(itemList)
@@ -218,14 +231,12 @@ function requestOne()
 					local itemToSend=copy(items[i])
 					--sb.logInfo("%s",itemToSend)
 					itemToSend[2].count=math.min(tonumber(text),itemToSend[2].count)
+					items[i][2].count = items[i][2].count - itemToSend[2].count
 
 					table.insert(itemToSend,world.entityPosition(pane.playerEntityId()))
 					--sb.logInfo(sb.printJson({playerPos=temp}))
 					world.sendEntityMessage(pane.containerEntityId(), "transferItem",itemToSend)
-					--table.remove(items, i);
-					items[i][2].count=items[i][2].count-1
-					deltatime=29.9
-					refreshList();
+					updateListItem(selected, items[i][2].count)
 					return;
 				end
 			end


### PR DESCRIPTION
This is the first iteration. Aside from being easier to request small amount of items, it should also be faster / less laggy. I'm planning on going further down that path but ran into issues with SB's scripting. Assuming everyone likes this change as much as I do, and I can get around those issues, I plan on further improvements along these same lines.

I talked to Kherae about this as requested and she liked it.