### PR TITLE
BYOS Techstation Stuff

### DIFF
--- a/interface/ai/fu_byosai.lua
+++ b/interface/ai/fu_byosai.lua
@@ -115,7 +115,7 @@ function racial()
 	race = player.species()
 	count = racialiserBootUp()
 	parameters = getBYOSParameters("techstation", true, _)
-	player.giveItem({name = "fu_byostechstationdeco", count = 1, parameters = parameters})
+	player.giveItem({name = "fu_byostechstation", count = 1, parameters = parameters})
 	player.startQuest("fu_shipupgrades")
 	player.upgradeShip(defaultShipUpgrade)
 end

--- a/objects/crafting/matterassembler/prototyper.object
+++ b/objects/crafting/matterassembler/prototyper.object
@@ -57,7 +57,7 @@
         },
 
         "filter" : [ "prototyper1" ],
-        "initialRecipeUnlocks" : [ "fu_crewdeed", "fu_upgradetable", "fu_byoscaptainschair", "fu_byosfuelhatch", "fu_byosshipdoor", "fu_byosshiphatch", "fu_byosshiplocker", "fu_byostechstationdeco", "fu_byosteleporterdeco", "powerstation", "petpicrepair", "servitorloader", "bothealingstation", "genecabinet", "genestorage", "polymer", "laserdiode", "wiretoolfu", "fu_alternatorgenerator", "fu_woodensifter", "siliconboard","electromagnet", "wire", "microscope", "handmill", "nanofabricator", "armory", "designlab", "sproutingtable", "fu_growingtray", "farmwell", "eggincubator", "heavypipe", "fulabpipe", "labtechpanel", "fu_autobeamer3bugs", "portablelight", "crewcontract_science", "fm_musicplayer", "fu_byospethouse", "fu_racialiser", "fu_shipcraftingtable", "fu_ftldrivedeco", "fu_byoscaptainschairdeco" ],
+        "initialRecipeUnlocks" : [ "fu_crewdeed", "fu_upgradetable", "fu_byoscaptainschair", "fu_byosfuelhatch", "fu_byosshipdoor", "fu_byosshiphatch", "fu_byosshiplocker", "fu_byostechstationdeco", "fu_byostechstation", "fu_byosteleporterdeco", "powerstation", "petpicrepair", "servitorloader", "bothealingstation", "genecabinet", "genestorage", "polymer", "laserdiode", "wiretoolfu", "fu_alternatorgenerator", "fu_woodensifter", "siliconboard","electromagnet", "wire", "microscope", "handmill", "nanofabricator", "armory", "designlab", "sproutingtable", "fu_growingtray", "farmwell", "eggincubator", "heavypipe", "fulabpipe", "labtechpanel", "fu_autobeamer3bugs", "portablelight", "crewcontract_science", "fm_musicplayer", "fu_byospethouse", "fu_racialiser", "fu_shipcraftingtable", "fu_ftldrivedeco", "fu_byoscaptainschairdeco" ],
         "upgradeMaterials" : [
           { "item" : "tungstenbar", "count" : 10 },
           { "item" : "siliconboard", "count" : 2 },
@@ -94,7 +94,7 @@
           }
         },
         "filter" : [ "prototyper1", "prototyper2" ],
-        "initialRecipeUnlocks" : [ "fu_crewdeed", "fu_upgradetable", "labcomputer2", "labcomputer3","fu_autobeamer3farmbeasts","mechassemblystation", "fusubcontroller", "fu_byoscaptainschair", "fu_byosfuelhatch", "fu_byosshipdoor", "fu_byosshiphatch", "fu_byosshiplocker", "fu_byostechstationdeco", "fu_byosteleporterdeco", "powerstation", "mechcraftingtable", "mechrepairpod", "miningbench", "checkpoint", "petpicrepair", "servitorloader", "bothealingstation", "genecabinet", "genestorage", "polymer", "laserdiode", "wiretoolfu", "fu_alternatorgenerator", "fu_woodensifter", "siliconboard", "electromagnet", "wire", "microscope", "handmill", "nanofabricator", "armory", "designlab", "sproutingtable", "fu_growingtray", "farmwell", "eggincubator", "heavypipe", "fulabpipe", "labtechpanel", "fu_autobeamer3bugs", "portablelight", "fulabhoverplatform", "fulabhoverpanel", "labvendingmachine", "techconsole", "xenostation", "apexcoolshelf2",  "apexpod2", "electronmicroscope", "titaniumwallblockmaterial", "speedblockmaterial", "jumpblockmaterial", "extractionlab", "manipulatormodule", "upgrademodule", "techcard", "crewcontract_gas", "crewcontract_sciencedrug", "crewcontract_scuba", "fm_musicplayer", "fu_byospethouse", "fu_racialiser", "fu_shipcraftingtable", "fu_ftldrivedeco", "fu_byoscaptainschairdeco" ],
+        "initialRecipeUnlocks" : [ "fu_crewdeed", "fu_upgradetable", "labcomputer2", "labcomputer3","fu_autobeamer3farmbeasts","mechassemblystation", "fusubcontroller", "fu_byoscaptainschair", "fu_byosfuelhatch", "fu_byosshipdoor", "fu_byosshiphatch", "fu_byosshiplocker", "fu_byostechstationdeco", "fu_byostechstation", "fu_byosteleporterdeco", "powerstation", "mechcraftingtable", "mechrepairpod", "miningbench", "checkpoint", "petpicrepair", "servitorloader", "bothealingstation", "genecabinet", "genestorage", "polymer", "laserdiode", "wiretoolfu", "fu_alternatorgenerator", "fu_woodensifter", "siliconboard", "electromagnet", "wire", "microscope", "handmill", "nanofabricator", "armory", "designlab", "sproutingtable", "fu_growingtray", "farmwell", "eggincubator", "heavypipe", "fulabpipe", "labtechpanel", "fu_autobeamer3bugs", "portablelight", "fulabhoverplatform", "fulabhoverpanel", "labvendingmachine", "techconsole", "xenostation", "apexcoolshelf2",  "apexpod2", "electronmicroscope", "titaniumwallblockmaterial", "speedblockmaterial", "jumpblockmaterial", "extractionlab", "manipulatormodule", "upgrademodule", "techcard", "crewcontract_gas", "crewcontract_sciencedrug", "crewcontract_scuba", "fm_musicplayer", "fu_byospethouse", "fu_racialiser", "fu_shipcraftingtable", "fu_ftldrivedeco", "fu_byoscaptainschairdeco" ],
         "upgradeMaterials" : [
           { "item" : "titaniumbar", "count" : 6 },
           { "item" : "cpu", "count" : 2 },
@@ -137,7 +137,7 @@
         "craftingSound" : "/sfx/interface/crafting_furnacetech.ogg",
         "initialRecipeUnlocks" : [
         "fu_crewdeed", "fu_upgradetable", "mechassemblystation", "fusubcontroller", "fu_autobeamer3farmbeasts",
-        "fu_byoscaptainschair", "fu_byosfuelhatch", "fu_byosshipdoor", "fu_byosshiphatch", "fu_byosshiplocker", "fu_byostechstationdeco", "fu_byosteleporterdeco",
+        "fu_byoscaptainschair", "fu_byosfuelhatch", "fu_byosshipdoor", "fu_byosshiphatch", "fu_byosshiplocker", "fu_byostechstationdeco", "fu_byostechstation", "fu_byosteleporterdeco",
         "mechcraftingtable",
         "mechrepairpod",
         "miningbench",

--- a/objects/ship/fu_bootuptemp/fu_bootuptemp.lua
+++ b/objects/ship/fu_bootuptemp/fu_bootuptemp.lua
@@ -9,11 +9,16 @@ function init()
 	message.setHandler("byos", function(_,_,species)
 		shipObjects = world.entityQuery(position, config.getParameter("scanRadius"))
 		newShipObjects = {}
+		newShipObjectsUniqueIds = {}
 		for _, shipObjectId in pairs (shipObjects) do
 			local shipObjectReplacement = world.getObjectParameter(shipObjectId, "byosBootupReplacement")
+			local shipObjectUniqueId = world.getObjectParameter(shipObjectId, "byosBootupUniqueId")
 			if shipObjectReplacement then
 				newShipObjects[world.entityPosition(shipObjectId)] = shipObjectReplacement
 				world.breakObject(shipObjectId, true)
+			end
+			if shipObjectUniqueId then
+				newShipObjectsUniqueIds[shipObjectReplacement] = shipObjectUniqueId
 			end
 		end
 		baseStats = config.getParameter("baseStats")
@@ -35,6 +40,10 @@ function update(dt)
 					parameters = nil
 					if newShipObjectData.racialiserType then
 						parameters = getBYOSParameters(newShipObjectData.racialiserType, newShipObjectData.shipPetType, newShipObjectData.byosBootupTreasure)
+					end
+					local newShipObjectsUniqueId = newShipObjectsUniqueIds[newShipObject]
+					if newShipObjectsUniqueId then
+						parameters.uniqueId = newShipObjectsUniqueId
 					end
 					world.placeObject(newShipObject, newShipObjectPosition, _, parameters)
 				end

--- a/objects/ship/fu_byosobjectdeath.lua
+++ b/objects/ship/fu_byosobjectdeath.lua
@@ -1,5 +1,11 @@
 function die()
+	if config.getParameter("keepStorage") then
+		storageData = storage
+	end
 	storage = {}
 	object.setConfigParameter("treasurePools", nil)
 	object.setConfigParameter("doorState", nil)
+	if config.getParameter("uniqueId") and not config.getParameter("keepUniqueId") then
+		object.setConfigParameter("uniqueId", nil)
+	end
 end

--- a/objects/ship/fu_byostechstation/fu_byostechstation.lua
+++ b/objects/ship/fu_byostechstation/fu_byostechstation.lua
@@ -1,0 +1,102 @@
+function init()
+  --Instantly spawn the pet when first created
+  storage.spawnTimer = storage.spawnTimer and 0.5 or 0
+  storage.petParams = storage.petParams or {}
+
+  self.monsterType = config.getParameter("shipPetType", "petcat")
+  
+  --Purcahasable Pets Fix
+  if self.monsterType == "slimecritter" and root.itemConfig("pethouseSlime") then
+    self.monsterType = "petslime"
+  end
+  
+  self.spawnOffset = config.getParameter("spawnOffset", {0, 2})
+
+  message.setHandler("activateShip", function()
+    animator.playSound("shipUpgrade")
+    self.dialog = config.getParameter("dialog.wakeUp")
+    self.dialogTimer = 0.0
+    self.dialogInterval = 5.0
+    self.drawMoreIndicator = true
+    object.setOfferedQuests({})
+  end)
+
+  message.setHandler("wakePlayer", function()
+    self.dialog = config.getParameter("dialog.wakePlayer")
+    self.dialogTimer = 0.0
+    self.dialogInterval = 14.0
+    self.drawMoreIndicator = false
+    object.setOfferedQuests({})
+  end)
+end
+
+function onInteraction()
+  if self.dialogTimer then
+    sayNext()
+    return nil
+  else
+    return config.getParameter("interactAction")
+  end
+end
+
+function hasPet()
+  return self.petId ~= nil
+end
+
+function setPet(entityId, params)
+  if self.petId == nil or self.petId == entityId then
+    self.petId = entityId
+    storage.petParams = params
+  else
+    return false
+  end
+end
+
+function sayNext()
+  if self.dialog and #self.dialog > 0 then
+    if #self.dialog > 0 then
+      local options = {
+        drawMoreIndicator = self.drawMoreIndicator
+      }
+      self.dialogTimer = self.dialogInterval
+      if #self.dialog == 1 then
+        options.drawMoreIndicator = false
+        self.dialogTimer = 0.0
+      end
+
+      object.sayPortrait(self.dialog[1][1], self.dialog[1][2], nil, options)
+      table.remove(self.dialog, 1)
+
+      return true
+    end
+  else
+    self.dialog = nil
+    return false
+  end
+end
+
+function update(dt)
+  if self.petId and not world.entityExists(self.petId) then
+    self.petId = nil
+  end
+
+  if storage.spawnTimer < 0 and self.petId == nil then
+    storage.petParams.level = 1
+    self.petId = world.spawnMonster(self.monsterType, object.toAbsolutePosition(self.spawnOffset), storage.petParams)
+    world.callScriptedEntity(self.petId, "setAnchor", entity.id())
+    storage.spawnTimer = 0.5
+  else
+    storage.spawnTimer = storage.spawnTimer - dt
+  end
+
+  if self.dialogTimer then
+    self.dialogTimer = math.max(self.dialogTimer - dt, 0.0)
+    if self.dialogTimer == 0 and not sayNext() then
+      self.dialogTimer = nil
+    end
+  end
+  
+  if self.dialogTimer == nil then
+    object.setOfferedQuests(config.getParameter("offeredQuests"))
+  end
+end

--- a/objects/ship/fu_byostechstation/fu_byostechstation.object
+++ b/objects/ship/fu_byostechstation/fu_byostechstation.object
@@ -9,8 +9,8 @@
 
   "category" : "decorative",
 
-  "description" : "Ship-based Artificial Intelligence Lattice, or S.A.I.L for short. (DO NOT PLACE MORE THAN ONE S.A.I.L)",
-  "shortdescription" : "S.A.I.L",
+  "description" : "Ship-based Artificial Intelligence Lattice, or S.A.I.L for short. Comes with a pet.",
+  "shortdescription" : "S.A.I.L Interface",
   "race" : "generic",
 
   "lightColor" : [61, 88, 102],
@@ -61,8 +61,9 @@
 
   "animation" : "/objects/ship/techstation.animation",
   "scripts" : [
-    "/objects/spawner/techstation.lua",
-    "/objects/scripts/customtechstation.lua"
+    "/objects/ship/fu_byostechstation/fu_byostechstation.lua",
+    "/objects/scripts/customtechstation.lua",
+	"/objects/ship/fu_byosobjectdeath.lua"
   ],
   "animationScripts" : ["/objects/ship/fu_byosobjectanimation.lua"],
   "scriptDelta" : 20,
@@ -88,7 +89,6 @@
     ]
   },
 
-  "uniqueId" : "techstation",
   "racialiserType" : "techstation",
   "retainObjectParametersInItem" : true
 }

--- a/objects/ship/fu_byostechstation/fu_byostechstationdeco.object
+++ b/objects/ship/fu_byostechstation/fu_byostechstationdeco.object
@@ -9,7 +9,7 @@
 
   "category" : "decorative",
 
-  "description" : "Ship-based Artificial Intelligence Lattice, or S.A.I.L for short.",
+  "description" : "Ship-based Artificial Intelligence Lattice, or S.A.I.L for short. Does not come with a pet.",
   "shortdescription" : "S.A.I.L Interface",
   "race" : "generic",
 

--- a/objects/ship/fu_byostechstationTier0/fu_byostechstationTier0.object
+++ b/objects/ship/fu_byostechstationTier0/fu_byostechstationTier0.object
@@ -58,5 +58,6 @@
       [ "Rebooting requires a conscious entity to interact with the S.A.I.L console.", "/ai/portraits/fu_byosportrait.png:unique.1" ]
     ]
   },
-  "byosBootupReplacement" : "fu_byostechstation"
+  "byosBootupReplacement" : "fu_byostechstation",
+  "byosBootupUniqueId" : "techstation"
 }

--- a/quests/scripts/story/bootship.lua
+++ b/quests/scripts/story/bootship.lua
@@ -16,6 +16,7 @@ function init()
   self.state:set(wakeSail)
 
   self.interactTimer = 0
+  self.activationTimer = 1
 end
 
 function questInteract(entityId)
@@ -37,9 +38,20 @@ function update(dt)
   self.interactTimer = math.max(self.interactTimer - dt, 0)
   
   promises:update()
+  
+  if self.questComplete then
+    promises:add(world.sendEntityMessage(self.techstationUid, "activateShip"), function()
+      quest.complete()
+	end)
+    if self.activationTimer <= 0 then
+      quest.complete()
+    else
+      self.activationTimer = self.activationTimer - dt
+    end	
+  end
 end
 
-function wakeSail()
+function wakeSail(dt)
   quest.setCompassDirection(nil)
   quest.setObjectiveList({
     {self.descriptions.wakeSail, false}
@@ -69,12 +81,9 @@ function wakeSail()
 
     local shipUpgrades = player.shipUpgrades()
     if shipUpgrades.shipLevel > 0 or player.hasQuest("fu_byos") then
-        --promises:add(world.sendEntityMessage(self.techstationUid, "activateShip"), function()
-        --  quest.complete()
-	--  end, function()
-	--end)   
-	  quest.complete()
-	  world.sendEntityMessage(self.techstationUid, "activateShip")
+        self.questComplete = true
+	  --quest.complete()
+	  --world.sendEntityMessage(self.techstationUid, "activateShip")
     end
     coroutine.yield()
   end

--- a/recipes/fu_shipcraftingtable/functional/fu_byostechstation.recipe
+++ b/recipes/fu_shipcraftingtable/functional/fu_byostechstation.recipe
@@ -1,0 +1,12 @@
+{
+  "input" : [
+	{ "item" : "tungstenbar", "count" : 3 },
+	{ "item" : "salvagetier4", "count" : 1 }
+  ],
+  "output" : {
+    "item" : "fu_byostechstation",
+    "count" : 1
+  },
+  "groups" : [ "prototyper1", "vehicle", "fu_shipcrafting", "furniture", "all" ],
+  "duration" : 1
+}


### PR DESCRIPTION
- Removed the unique Id from the BYOS techstation (gets given one when spawned during bootup and loses it if broken)
- Added a recipe for the non-decorative BYOS techstation (only difference from the decorative one is that this one comes with a pet (check object description to see which is which))
- Made it so that the BYOS techstation will spawn a pet even if you have a mod like purchasable pets
- Made it so that the SAIL speech after bootup should occur on BYOS ships (and it doesn't cause issues with avali this time)