### PR TITLE
Remove Quagmutt's Charge Action

### DIFF
--- a/monsters/walkers/quagmutt/quagmutt.monstertype.patch
+++ b/monsters/walkers/quagmutt/quagmutt.monstertype.patch
@@ -33,27 +33,5 @@
     "op": "add",
     "path": "/dropPools/0/shadowbow",
     "value": "quagmuttHunting"
-  },
-  {
-    "op": "add",
-    "path": "/baseParameters/behaviorConfig/damageTakenActions",
-    "value": [
-      {
-        "name": "action-charge",
-        "cooldown": 5,
-        "parameters": {
-          "maximumRange": 12,
-          "windupTime": 0.4,
-          "aimAtTarget": true,
-          "aimDirection": [1,1],
-          "chargeTime": [0.3,0.5],
-          "chargeSpeed": 30,
-          "chargeControlForce": 220,
-          "wallCrashSound": "",
-          "wallCrashEmitter": "",
-          "winddownTime": 0.5
-        }
-      }
-    ]
   }
 ]


### PR DESCRIPTION
A "Charge" damageTakenAction was introduced to the Quagmutt in the Monday update, along with the hunting loot. 
However, the animation is incomplete so when players attack Quagmutt, if it was not defeated, it will send the players back to their ships. 
The issue can be solved by removing the action. (Or, perhaps, fixing the animation?)