### PR TITLE
[energy_pack_fixes_fixes] Fixed stat error for Energy Pack EPPs

### DIFF
--- a/items/armors/backitems/erithianalgaepack/batterypack_erithian.back
+++ b/items/armors/backitems/erithianalgaepack/batterypack_erithian.back
@@ -17,12 +17,15 @@
 
   "statusEffects" : [
     "energyregenfu_erithian",
-    "biomeelectricImmunity",
     {
       "stat" : "maxEnergy",
       "effectiveMultiplier" : 1.10
     },
-    "glowgreen2"
+    "glowgreen2",
+    {
+      "stat" : "biomeelectricImmunity",
+      "amount" : 1.0
+    }
   ]
 
 

--- a/items/armors/backitems/morphitepack/batterypack_morphite.back
+++ b/items/armors/backitems/morphitepack/batterypack_morphite.back
@@ -17,12 +17,15 @@
 
   "statusEffects" : [
     "energyregenfu_morphite",
-    "biomeelectricImmunity",
     {
       "stat" : "maxEnergy",
       "effectiveMultiplier" : 1.20
     },
-    "glowpurple2"
+    "glowpurple2",
+    {
+      "stat" : "biomeelectricImmunity",
+      "amount" : 1.0
+    }
   ]
 
 

--- a/items/armors/backitems/protocytepack/batterypack_protocyte.back
+++ b/items/armors/backitems/protocytepack/batterypack_protocyte.back
@@ -17,13 +17,16 @@
 
   "statusEffects" : [
     "protoimmunity",
-    "biomeelectricImmunity",
     "energyregenfu_proto",
     {
       "stat" : "maxEnergy",
       "effectiveMultiplier" : 1.15
     },
-    "glowyellow2"
+    "glowyellow2",
+    {
+      "stat" : "biomeelectricImmunity",
+      "amount" : 1.0
+    }
   ]
 
 

--- a/items/armors/backitems/quantumpack/batterypack_quantum.back
+++ b/items/armors/backitems/quantumpack/batterypack_quantum.back
@@ -17,12 +17,15 @@
   "maxStack" : 1,
   "statusEffects" : [
     "energyregenfu_quantum",
-    "biomeelectricImmunity",
     {
       "stat" : "maxEnergy",
       "effectiveMultiplier" : 1.25
     },
-    "glowblue2"
+    "glowblue2",
+    {
+      "stat" : "biomeelectricImmunity",
+      "amount" : 1.0
+    }
   ]
 
 


### PR DESCRIPTION
This branch fixes a bug I introduced with the previous `[energy_pack_fixes]` branch. I had mistakenly made the affected EPPs add `biomeelectricImmunity` as a status effect (which doesn't exist) rather than a stat. Oops!