### PR TITLE
Fix main loop soft crash when falling onto healing slime

### DIFF
--- a/scripts/basictilegroundeffects.lua
+++ b/scripts/basictilegroundeffects.lua
@@ -140,34 +140,36 @@ end
 
 
 brittleTiles = function(yVelChange,minimumFallVel, groundMat, offset)
-  if currentTile then
-    local brittle = currentTile["brittle"] or false
-    local options = currentTile["options"] or false
+  local brittle = currentTile["brittle"] or false
+  local opts = currentTile["options"] or false
 
-    if brittle and self.fallDistance > brittle and yVelChange > minimumFallVel - brittle then
-      local damage = math.random(currentTile["damage"])+1
-      local position = {self.position[1],math.floor(self.position[2])}
-      world.damageTiles({vec2.add(position,{offset,-3})}, "foreground", position, "blockish", damage, 0)
-      for y = -1, 0 do
-        for x = -1, 1 do
-          local tilePos = vec2.add({position[1]+x, position[2]+y}, {offset,-3})
-          local tile = world.material(tilePos, "foreground")
-          if not (x == 0 and y == 0) and type(tile) == "string" and tile == groundMat then
-            world.damageTiles({tilePos}, "foreground", position, "blockish", math.random(0,damage), 0)
-          end
+  if brittle and self.fallDistance > brittle and yVelChange > minimumFallVel - brittle then
+    local damage = math.random(currentTile["damage"])+1
+    local position = {self.position[1],math.floor(self.position[2])}
+    world.damageTiles({vec2.add(position,{offset,-3})}, "foreground", position, "blockish", damage, 0)
+    for y = -1, 0 do
+      for x = -1, 1 do
+        local tilePos = vec2.add({position[1]+x, position[2]+y}, {offset,-3})
+        local tile = world.material(tilePos, "foreground")
+        if not (x == 0 and y == 0) and type(tile) == "string" and tile == groundMat then
+          world.damageTiles({tilePos}, "foreground", position, "blockish", math.random(0,damage), 0)
         end
       end
-
-      world.spawnProjectile("invisibleprojectile", position, entity.id(), {0,0}, false, {
-        timeToLive = 0,
-        damageType = "noDamage",
-        actionOnReap = {
-          {
-            action = "sound",
-            options = currentTile["options"] or false
+    end
+    if (opts) then
+      world.spawnProjectile(
+        "invisibleprojectile", position, entity.id(), {0,0}, false,
+        {
+          timeToLive = 0,
+          damageType = "noDamage",
+          actionOnReap = {
+            {
+              action = "sound",
+              options = opts
+            }
           }
         }
-      })
+      )
     end
   end
 end

--- a/scripts/basictilegroundeffects.lua
+++ b/scripts/basictilegroundeffects.lua
@@ -32,7 +32,7 @@ function update(dt)
     mcontroller.controlModifiers({airJumpModifier = self.airJumpModifier})
   end
 
-  
+
   --reworked falling to apply Softness and Brittle tiles
   local minimumFallDistance = collisionParams.minimumFallDistance
   local fallDistanceDamageFactor = collisionParams.fallDistanceDamageFactor
@@ -48,7 +48,7 @@ function update(dt)
 
     if currentTile then
       applyTileEffects()
-      
+
       -- check if player gets Research randomly
       if not self.researchTimer then self.researchTimer = 0 end
       if self.researchTimer == 0 then
@@ -57,7 +57,7 @@ function update(dt)
       else
         self.researchTimer = self.researchTimer - dt
       end
-      
+
       --applyTileEffects(groundMat)
       softness = currentTile["softness"]
       --softness = self.matCheck[groundMat][9]
@@ -86,7 +86,7 @@ end
 
 
 applyTileEffects = function(groundMat)
-  
+
   status.addEphemeralEffects(currentTile["effects"])
   mcontroller.controlModifiers(currentTile["controlModifiers"])
   mcontroller.controlParameters(currentTile["controlParameters"])
@@ -140,7 +140,7 @@ end
 
 
 brittleTiles = function(yVelChange,minimumFallVel, groundMat, offset)
-  --if currentTile then
+  if currentTile then
     local brittle = currentTile["brittle"] or false
     local options = currentTile["options"] or false
 
@@ -169,7 +169,7 @@ brittleTiles = function(yVelChange,minimumFallVel, groundMat, offset)
         }
       })
     end
-  --end
+  end
 end
 
 

--- a/tileEffects.config
+++ b/tileEffects.config
@@ -265,7 +265,7 @@
       "softness" : 0.75
     }
   },
-  
+
   "FU_tiles" : {
     "asphalt" : {
       "brittle" : false,
@@ -365,9 +365,9 @@
         "normalGroundFriction" : 14,
         "slopeSlidingFactor" : 0.0
       },
-      "damage" : "/sfx/blocks/footstep_ash.ogg",
+      "damage" : 3,
       "effects" : [ "regenerationblock", "slimestick" ],
-      "options" : [],
+      "options" : [ "/sfx/blocks/footstep_ash.ogg" ],
       "softness" : 1.1
     },
     "fublueslimedirt" : {
@@ -383,9 +383,9 @@
         "normalGroundFriction" : 14,
         "slopeSlidingFactor" : 0.0
       },
-      "damage" : "/sfx/blocks/footstep_ash.ogg",
+      "damage" : 3,
       "effects" : [ "regenerationblock", "slimestick" ],
-      "options" : [],
+      "options" : [ "/sfx/blocks/footstep_ash.ogg" ],
       "softness" : 1.1
     },
     "fublueslimestone" : {


### PR DESCRIPTION
Addresses issue #1626.

I found that landing on healing slime did indeed cause the main loop to crash. This was a result of incorrect entries for `fublueslime` (and `fublueslimedirt`) in `tileEffects.config`. 

I've fixed these entries, so you should be able to destroy blue slime by jumping up and down on it as much as you want now.

EDIT: I've marked this WIP for now. I think the code which was causing the crash could be made a bit more stable, so I'll have a look through that a bit later today.

EDIT 2: Tweaked the logic to only create a sound-playing projectile if the sound file is actually set as an option. This should reduce the likelihood of soft or hard crashes due to misconfigured options. Should be ready for merge now.