### PR TITLE
Fix baseDamage scaling

### DIFF
--- a/items/active/weapons/ranged/gunfire.lua
+++ b/items/active/weapons/ranged/gunfire.lua
@@ -147,7 +147,7 @@ function GunFire:energyPerShot()
 end
 
 function GunFire:damagePerShot()      --return (self.baseDamage or (self.baseDps * self.fireTime)) * (self.baseDamageMultiplier or 1.0) * config.getParameter("damageLevelMultiplier") / self.projectileCount
-    return Crits.setCritDamage(self, self.baseDamage or (self.baseDps * self.fireTime) * (self.baseDamageMultiplier or 1.0) * config.getParameter("damageLevelMultiplier") / self.projectileCount)
+    return Crits.setCritDamage(self, (self.baseDamage or (self.baseDps * self.fireTime)) * (self.baseDamageMultiplier or 1.0) * config.getParameter("damageLevelMultiplier") / self.projectileCount)
 end
 
 


### PR DESCRIPTION
Currently, gunfire doesn't scale baseDamage at all. Which is a problem because some vanilla things, like grenade launcher alt, use it by default.