### PR TITLE
Weather revamp hotfixes

### DIFF
--- a/stats/effects/fu_weathereffects/new/cold/ffbiomecold0.statuseffect
+++ b/stats/effects/fu_weathereffects/new/cold/ffbiomecold0.statuseffect
@@ -29,7 +29,7 @@
     },
 
     "messages" : {
-      "intro" : "biomecold"
+      "intro" : "ffbiomegenericmildcold"
     },
 
     "configPath" : "/stats/effects/fu_weathereffects/new/cold/ffbiomecold0.statuseffect"

--- a/stats/effects/fu_weathereffects/new/gasworldnew/gasworldnew.lua
+++ b/stats/effects/fu_weathereffects/new/gasworldnew/gasworldnew.lua
@@ -42,8 +42,10 @@ end
 function fuPressureWeather.update(self, dt)
   self.parent.update(self, dt)
   -- Extra hook to play the daytime warning message.
-  if (self:isDaytime()) then
-    self:sendWarning("day")
+  if self.effectActive then
+    if (self:isDaytime()) then
+      self:sendWarning("day")
+    end
   end
 end
 


### PR DESCRIPTION
This fixes two issues from the recent pull of `fu_weather_revamp`:
* Fixes a crash in `gasworldnew.lua` on gas giant planets, due to attempting to play a radio warning when the message timer was unset.
* Fixes the default "extreme cold" warning being played on Snowy planets. It has been replaced with an already-existing "mild cold" warning.