### PR TITLE
Fix for resistances applying twice to damage-over-time effects

### DIFF
--- a/stats/effects/burning/burning.lua
+++ b/stats/effects/burning/burning.lua
@@ -3,26 +3,19 @@ function init()
   animator.setParticleEmitterActive("flames", true)
   effect.setParentDirectives("fade=BF3300=0.25")
   animator.playSound("burn", -1)
-  
+
   script.setUpdateDelta(5)
 
   self.tickDamagePercentage = 0.025
   self.tickTime = 1.0
   self.tickTimer = self.tickTime
-  
+
   self.baseDmg = 6
 
 end
 
-
-function setEffectDamage()
-  return ( ( self.baseDmg ) *  (1 -status.stat("fireResistance",0) ) )
-end
-
-
 function update(dt)
   if (status.stat("fireResistance") <= 0.65) then
-  	self.damageApply = setEffectDamage() 
 	  if effect.duration() and world.liquidAt({mcontroller.xPosition(), mcontroller.yPosition() - 1}) then
 	    effect.expire()
 	  end
@@ -33,16 +26,16 @@ function update(dt)
 
 	    status.applySelfDamageRequest({
 		damageType = "IgnoresDef",
-		damage = self.damageApply,
+		damage = self.baseDmg,
 		damageSourceKind = "fire",
 		sourceEntityId = entity.id()
 	      })
 
-	  end    
+	  end
   end
 end
 
 
 function uninit()
-  
+
 end

--- a/stats/effects/fu_tileeffects/gas_effects/shadowgas/shadowgasfx.lua
+++ b/stats/effects/fu_tileeffects/gas_effects/shadowgas/shadowgasfx.lua
@@ -59,7 +59,7 @@ mcontroller.controlParameters(self.liquidMovementParameter)
     self.tickTimer = self.tickTime
     status.applySelfDamageRequest({
         damageType = "IgnoresDef",
-        damage = math.floor(status.resourceMax("health") * self.tickDamagePercentage) + 1,
+        damage = math.ceil(status.resourceMax("health") * self.tickDamagePercentage),
         damageSourceKind = "shadow",
         sourceEntityId = entity.id()
       })

--- a/stats/effects/fu_tileeffects/gas_effects/shadowgas/shadowgasfx2.lua
+++ b/stats/effects/fu_tileeffects/gas_effects/shadowgas/shadowgasfx2.lua
@@ -7,8 +7,8 @@ function init()
   self.tickDamagePercentage = 0.01
   self.tickTime = 1.2
   self.tickTimer = self.tickTime
-  
-  
+
+
   self.liquidMovementParameter = {
     groundForce = 70,
     airForce = 20,
@@ -26,13 +26,13 @@ function init()
       multiJump = false,
       reJumpDelay = 1.05,
       autoJump = false,
-      collisionCancelled = false 
+      collisionCancelled = false
     }
-  }  
+  }
 	if status.statPositive("shadowImmunity") or status.statPositive("shadowgasImmunity") or ( status.stat("shadowResistance",0) > 0.5) then
 	  deactivateVisualEffects()
 	  effect.expire()
-	end  
+	end
 end
 
 function deactivateVisualEffects()
@@ -46,7 +46,7 @@ function activateVisualEffects()
   animator.setParticleEmitterOffsetRegion("statustext", statusTextRegion)
   animator.burstParticleEmitter("statustext")
 end
-  
+
 
 function update(dt)
 	if status.statPositive("shadowImmunity") or status.statPositive("shadowgasImmunity") or ( status.stat("shadowResistance",0) > 0.5) then
@@ -60,12 +60,12 @@ mcontroller.controlParameters(self.liquidMovementParameter)
     self.tickTimer = self.tickTime
     status.applySelfDamageRequest({
         damageType = "IgnoresDef",
-        damage = math.floor(status.resourceMax("health") * self.tickDamagePercentage) + 1,
+        damage = math.ceil(status.resourceMax("health") * self.tickDamagePercentage),
         damageSourceKind = "shadow",
         sourceEntityId = entity.id()
       })
   end
-  
+
 end
 
 function uninit()

--- a/stats/effects/fu_tileeffects/poison_effects/biooozepoison/biooozepoison.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/biooozepoison/biooozepoison.lua
@@ -4,23 +4,18 @@ function init()
   script.setUpdateDelta(5)
   self.tickTime = 2.0
   self.tickTimer = self.tickTime
-  self.baseDamage = setEffectDamage()
+  self.baseDamage = config.getParameter("healthDown",0)
   self.baseTime = setEffectTime()
 end
 
-function setEffectDamage()
-  self.baseValue = config.getParameter("healthDown",0)
-  return ( self.baseValue *  (1 -status.stat("poisonResistance",0) )  )
-end
-
 function setEffectTime()
-  return (  self.tickTimer *  math.min(   1 - math.min( status.stat("poisonResistance",0) ),0.45))
+  return self.tickTimer * math.min(1 - status.stat("poisonResistance",0), 0.45)
 end
 
 function update(dt)
   	if ( status.stat("poisonResistance",0)  >= 0.4 ) then
-	  effect.expire() 
-	end  
+	  effect.expire()
+	end
   if status.isResource("food") then
       hungerLevel = status.resource("food")
   else
@@ -28,7 +23,7 @@ function update(dt)
   end
 
   self.tickTimer = self.tickTimer - dt
-  
+
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime
     status.applySelfDamageRequest({

--- a/stats/effects/fu_tileeffects/poison_effects/contaminatedpoison/contaminatedpoison.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/contaminatedpoison/contaminatedpoison.lua
@@ -4,23 +4,18 @@ function init()
   script.setUpdateDelta(5)
   self.tickTime = 3.0
   self.tickTimer = self.tickTime
-  self.baseDamage = setEffectDamage()
-  self.baseTime = setEffectTime() 
-end
-
-function setEffectDamage()
-  self.baseValue = config.getParameter("healthDown",0)
-  return ( self.baseValue *  (1 -status.stat("poisonResistance",0) )  )
+  self.baseDamage = config.getParameter("healthDown",0)
+  self.baseTime = setEffectTime()
 end
 
 function setEffectTime()
-  return (  self.tickTimer *  math.min(   1 - math.min( status.stat("poisonResistance",0) ),0.45))
+  return self.tickTimer * math.min(1 - status.stat("poisonResistance",0), 0.45)
 end
 
 function update(dt)
   	if ( status.stat("poisonResistance",0)  >= 0.25 ) then
-	  effect.expire() 
-	end  
+	  effect.expire()
+	end
   self.tickTimer = self.tickTimer - dt
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime
@@ -37,5 +32,5 @@ function update(dt)
 end
 
 function uninit()
-  
+
 end

--- a/stats/effects/fu_tileeffects/poison_effects/darkwaterpoison/darkwaterpoison.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/darkwaterpoison/darkwaterpoison.lua
@@ -2,18 +2,13 @@ function init()
   script.setUpdateDelta(5)
   self.tickTime = 1.0
   self.tickTimer = self.tickTime
-  self.baseDamage = setEffectDamage()
+  self.baseDamage = config.getParameter("healthDown",0)
   self.baseTime = setEffectTime()
   activateVisualEffects()
 end
 
-function setEffectDamage()
-  self.baseValue = config.getParameter("healthDown",0)
-  return ( self.baseValue *  (1 -status.stat("poisonResistance",0) )  )
-end
-
 function setEffectTime()
-  return (  self.tickTimer *  math.min(   1 - math.min( status.stat("poisonResistance",0) ),0.45))
+  return self.tickTimer * math.min(1 - status.stat("poisonResistance",0), 0.45)
 end
 
 function activateVisualEffects()
@@ -32,8 +27,8 @@ function update(dt)
 
   	if ( status.stat("poisonResistance",0)  >= 0.5 ) then
   	  deactivateVisualEffects()
-	  effect.expire() 
-	end  
+	  effect.expire()
+	end
   self.tickTimer = self.tickTimer - dt
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime
@@ -50,5 +45,5 @@ end
 
 
 function uninit()
-  
+
 end

--- a/stats/effects/fu_tileeffects/poison_effects/killpod/killpod.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/killpod/killpod.lua
@@ -2,18 +2,13 @@ function init()
   script.setUpdateDelta(5)
   self.tickTime = 1.0
   self.tickTimer = self.tickTime
-  self.baseDamage = setEffectDamage()
+  self.baseDamage = config.getParameter("healthDown",0)
   self.baseTime = setEffectTime()
   activateVisualEffects()
 end
 
-function setEffectDamage()
-  self.baseValue = config.getParameter("healthDown",0)
-  return ( self.baseValue *  (1 -status.stat("poisonResistance",0) )  )
-end
-
 function setEffectTime()
-  return (  self.tickTimer *  math.min(   1 - math.min( status.stat("poisonResistance",0) ),0.45))
+  return self.tickTimer * math.min(1 - status.stat("poisonResistance",0), 0.45)
 end
 
 function activateVisualEffects()
@@ -45,5 +40,5 @@ end
 
 
 function uninit()
-  
+
 end

--- a/stats/effects/fu_tileeffects/poison_effects/mercurypoison/mercurypoison.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/mercurypoison/mercurypoison.lua
@@ -1,19 +1,14 @@
 function init()
   script.setUpdateDelta(5)
   self.tickTime = 3.0
-  self.tickTimer = self.tickTime  
-  self.baseDamage = setEffectDamage()
+  self.tickTimer = self.tickTime
+  self.baseDamage = config.getParameter("healthDown",0)
   self.baseTime = setEffectTime()
   activateVisualEffects()
 end
 
-function setEffectDamage()
-  self.baseValue = config.getParameter("healthDown",0)
-  return ( self.baseValue *  (1 -status.stat("poisonResistance",0) )  )
-end
-
 function setEffectTime()
-  return (  self.tickTimer *  math.min(   1 - math.min( status.stat("poisonResistance",0) ),0.45))
+  return self.tickTimer * math.min(1 - status.stat("poisonResistance",0), 0.45)
 end
 
 function activateVisualEffects()
@@ -31,8 +26,8 @@ end
 function update(dt)
   	if ( status.stat("poisonResistance",0)  >= 0.50 ) and ( status.stat("radioactiveResistance",0)  >= 0.25 ) then
   	  deactivateVisualEffects()
-	  effect.expire() 
-	end  
+	  effect.expire()
+	end
   self.tickTimer = self.tickTimer - dt
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime
@@ -49,5 +44,5 @@ function update(dt)
 end
 
 function uninit()
-  
+
 end

--- a/stats/effects/fu_tileeffects/poison_effects/moltenmetal/moltenmetal.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/moltenmetal/moltenmetal.lua
@@ -2,17 +2,17 @@ function init()
   script.setUpdateDelta(5)
   self.tickTime = 0.5
   self.tickTimer = self.tickTime
-  self.baseDamage = setEffectDamage()
-  self.baseTime = 0.5 
+  self.baseDamage = config.getParameter("healthDown",0)
+  self.baseTime = 0.5
   activateVisualEffects()
-  
+  -- Initial damage on touch.
   status.applySelfDamageRequest({
       damageType = "IgnoresDef",
       damage = self.baseDamage,
       damageSourceKind = "fire",
       sourceEntityId = entity.id()
     })
-    
+
 end
 
 function deactivateVisualEffects()
@@ -27,11 +27,6 @@ function activateVisualEffects()
   animator.burstParticleEmitter("statustext")
 end
 
-function setEffectDamage()
-  self.baseValue = config.getParameter("healthDown",0)
-  return ( self.baseValue *  (1 -status.stat("fireResistance",0) )  )
-end
-
 function setEffectTime()
   return (  self.tickTimer *  math.min(   1 - math.min( status.stat("fireResistance",0) ),0.5))
 end
@@ -39,11 +34,11 @@ end
 function update(dt)
   	if ( status.stat("fireResistance",0)  >= 1.0 ) then
   	  deactivateVisualEffects()
-	  effect.expire() 
-	end  
+	  effect.expire()
+	end
   self.tickTimer = self.tickTimer - dt
   if self.tickTimer <= 0 then
-    self.baseDamage = self.baseDamage +3
+    self.baseDamage = self.baseDamage + 3
     self.tickTimer = self.tickTime
     status.applySelfDamageRequest({
         damageType = "IgnoresDef",
@@ -61,5 +56,5 @@ function onExpire()
 end
 
 function uninit()
-  
+
 end

--- a/stats/effects/fu_tileeffects/poison_effects/nitrogenfreeze/nitrogenfreeze.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/nitrogenfreeze/nitrogenfreeze.lua
@@ -4,27 +4,21 @@ function init()
   script.setUpdateDelta(5)
   self.tickTime = 0.7
   self.tickTimer = self.tickTime
-  self.baseDamage = setEffectDamage()
-  self.baseTime = setEffectTime() 
-end
-
-
-function setEffectDamage()
-  self.baseValue = config.getParameter("healthDown",0)
-  return ( self.baseValue *  (1 -status.stat("iceResistance",0) )  )
+  self.baseDamage = config.getParameter("healthDown",0)
+  self.baseTime = setEffectTime()
 end
 
 function setEffectTime()
-  return (  self.tickTimer *  math.min(   1 - math.min( status.stat("iceResistance",0) ),0.45))
+  return self.tickTimer * math.min(1 - status.stat("iceResistance",0), 0.45)
 end
 
 function update(dt)
   	if ( status.stat("iceResistance",0)  >= 0.75 ) then
-	  effect.expire() 
-	end  
+	  effect.expire()
+	end
   mcontroller.controlModifiers({
         groundForce = 60.5,
-        slopeSlidingFactor = 0.6,  
+        slopeSlidingFactor = 0.6,
         groundMovementModifier = 0.45,
         runModifier = 0.65,
         jumpModifier = 0.75
@@ -33,7 +27,7 @@ function update(dt)
   mcontroller.controlParameters({
       normalGroundFriction = 4.675
     })
-    
+
   self.tickTimer = self.tickTimer - dt
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime

--- a/stats/effects/fu_tileeffects/poison_effects/pus/puseffect.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/pus/puseffect.lua
@@ -1,19 +1,14 @@
 function init()
   script.setUpdateDelta(5)
   self.tickTime = 3.0
-  self.tickTimer = self.tickTime  
-  self.baseDamage = setEffectDamage()
+  self.tickTimer = self.tickTime
+  self.baseDamage = config.getParameter("healthDown",0)
   self.baseTime = setEffectTime()
   activateVisualEffects()
 end
 
-function setEffectDamage()
-  self.baseValue = config.getParameter("healthDown",0)
-  return ( self.baseValue *  (1 -status.stat("physicalResistance",0) )  )
-end
-
 function setEffectTime()
-  return (  self.tickTimer *  math.min(   1 - math.min( status.stat("physicalResistance",0) ),0.45))
+  return self.tickTimer * math.min(1 - status.stat("physicalResistance",0), 0.45)
 end
 
 function deactivateVisualEffects()
@@ -31,8 +26,8 @@ end
 function update(dt)
   	if ( status.stat("physicalResistance",0)  >= 0.45 ) then
   	  deactivateVisualEffects()
-	  effect.expire() 
-	end  
+	  effect.expire()
+	end
   self.tickTimer = self.tickTimer - dt
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime
@@ -50,5 +45,5 @@ end
 
 
 function uninit()
-  
+
 end

--- a/stats/effects/fu_tileeffects/poison_effects/sulphuricacideffect/sulphuricacideffect.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/sulphuricacideffect/sulphuricacideffect.lua
@@ -4,23 +4,18 @@ function init()
   script.setUpdateDelta(5)
   self.tickTime = 0.5
   self.tickTimer = self.tickTime
-  self.baseDamage = setEffectDamage()
-  self.baseTime = setEffectTime()   
-end
-
-function setEffectDamage()
-  self.baseValue = config.getParameter("healthDown",0)
-  return ( self.baseValue *  (1 -status.stat("physicalResistance",0) )  )
+  self.baseDamage = config.getParameter("healthDown",0)
+  self.baseTime = setEffectTime()
 end
 
 function setEffectTime()
-  return (  self.tickTimer *  math.min(   1 - math.min( status.stat("physicalResistance",0) ),0.45))
+  return self.tickTimer * math.min(1 - status.stat("physicalResistance",0),0.45 )
 end
 
 function update(dt)
   	if ( status.stat("physicalResistance",0)  >= 0.90 ) then
-	  effect.expire() 
-	end  
+	  effect.expire()
+	end
   self.tickTimer = self.tickTimer - dt
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime
@@ -35,5 +30,5 @@ function update(dt)
 end
 
 function uninit()
-  
+
 end

--- a/stats/effects/weakpoison/weakpoison.lua
+++ b/stats/effects/weakpoison/weakpoison.lua
@@ -3,28 +3,22 @@ function init()
     animator.setParticleEmitterOffsetRegion("drips", mcontroller.boundBox())
     animator.setParticleEmitterActive("drips", true)
   end
-  
+
   script.setUpdateDelta(5)
 
-  self.tickDamagePercentageP = 0.025
+  self.tickDamagePercentage = 0.025
   self.tickTime = 1.2
   self.tickTimer = self.tickTime
 end
 
-
-function setEffectDamage()
-  return ( self.tickDamagePercentageP * (1 -status.stat("poisonResistance",0) )  )
-end
-
 function update(dt)
   if (status.stat("poisonResistance",0) <= 0.45) then
-	  self.tickDamagePercentage = setEffectDamage()
 	  self.tickTimer = self.tickTimer - dt
 	  if self.tickTimer <= 0 then
 	    self.tickTimer = self.tickTime
 	    status.applySelfDamageRequest({
 		damageType = "IgnoresDef",
-		damage = math.floor(status.resourceMax("health") * self.tickDamagePercentageP) + 1,
+		damage = math.ceil(status.resourceMax("health") * self.tickDamagePercentage),
 		damageSourceKind = "poison",
 		sourceEntityId = entity.id()
 	      })


### PR DESCRIPTION
This branch removes the modifications in FU code which were scaling the base damage of damage-over-time effects (poison, burning etc.) with the player's resistances to the respective element. The same resistances are also applied to the damage ticks, so the net result was that the player's resistance would be squared for DoTs.

For example, a Floran with the Burning effect:
* Base damage: 6
* Fire resistance: -50%
Damage per tick: 6 * 1.5 * 1.5 = 14 (rounded up)

I suspect the person who originally wrote the code thought that applying damage with `damageType = "IgnoresDef"` would also bypass resistances, but it only bypasses the player's protection stat.