### PR TITLE
Fix energy delay modifiers for Energy Pack EPPs

### DIFF
--- a/items/armors/backitems/erithianalgaepack/batterypack_erithian.back
+++ b/items/armors/backitems/erithianalgaepack/batterypack_erithian.back
@@ -4,25 +4,26 @@
   "inventoryIcon" : "batterypack_erithianicon.png",
   "dropCollision" : [-4.0, -3.0, 4.0, 3.0],
   "rarity" : "common",
-  "description" : "This lovely piece of gear grants +15% energy, 8% energy regen and a slight glow",
+  "description" : "This lovely piece of gear grants +10% energy, +10% energy regen, protection from electrical storms and a slight glow.",
   "shortdescription" : "Erithian Energy Pack",
   "tooltipKind" : "baseaugment",
   "category" : "^#e43774;Upgradeable EPP^reset;",
   "acceptsAugmentType" : "back",
   "radioMessagesOnPickup" : [ "pickupepp" ],
   "maxStack" : 1,
-  
+
   "maleFrames" : "back.png",
   "femaleFrames" : "back.png",
 
   "statusEffects" : [
     "energyregenfu_erithian",
+    "biomeelectricImmunity",
     {
       "stat" : "maxEnergy",
-      "effectiveMultiplier" : 1.16
-    },    
+      "effectiveMultiplier" : 1.10
+    },
     "glowgreen2"
   ]
-  
-  
+
+
 }

--- a/items/armors/backitems/morphitepack/batterypack_morphite.back
+++ b/items/armors/backitems/morphitepack/batterypack_morphite.back
@@ -4,25 +4,26 @@
   "inventoryIcon" : "batterypack_eridianicon.png",
   "dropCollision" : [-4.0, -3.0, 4.0, 3.0],
   "rarity" : "rare",
-  "description" : "An advanced energy pack. Grants +20% energy, 12% energy regen and a slight glow.",
+  "description" : "An advanced energy pack. Blocks electrical storms and grants +20% energy, +30% energy regen and a slight glow.",
   "shortdescription" : "Antimatter Energy Pack",
   "tooltipKind" : "baseaugment",
   "category" : "^#e43774;Upgradeable EPP^reset;",
   "acceptsAugmentType" : "back",
   "radioMessagesOnPickup" : [ "pickupepp" ],
-  
+
   "maxStack" : 1,
   "maleFrames" : "back.png",
   "femaleFrames" : "back.png",
 
   "statusEffects" : [
     "energyregenfu_morphite",
+    "biomeelectricImmunity",
     {
       "stat" : "maxEnergy",
-      "effectiveMultiplier" : 1.2
+      "effectiveMultiplier" : 1.20
     },
     "glowpurple2"
   ]
-  
-  
+
+
 }

--- a/items/armors/backitems/protocytepack/batterypack_protocyte.back
+++ b/items/armors/backitems/protocytepack/batterypack_protocyte.back
@@ -4,26 +4,27 @@
   "inventoryIcon" : "batterypack_protocyteicon.png",
   "dropCollision" : [-4.0, -3.0, 4.0, 3.0],
   "rarity" : "uncommon",
-  "description" : "Blocks proto-poison. Grants +10% energy, 5% energy regen and a slight glow.",
+  "description" : "An improved energy pack which blocks proto-poison and electrical storms. Grants +15% energy, +20% energy regen and a slight glow.",
   "shortdescription" : "Protocite Energy Pack",
   "tooltipKind" : "baseaugment",
   "category" : "^#e43774;Upgradeable EPP^reset;",
   "acceptsAugmentType" : "back",
   "radioMessagesOnPickup" : [ "pickupepp" ],
-  
+
   "maxStack" : 1,
   "maleFrames" : "back.png",
   "femaleFrames" : "back.png",
 
   "statusEffects" : [
     "protoimmunity",
+    "biomeelectricImmunity",
     "energyregenfu_proto",
     {
       "stat" : "maxEnergy",
-      "effectiveMultiplier" : 1.10
+      "effectiveMultiplier" : 1.15
     },
     "glowyellow2"
   ]
-  
-  
+
+
 }

--- a/items/armors/backitems/quantumpack/batterypack_quantum.back
+++ b/items/armors/backitems/quantumpack/batterypack_quantum.back
@@ -4,25 +4,26 @@
   "inventoryIcon" : "batterypack_quantumicon.png",
   "dropCollision" : [-4.0, -3.0, 4.0, 3.0],
   "rarity" : "legendary",
-  "description" : "An extremely powerful energy storage tank. Grants +25% energy, 15% energy regen and a slight glow.",
+  "description" : "An extremely powerful energy storage tank. Blocks electrical storms and grants +25% energy, +40% energy regen and a slight glow.",
   "shortdescription" : "Quantum Energy Pack",
   "tooltipKind" : "baseaugment",
   "category" : "enviroProtectionPack",
   "acceptsAugmentType" : "back",
   "radioMessagesOnPickup" : [ "pickupepp" ],
-  
+
   "maleFrames" : "back.png",
   "femaleFrames" : "back.png",
 
   "maxStack" : 1,
   "statusEffects" : [
     "energyregenfu_quantum",
+    "biomeelectricImmunity",
     {
       "stat" : "maxEnergy",
       "effectiveMultiplier" : 1.25
     },
     "glowblue2"
   ]
-  
-  
+
+
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu05.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu05.statuseffect
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : " +3% E. Regen",
+  "label" : "+3% E. Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu15.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu15.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "energyregenfu15",
   "effectConfig" : {
-    "regenAmount" : 1.8,
+    "regenAmount" : 1.08,
     "regenBlockAmount" : 0.92
   },
   "defaultDuration" : 30,

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_armor20.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_armor20.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_armor20",
   "effectConfig" : {
-    "regenAmount" : 1.05,
-    "regenBlockAmount" : 0.9
+    "regenAmount" : 1.20,
+    "regenBlockAmount" : 1.0
   },
   "defaultDuration" : 180,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+5% E. Regen",
+  "label" : "+20% E. Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_armor30.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_armor30.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_armor30",
   "effectConfig" : {
-    "regenAmount" : 1.08,
-    "regenBlockAmount" : 0.8
+    "regenAmount" : 1.30,
+    "regenBlockAmount" : 1.0
   },
   "defaultDuration" : 180,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+8% E. Regen",
+  "label" : "+30% E. Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_armor40.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_armor40.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_armor40",
   "effectConfig" : {
-    "regenAmount" : 1.12,
-    "regenBlockAmount" : 0.7
+    "regenAmount" : 1.40,
+    "regenBlockAmount" : 1.0
   },
   "defaultDuration" : 120,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+12% E. Regen",
+  "label" : "+40% E. Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_armor50.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_armor50.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_armor50",
   "effectConfig" : {
-    "regenAmount" : 1.15,
-    "regenBlockAmount" : 0.6
+    "regenAmount" : 1.50,
+    "regenBlockAmount" : 0.95
   },
   "defaultDuration" : 120,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+15% E. Regen",
+  "label" : "+50% E. Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_armor60.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_armor60.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_armor60",
   "effectConfig" : {
-    "regenAmount" : 1.20,
-    "regenBlockAmount" : 0.5
+    "regenAmount" : 1.60,
+    "regenBlockAmount" : 0.90
   },
   "defaultDuration" : 120,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+20% E. Regen",
+  "label" : "+60% E. Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_armor75.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_armor75.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_armor75",
   "effectConfig" : {
-    "regenAmount" : 1.25,
-    "regenBlockAmount" : 0.4
+    "regenAmount" : 1.75,
+    "regenBlockAmount" : 0.85
   },
   "defaultDuration" : 120,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+25% E. Regen",
+  "label" : "+75% E. Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_erithian.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_erithian.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_erithian",
   "effectConfig" : {
-    "regenAmount" : 1.05,
-    "regenBlockAmount" : 0.15
+    "regenAmount" : 1.10,
+    "regenBlockAmount" : 0.95
   },
   "defaultDuration" : 120,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+5% Energy Regen",
+  "label" : "+10% E. Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_morphite.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_morphite.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_morphite",
   "effectConfig" : {
-    "regenAmount" : 1.1,
-    "regenBlockAmount" : 0.35
+    "regenAmount" : 1.30,
+    "regenBlockAmount" : 0.85
   },
   "defaultDuration" : 120,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+10% Energy Regen",
+  "label" : "+30% Energy Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_proto.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_proto.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_proto",
   "effectConfig" : {
-    "regenAmount" : 1.08,
-    "regenBlockAmount" : 0.25
+    "regenAmount" : 1.20,
+    "regenBlockAmount" : 0.90
   },
   "defaultDuration" : 120,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+8% Energy Regen",
+  "label" : "+20% Energy Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }

--- a/stats/effects/fu_effects/energyregenfu/energyregenfu_quantum.statuseffect
+++ b/stats/effects/fu_effects/energyregenfu/energyregenfu_quantum.statuseffect
@@ -1,8 +1,8 @@
 {
   "name" : "energyregenfu_quantum",
   "effectConfig" : {
-    "regenAmount" : 1.12,
-    "regenBlockAmount" : 0.45
+    "regenAmount" : 1.40,
+    "regenBlockAmount" : 0.80
   },
   "defaultDuration" : 120,
 
@@ -12,6 +12,6 @@
 
   "animationConfig" : "energyregenfu.animation",
 
-  "label" : "+12% Energy Regen",
+  "label" : "+40% Energy Regen",
   "icon" : "/interface/statuses/energyregen2.png"
 }


### PR DESCRIPTION
A couple of fixes for energy-regeneration-related stats:
* Energy regen delays for the upgradeable Energy Pack EPPs were pretty broken, causing energy delay to be ridiculously short - and more so for the lower-tier EPPs. I've fixed these and bumped up the energy regeneration rate to compensate.
* The `energyregenfu_armorXX` stats also had extremely powerful multipliers to energy regen delay. I've restored their energy regen rate stats to the values suggested by their names, and only the higher-tier ones reduce the energy regen delay.
* I fixed a couple of typos in the other non-equipment energy regen stats.
* EDIT: I also updated the descriptions for the EPPs, and added `biomeelectricImmunity` to allow them to block electrical storm effects. It makes sense for them and storms may be a bit more annoying soon ;)

I do think that shortening energy regen delay is extremely powerful and should be applied with care, as it allows slow weapons to completely regenerate energy between shots. But feel free to discuss or just tweak it yourself before merging.