### PR TITLE
keys to the duplicator

### DIFF
--- a/interface/objectcrafting/fu_precursorduplicator.config
+++ b/interface/objectcrafting/fu_precursorduplicator.config
@@ -16,31 +16,10 @@
     },    
     "itemGrid" : {
       "type" : "itemgrid",
-      "position" : [32, 44],
-      "dimensions" : [1, 1],
+      "position" : [21, 44],
+      "dimensions" : [5, 1],
       "spacing" : [19, 19],
       "backingImage" : "/interface/objectcrafting/grayborder2.png"
-    },
-    "itemGrid2" : {
-      "type" : "itemgrid",
-      "slotOffset" : 1,
-      "position" : [60, 44],
-      "dimensions" : [1, 1],
-      "spacing" : [19, 19],
-      "backingImage" : "/interface/objectcrafting/grayborder2.png"
-    },
-    "outputItemGrid" : {
-      "type" : "itemgrid",
-      "position" : [94, 44],
-      "slotOffset" : 2,
-      "dimensions" : [1, 1],
-      "spacing" : [19, 19],
-      "backingImage" : "/interface/inventory/empty.png"
-    },    
-    "pointer" : {
-      "type" : "image",
-      "position" : [82, 48],
-      "file" : "/interface/objectcrafting/arrow.png"
     }
   }
 }

--- a/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.lua
+++ b/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.lua
@@ -29,7 +29,8 @@ function update(dt)
 						world.containerConsumeAt(entity.id(),1,1)
 						storage.timer = self.craftTime
 						storage.output = inputSlot
-
+						local fuelMod = self.fuel[inputSlot] and 0.5 or 1
+						
 						--sb.logInfo("%s",root.itemConfig(inputSlot))
 						itemOre = root.itemConfig(world.containerItemAt(entity.id(),0))
 
@@ -39,7 +40,7 @@ function update(dt)
 							end
 
 							itemValue = itemOre.config.price /1000
-							fuelValue = (fuelValue - (fuelValue  * itemValue)) + fuelValueBonus
+							fuelValue = ((fuelValue - (fuelValue  * itemValue)) + fuelValueBonus) * fuelMod
 							if fuelValue < 1 then
 								fuelValue = 1
 							end

--- a/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.lua
+++ b/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.lua
@@ -1,90 +1,110 @@
 require '/scripts/power.lua'
 require '/scripts/util.lua'
 
-local crafting = false
-local output = nil
-
 function init()
 	power.init()
 	self = config.getParameter("duplicator")
 	self.craftTime = config.getParameter("craftTime")
-	self.timer = self.craftTime
+	storage.timer = storage.timer or self.craftTime -- making this, storage.crafting, etc. persistent so that on server terminus, nothing is lost.
 end
 
 function update(dt)
 	local fuelSlot = world.containerItemAt(entity.id(),1)
-	fuelSlot = fuelSlot and fuelSlot.name or ""
 
-	local inputOutputSlot = world.containerItemAt(entity.id(),0)
-	inputOutputSlot = inputOutputSlot and inputOutputSlot.name or ""
+	local inputSlot = world.containerItemAt(entity.id(),0)
+	inputSlot = inputSlot and inputSlot.name or ""
 
-	local fuelValue=self.fuel[fuelSlot] or 0
+	local fuelValue=self.fuel[fuelSlot and fuelSlot.name or ""] or 0
 	local fuelValueBonus = 0  -- bonus output
 
-	if wireCheck() == true and fuelValue > 0 then -- make sure there is fuel in there
-		if crafting == false then
-			if power.getTotalEnergy() >= config.getParameter('isn_requiredPower') then
-			animator.setAnimationState("base", "on")
-				if contains(self.inputOutput,inputOutputSlot) then
-					world.containerConsumeAt(entity.id(),1,1)
-					self.timer = self.craftTime
-					output = inputOutputSlot
+	if not storage.crafting then--no point doing further comparisons unless we actually need them.
+		if wireCheck() then -- logic wires on? neutronium and antineutronium in?
+			if fuelValue > 0 then -- fueled?
+				if power.getTotalEnergy() >= config.getParameter('isn_requiredPower') then
+					animator.setAnimationState("base", "on")
+					
+					if contains(self.inputs,inputSlot) then
+						storage.fuelTaken=fuelSlot --recorded for potential refund later
+						storage.fuelTaken.count=1
+						world.containerConsumeAt(entity.id(),1,1)
+						storage.timer = self.craftTime
+						storage.output = inputSlot
 
-					--sb.logInfo("%s",root.itemConfig(inputOutputSlot))
-					itemOre = root.itemConfig(world.containerItemAt(entity.id(),0))
+						--sb.logInfo("%s",root.itemConfig(inputSlot))
+						itemOre = root.itemConfig(world.containerItemAt(entity.id(),0))
 
-					if itemOre then
-					  if math.random(10) == 10 then
-					    fuelValueBonus = math.random(1,2)
-					  end
+						if itemOre then
+							if math.random(10) == 10 then
+								fuelValueBonus = math.random(1,2)
+							end
 
-					  itemValue = itemOre.config.price /1000
-					  fuelValue = (fuelValue - (fuelValue  * itemValue)) + fuelValueBonus
-					  if fuelValue < 1 then
-					    fuelValue = 1
-					  end
+							itemValue = itemOre.config.price /1000
+							fuelValue = (fuelValue - (fuelValue  * itemValue)) + fuelValueBonus
+							if fuelValue < 1 then
+								fuelValue = 1
+							end
+						end
+						
+						storage.outputCount = fuelValue
+						storage.crafting = true
 					end
-
-					outputCount = fuelValue
-					crafting = true
 				end
 			end
 		end
 	end
-	if self.timer <= 0 then
-		if crafting == true then
+	
+	if storage.timer <= 0 then
+		if storage.crafting then
 
-			if power.consume(config.getParameter('isn_requiredPower')) then
+			if wireCheck() and power.consume(config.getParameter('isn_requiredPower')) then -- added option for a hard abort that won't eat materials
+				--local slots = getOutSlotsFor(storage.output)
+				storage.output = world.containerPutItemsAt(entity.id(), {name=storage.output,count=storage.outputCount}, 2)
 
-				--local slots = getOutSlotsFor(output)
-				output = world.containerPutItemsAt(entity.id(), {name=output,count=outputCount}, 2)
-
-				if output then
-					output=world.containerPutItemsAt(entity.id(), output, 0)
+				if storage.output then
+					storage.output=world.containerPutItemsAt(entity.id(), storage.output, 0)
 				end
 				
-				if output then
-					world.spawnItem(output, entity.position())
-					output=nil
+				if storage.output then
+					world.spawnItem(storage.output, entity.position())
+					storage.output=nil
 				end
 				
-				crafting = false
+				storage.fuelTaken=nil
+				storage.crafting = false
+			else
+				--if we can't get power, we just chuck the fuel back into the hopper (or on the ground). and stop animating.
+				animator.setAnimationState("base", "off")
+				storage.fuelTaken = world.containerPutItemsAt(entity.id(), storage.fuelTaken, 1)
+				if storage.fuelTaken then
+					world.spawnItem(storage.fuelTaken, entity.position())
+					storage.fuelTaken=nil
+				end
+				--stop crafting. nil values.
+				storage.output=nil
+				storage.crafting=false
 			end
 		else
-		  animator.setAnimationState("base", "off")
+			animator.setAnimationState("base", "off")
 		end
 	end
 
-	self.timer = self.timer - dt
-	if not crafting and self.timer <= 0 then
-	  self.timer = 0
+	storage.timer = storage.timer - dt
+	if not storage.crafting and storage.timer <= 0 then
+		storage.timer = 0
 	end
 
 	power.update(dt)
 end
 
 function wireCheck()
-	return (object.inputNodeCount() >= 1) or not object.isInputNodeConnected(0) or object.getInputNodeLevel(1)
+	--since we're only really using them here these neutronium parts got added here. can easily be moved out if needed.
+	local neutronium = world.containerItemAt(entity.id(),3)
+	neutronium=neutronium and (neutronium.name=="neutronium")
+	
+	local antineutronium = world.containerItemAt(entity.id(),4)
+	antineutronium=antineutronium and (antineutronium.name=="antineutronium")
+	
+	return (neutronium and antineutronium) and (object.inputNodeCount() < 1 or not object.isInputNodeConnected(0) or object.getInputNodeLevel(0))
 end
 
 --[[

--- a/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.object
+++ b/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.object
@@ -1,133 +1,145 @@
 {
-  "objectName" : "fu_precursorduplicator",
-  "colonyTags" : ["precursor","ancient"],
-  "rarity" : "Legendary",
-  "description" : "Place fuel in the FUEL slot to duplicate materials in the ITEM slot. ^cyan;Requires ^orange;120W ^cyan;power.^reset;",
-  "shortdescription" : "Duplicator",
-  "race" : "precursor",
-  "printable" : false,
-  "category" : "crafting",
-  
-  "health" : 2,
+	"objectName": "fu_precursorduplicator",
+	"colonyTags": ["precursor", "ancient"],
+	"rarity": "Legendary",
+	"description": "Place fuel in the FUEL slot to duplicate materials in the ITEM slot.\n^cyan;Requires ^orange;120W ^cyan;power.^reset;\n^blue;Upper Input^reset;: Power Switch.",
+	"shortdescription": "Duplicator",
+	"race": "precursor",
+	"printable": false,
+	"category": "crafting",
 
-  "animation" : "fu_precursorduplicator.animation",
-  "animationParts" : {
-    "base" : "fu_precursorduplicator.png"
-  },
-  "animationPosition" : [-26, 0],
-  
-  "inventoryIcon" : "fu_precursorduplicatoricon.png",
-  "orientations" : [
-    {
-      "imageLayers" : [ { "image" : "fu_precursorduplicator.png:<color>.<frame>", "fullbright" : true }, { "image" : "fu_precursorduplicatorlit.png:<color>.<frame>"} ],
-      "imagePosition" : [-26, 0],
-      "frames" : 81,
-      "direction" : "left",
-      "flipImages" : true,      
-      "animationCycle" : 3,
-      "spaceScan" : 0.1,
-      "anchors" : [ "bottom" ]
-    },
-    {
-      "imageLayers" : [ { "image" : "fu_precursorduplicator.png:<color>.<frame>", "fullbright" : true }, { "image" : "fu_precursorduplicatorlit.png:<color>.<frame>"} ],
-      "imagePosition" : [-26, 0],
-      "frames" : 81,
-      "direction" : "right",    
-      "animationCycle" : 3,
-      "spaceScan" : 0.1,
-      "anchors" : [ "bottom" ]
-    }
-  ],
+	"health": 2,
 
-  "scripts" : [ "/scripts/power.lua", "/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.lua" ],
-  "scriptDelta" : 10,
+	"animation": "fu_precursorduplicator.animation",
+	"animationParts": {
+		"base": "fu_precursorduplicator.png"
+	},
+	"animationPosition": [-26, 0],
 
-  "inputNodes" : [ [-1, 0] ],
+	"inventoryIcon": "fu_precursorduplicatoricon.png",
+	"orientations": [{
+			"imageLayers": [{
+				"image": "fu_precursorduplicator.png:<color>.<frame>",
+				"fullbright": true
+			}, {
+				"image": "fu_precursorduplicatorlit.png:<color>.<frame>"
+			}],
+			"imagePosition": [-26, 0],
+			"frames": 81,
+			"direction": "left",
+			"flipImages": true,
+			"animationCycle": 3,
+			"spaceScan": 0.1,
+			"anchors": ["bottom"]
+		},
+		{
+			"imageLayers": [{
+				"image": "fu_precursorduplicator.png:<color>.<frame>",
+				"fullbright": true
+			}, {
+				"image": "fu_precursorduplicatorlit.png:<color>.<frame>"
+			}],
+			"imagePosition": [-26, 0],
+			"frames": 81,
+			"direction": "right",
+			"animationCycle": 3,
+			"spaceScan": 0.1,
+			"anchors": ["bottom"]
+		}
+	],
 
-  "duplicator" : {
+	"scripts": ["/scripts/power.lua", "/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.lua"],
+	"scriptDelta": 10,
+
+	"inputNodes": [
+		[-1, 1],
+		[-1, 0]
+	],
+
+	"duplicator": {
 		"fuel": {
-		        "elderrelic1" : 10,
-		        "exoticmatter" : 10,
-		        "honedlunari" : 6,
+			"elderrelic1": 10,
+			"exoticmatter": 10,
+			"honedlunari": 6,
 			"precursorfluid": 4,
-			"energiwood" : 5,
-			
-			"lunaricrystal" : 5,
-			"triangliumpyramid" : 4,
-			"prisilitestar" : 4,
-			
-			"tritium" : 6,
-			"ultronium" : 5,			
+			"energiwood": 5,
+
+			"lunaricrystal": 5,
+			"triangliumpyramid": 4,
+			"prisilitestar": 4,
+
+			"tritium": 6,
+			"ultronium": 5,
 			"solariumstar": 3,
 			"thoriumrod": 2,
-			"enricheduranium" : 2,
+			"enricheduranium": 2,
 			"uraniumrod": 1,
-			"enrichedplutonium" : 2,
+			"enrichedplutonium": 2,
 			"plutoniumrod": 1,
 			"neptuniumrod": 1,
 
-		        "pureerchius" : 8,
-		        "supermatter" : 4,
-		        "liquidfuel" : 1,
-		        
-			"biofuelcannistermax" : 3,
-			"biofuelcannisteradv" : 2,
-			"biofuelcannister" : 1			
+			"pureerchius": 8,
+			"supermatter": 4,
+			"liquidfuel": 1,
+
+			"biofuelcannistermax": 3,
+			"biofuelcannisteradv": 2,
+			"biofuelcannister": 1
 		},
-		
-	"inputOutput" : [ 
-	  "biofuelcannister",
-	  "biofuelcannisteradv",
-	  "biofuelcannistermax",
-	  "corruptionseed",
-	  "ff_fertilizer",
-	  "ff_fertilizer2",
-	  "ff_fertilizer3",
-	  "glass",
-	  "blobbushjelly",
-	  "fu_mulch",
-	  "morphiteore",
-	  "unstableparticles",
-	  "plutoniumrod",
-	  "uraniumrod", 
-	  "neptuniumrod", 
-	  "thoriumrod", 
-	  "solariumstar", 
-	  "copperbar", 
-	  "silverbar", 
-	  "ironbar", 
-	  "titaniumbar", 
-	  "durasteelbar", 
-	  "goldbar", 
-	  "tungstenbar", 
-	  "densiniumbar", 
-	  "quietusbar",
-	  "effigiumbar",
-	  "fuamberchunk",
-	  "irradiumbar",
-	  "isogenbar",
-	  "moonstonebar",
-	  "penumbriteshard",
-	  "prisilitestar",
-	  "protocitebar",
-	  "pyreitebar",
-	  "solaricrystal",
-	  "triangliumpyramid",
-	  "xithricitecrystal",
-	  "zerchesiumbar",
-	  "refinedaegisalt",
-	  "refinedviolium",
-	  "refinedferozium"
-	  ]
-  },
-  
-  "objectType" : "container",
-  "slotCount" : 3,
-  "uiConfig" : "/interface/objectcrafting/fu_precursorduplicator.config",
-  "subtitle" : "",
-  "frameCooldown" : 5,
-  "autoCloseCooldown" : 3600,
-  "craftTime" : 3,
-  "powertype" : "input",
-  "isn_requiredPower" : 120
+
+		"inputs": [
+			"biofuelcannister",
+			"biofuelcannisteradv",
+			"biofuelcannistermax",
+			"corruptionseed",
+			"ff_fertilizer",
+			"ff_fertilizer2",
+			"ff_fertilizer3",
+			"glass",
+			"blobbushjelly",
+			"fu_mulch",
+			"morphiteore",
+			"unstableparticles",
+			"plutoniumrod",
+			"uraniumrod",
+			"neptuniumrod",
+			"thoriumrod",
+			"solariumstar",
+			"copperbar",
+			"silverbar",
+			"ironbar",
+			"titaniumbar",
+			"durasteelbar",
+			"goldbar",
+			"tungstenbar",
+			"densiniumbar",
+			"quietusbar",
+			"effigiumbar",
+			"fuamberchunk",
+			"irradiumbar",
+			"isogenbar",
+			"moonstonebar",
+			"penumbriteshard",
+			"prisilitestar",
+			"protocitebar",
+			"pyreitebar",
+			"solaricrystal",
+			"triangliumpyramid",
+			"xithricitecrystal",
+			"zerchesiumbar",
+			"refinedaegisalt",
+			"refinedviolium",
+			"refinedferozium"
+		]
+	},
+
+	"objectType": "container",
+	"slotCount": 5,
+	"uiConfig": "/interface/objectcrafting/fu_precursorduplicator.config",
+	"subtitle": "",
+	"frameCooldown": 5,
+	"autoCloseCooldown": 3600,
+	"craftTime": 3,
+	"powertype": "input",
+	"isn_requiredPower": 120
 }


### PR DESCRIPTION
duplicator now requires (anti)neutronium rods to function. device now has severely reduced effectiveness duplicating fuels. (more or less impossible, with a maybe 10 percent chance of actually duplicating, in most cases.)
slots: 1) input. 2)fuel. 3) output. 4) neutronium. 5) antineutronium. still needs ui fix...bleh.