### PR TITLE
Fix radiation burn physical resistance debuff

### DIFF
--- a/items/active/weapons/other/angryrocket/angryrocket.activeitem
+++ b/items/active/weapons/other/angryrocket/angryrocket.activeitem
@@ -4,7 +4,7 @@
   "level" : 6,
   "maxStack" : 1,
   "rarity" : "Legendary",
-  "description" : "Deadly rockets. Internal energy source.
+  "description" : "Deadly rockets. Internal battery charged by your energy pool when not in use.
 ^cyan;Heat-Seeking Alt (3 tick lock-on)^reset;
 ^yellow;Alt slows, irradiates and burns!^reset;",
   "shortdescription" : "Spankr",
@@ -28,19 +28,19 @@
     }
   },
   "animationScripts" : [ "/items/active/effects/entitymarker.lua" ],
-  
+
   "scripts" : ["angryrocket.lua"],
-  
+
   "fireOffset" : [3.0, 0.625],
   "critChance" : 6,
-  "critBonus" : 8, 
+  "critBonus" : 8,
   "primaryAbility" : {
     "energyUsage" : 112,
     "baseDamage" : 22,
     "projectileType" : "rocketshell",
     "projectileCount" : 1
   },
-  
+
   "altAbility" : {
     "energyUsage" : 112,
     "baseDamage" : 17.5,

--- a/projectiles/activeitems/staff/slowzone/slowzoneinvis.projectile
+++ b/projectiles/activeitems/staff/slowzone/slowzoneinvis.projectile
@@ -10,19 +10,19 @@
   "periodicActions" : [
 	    {
               "time" : 0.1,
-              "repeat" : false,	    
+              "repeat" : false,
 	      "action" : "projectile",
 	      "type" : "flamethrowerflameff",
 	      "fuzzAngle" : 360,
 	      "inheritDamageFactor" : 0.05,
 	      "config" : { "statusEffects" : [ "radiationburn" ] }
-	    },   
+	    },
     	    {
               "time" : 0.3,
-              "repeat" : false,    	    
+              "repeat" : false,
     	      "action" : "config",
     	      "file" : "/projectiles/explosions/hellfireexplosion/spankrexplosion.config"
-	    },     
+	    },
     {
       "time" : 1,
       "repeat" : false,
@@ -62,14 +62,14 @@
 	      "inheritDamageFactor" : 0.15,
 	      "config" : { "statusEffects" : [ "radiationburn" ] },
 	      "angleAdjust" : 180
-	    } 	  
+	    }
   ],
   "speed" : 0,
   "power" : 0,
   "renderLayer" : "Player+1",
 
   "onlyHitTerrain" : true,
-  "persistentStatusEffects" : ["staffslow", "radiationburn"],
+  "persistentStatusEffects" : ["staffslow"],
   "statusEffectArea" : [ [-6.0, 0], [-4.0, -4.0], [0, -6.0], [4.0, -4.0], [6.0, 0], [4.0, 4.0], [0, 6.0], [-4.0, 4.0] ],
 
 
@@ -81,6 +81,6 @@
   "bounces" : -1,
 
   "scripts" : [ "/projectiles/activeitems/staff/staffprojectile.lua" ],
-  
+
   "persistentAudio" : "/sfx/projectiles/zone_slow_loop.ogg"
 }

--- a/stats/effects/fu_tileeffects/poison_effects/radiationburn/radiationburn.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/radiationburn/radiationburn.lua
@@ -18,26 +18,22 @@ function update(dt)
   end
 
   self.tickTimer = self.tickTimer - dt
-  self.currentDebuff = self.currentDebuff + self.debuffPerSec * dt
+  self.currentDebuff = math.max(self.currentDebuff + self.debuffPerSec * dt, self.maxDebuff)
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime
-    if self.currentDebuff >= self.maxDebuff then
-      status.setPersistentEffects("aciddust", { {stat = "physicalResistance", amount = self.currentDebuff } })
-      -- Apply a tiny amount of damage for "hurt" noise --
-      status.applySelfDamageRequest({
-        damageType = "IgnoresDef",
-        damage = 0.1,
-        damageSourceKind = "radioactive",
-        sourceEntityId = entity.id()
-      })
-    else
-      status.applySelfDamageRequest({
-        damageType = "IgnoresDef",
-        damage = math.floor(status.resourceMax("health") * self.tickDamagePercentage),
-        damageSourceKind = "radioactive",
-        sourceEntityId = entity.id()
-      })
+    -- Incrementally debuff target's physical resistance. --
+    status.setPersistentEffects("aciddust", { {stat = "physicalResistance", amount = self.currentDebuff } })
+    -- Apply damage if target's physical resistance is zero (otherwise, just make the 'hurt' SFX). --
+    local dmg = 0.1
+    if (self.currentDebuff == self.maxDebuff) then
+      dmg = math.floor(status.resourceMax("health") * self.tickDamagePercentage)
     end
+    status.applySelfDamageRequest({
+      damageType = "IgnoresDef",
+      damage = dmg,
+      damageSourceKind = "radioactive",
+      sourceEntityId = entity.id()
+    })
   end
 end
 

--- a/stats/effects/fu_tileeffects/poison_effects/radiationburn/radiationburn2.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/radiationburn/radiationburn2.lua
@@ -21,23 +21,19 @@ function update(dt)
   self.currentDebuff = self.currentDebuff + self.debuffPerSec * dt
   if self.tickTimer <= 0 then
     self.tickTimer = self.tickTime
-    if self.currentDebuff >= self.maxDebuff then
-      status.setPersistentEffects("aciddust2", { {stat = "physicalResistance", amount = self.currentDebuff } })
-      -- Apply a tiny amount of damage for "hurt" noise --
-      status.applySelfDamageRequest({
-        damageType = "IgnoresDef",
-        damage = 0.1,
-        damageSourceKind = "radioactive",
-        sourceEntityId = entity.id()
-      })
-    else
-      status.applySelfDamageRequest({
-        damageType = "IgnoresDef",
-        damage = math.floor(status.resourceMax("health") * self.tickDamagePercentage),
-        damageSourceKind = "radioactive",
-        sourceEntityId = entity.id()
-      })
+    -- Incrementally debuff target's physical resistance. --
+    status.setPersistentEffects("aciddust2", { {stat = "physicalResistance", amount = self.currentDebuff } })
+    -- Apply damage if target's physical resistance is zero (otherwise, just make the 'hurt' SFX). --
+    local dmg = 0.1
+    if (self.currentDebuff == self.maxDebuff) then
+      dmg = math.floor(status.resourceMax("health") * self.tickDamagePercentage)
     end
+    status.applySelfDamageRequest({
+      damageType = "IgnoresDef",
+      damage = dmg,
+      damageSourceKind = "radioactive",
+      sourceEntityId = entity.id()
+    })
   end
 end
 

--- a/stats/effects/fu_tileeffects/poison_effects/radiationburn/radiationburn2.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/radiationburn/radiationburn2.lua
@@ -4,35 +4,43 @@ function init()
   animator.setParticleEmitterActive("fx", true)
   effect.setParentDirectives("fade=00FF33=0.15")
   script.setUpdateDelta(5)
-  self.tickDamagePercentage = 0.03
-  self.tickTime = 0.1
+  self.tickDamagePercentage = 0.04
+  self.tickTime = 0.2
   self.tickTimer = self.tickTime
-  self.statusValue = status.stat("physicalResistance",0)
+  self.currentDebuff = 0.0
+  self.debuffPerSec = -0.25 -- Lose 25% phys resist per second
+  self.maxDebuff = -status.stat("physicalResistance",0)
 end
 
 function update(dt)
-  if (status.stat("radioactiveResistance",0)  >= 0.4) then
+  if (status.stat("radioactiveResistance",0)  >= 0.4) or status.statPositive("biomeradiationImmunity") or status.statPositive("ffextremeradiationImmunity") then
     effect.expire()
   end
-  
-  
+
   self.tickTimer = self.tickTimer - dt
-  self.statusValue = self.statusValue - dt
+  self.currentDebuff = self.currentDebuff + self.debuffPerSec * dt
   if self.tickTimer <= 0 then
-      	self.tickTimer = self.tickTime
-	if self.statusValue > 0.05 then
-	  status.setPersistentEffects("aciddust", { {stat = "physicalResistance", amount = self.statusValue } })
-        else 
-	    status.applySelfDamageRequest({
-		damageType = "IgnoresDef",
-		damage = math.floor(status.resourceMax("health") * self.tickDamagePercentage),
-		damageSourceKind = "radioactive",
-		sourceEntityId = entity.id()
-	    })          
-	end  
+    self.tickTimer = self.tickTime
+    if self.currentDebuff >= self.maxDebuff then
+      status.setPersistentEffects("aciddust2", { {stat = "physicalResistance", amount = self.currentDebuff } })
+      -- Apply a tiny amount of damage for "hurt" noise --
+      status.applySelfDamageRequest({
+        damageType = "IgnoresDef",
+        damage = 0.1,
+        damageSourceKind = "radioactive",
+        sourceEntityId = entity.id()
+      })
+    else
+      status.applySelfDamageRequest({
+        damageType = "IgnoresDef",
+        damage = math.floor(status.resourceMax("health") * self.tickDamagePercentage),
+        damageSourceKind = "radioactive",
+        sourceEntityId = entity.id()
+      })
+    end
   end
 end
 
 function uninit()
-  status.clearPersistentEffects("aciddust")
+  status.clearPersistentEffects("aciddust2")
 end


### PR DESCRIPTION
I had a pass through the `radiationburn.lua` file and got it to work as I think you intended. It properly drains the target's physical resistance by 15% per second (25% for `radiationburn2`), and then applies damage ticks once physical resistance is zero.

I also re-added the `clearPersistentEffects()` call to actually remove the debuff when the effect expires. However, this re-introduces the crash with the Spankr alt-fire... I have removed the `radiationburn` persistent effect from the Spankr's alt "slow field" for stability. I think the best solution here would be not to use a temporary effect as a persistent one.

Anyway, try out the radiation burn and see what you think. (I just jumped on radioactive stone a lot.)

EDIT: I just resolved merge conflicts with the changes you already made. This merge will overwrite them, which you probably want if you're happy with the new behaviour :)