### PR TITLE
Byos crew changes

### DIFF
--- a/quests/scripts/byos/fu_shipupgrades.config
+++ b/quests/scripts/byos/fu_shipupgrades.config
@@ -26,6 +26,6 @@
 	},
 	"atmosphereSystem" : {
 		"maxPerimeter" : 500,
-		"requireBackground" : false
+		"requireBackground" : true
 	}
 }

--- a/quests/scripts/byos/fu_shipupgrades.config
+++ b/quests/scripts/byos/fu_shipupgrades.config
@@ -23,5 +23,9 @@
 		"min" : -30,
 		"max" : 30,
 		"totalMin" : 0
+	},
+	"atmosphereSystem" : {
+		"maxPerimeter" : 500,
+		"requireBackground" : false
 	}
 }

--- a/quests/scripts/byos/fu_shipupgrades.lua
+++ b/quests/scripts/byos/fu_shipupgrades.lua
@@ -1,9 +1,11 @@
 require "/scripts/util.lua"
 require "/quests/scripts/questutil.lua"
 require "/quests/scripts/portraits.lua"
+require "/objects/spawner/colonydeed/scanning.lua"
 
 function init()
 	upgradeConfig = root.assetJson("/quests/scripts/byos/fu_shipupgrades.config")
+	self = upgradeConfig.atmosphereSystem
 	crewSizeShipOld = 0
 	maxFuelShipOld = 0
 	fuelEfficiencyShipOld = 0
@@ -14,10 +16,20 @@ function update(dt)
 	if world.type() == "unknown" then
 		shipLevel = world.getProperty("ship.level")
 		if shipLevel == 0 then
-			if not world.tileIsOccupied(mcontroller.position(), false) then
-				lifeSupport(false)
+			if world.getProperty("fu_byos.newAtmosphereSystem") then
+				self.position = entity.position()
+				room = findHouseBoundary(self.position, self.maxPerimeter or 500)
+				if not room.poly then
+					lifeSupport(false)
+				else
+					lifeSupport(true)
+				end
 			else
-				lifeSupport(true)
+				if not world.tileIsOccupied(mcontroller.position(), false) then
+					lifeSupport(false)
+				else
+					lifeSupport(true)
+				end
 			end
 		else
 			lifeSupport(true)
@@ -155,4 +167,8 @@ end
 function round(num, numDecimalPlaces)
   local mult = 10^(numDecimalPlaces or 0)
   return math.floor(num * mult + 0.5) / mult
+end
+
+function isShipWorld()
+  return false
 end

--- a/zb/newSail/data.config
+++ b/zb/newSail/data.config
@@ -163,7 +163,8 @@
 		
 		"misc" : [
 			//[ "ScriptPane", "^orange;[FU]^reset; FU Guides", "/codex/documents/ffbook.png", "/zb/researchTree/researchTree.config" ],
-			[ "OpenAiInterface", "Vanilla SAIL", "/zb/newSail/vanillaAI.png" ],
+			[ "OpenAiInterface", "Vanilla SAIL", "/zb/newSail/vanillaAI.png" ],	
+			[ "externalscript", "^orange;[FU]^reset; Switch BYOS Atmosphere Mode", "/interface/inspect.png", "/zb/newSail/fu_customFunctions.lua", "fu_toggleAtmosphereMode"],
 			[ "ScriptPane", "^orange;[ZB]^reset; Update Window", "/interface/quest.png", "/zb/updateInfoWindow/updateInfoWindow.config" ],
 			[ "ScriptPane", "^orange;[ZB]^reset; Quest List", "/interface/quest.png", "/zb/questList/questList.config" ],
 			[ "ScriptPane", "^#adadad;[FU] Research Tree^reset;", "/zb/newSail/researchTree.png", "/zb/researchTree/researchTree.config" ],

--- a/zb/newSail/fu_customFunctions.lua
+++ b/zb/newSail/fu_customFunctions.lua
@@ -1,0 +1,16 @@
+function fu_toggleAtmosphereMode()
+	local text = ""
+	if player.worldId() ~= player.ownShipWorldId() then
+		text = "Only the owner of the ship can switch the atmosphere mode."
+	elseif world.getProperty("ship.level") ~= 0 then
+		text = "This feature is BYOS only."
+	elseif world.getProperty("fu_byos.newAtmosphereSystem") then
+		world.setProperty("fu_byos.newAtmosphereSystem", false)
+		text = "BYOS atmosphere mode has been set to only check for background behind the player."
+	else
+		world.setProperty("fu_byos.newAtmosphereSystem", true)
+		text = "BYOS atmosphere mode has been set to check if the player is in an enclosed room (WIP)."
+	end
+	resetGUI()
+	textTyper.init(cfg.TextData, text)
+end


### PR DESCRIPTION
- Adds a new BYOS atmosphere system that can be enabled at SAIL under the misc category
- This new system checks if you are in an enclosed room instead of just checking if you have a background tile behind you
- It currently only supports rooms that have a perimeter of less then 500 tiles and doesn't work properly when part of the room is unloaded