### PR TITLE
Adds "BYOS Only" to byos only object descriptions

### DIFF
--- a/objects/ship/fu_crewbed/fu_crewbed.object
+++ b/objects/ship/fu_crewbed/fu_crewbed.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_crewbed",
   "colonyTags" : ["misc", "bed"],
   "rarity" : "Legendary",
-  "description" : "These cosy beds can stack on top of each other. ^yellow;Crew +1^reset;",
+  "description" : "These cosy beds can stack on top of each other. ^yellow;Crew +1^reset; ^red;BYOS Only^reset;",
   "shortdescription" : "Crew Bed",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_crewbed0/fu_crewbed0.object
+++ b/objects/ship/fu_crewbed0/fu_crewbed0.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_crewbed0",
   "colonyTags" : ["misc", "bed"],
   "rarity" : "legendary",
-  "description" : "These crappy beds attach to a wall. Horribly uncomfortable. Can only place 4. ^yellow;Crew +1^reset;",
+  "description" : "These crappy beds attach to a wall. Horribly uncomfortable. Can only place 4. ^yellow;Crew +1^reset; ^red;BYOS Only^reset;",
   "shortdescription" : "Crappy Crew Bed",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_crewbed2/fu_crewbed2.object
+++ b/objects/ship/fu_crewbed2/fu_crewbed2.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_crewbed2",
   "colonyTags" : ["misc", "bed"],
   "rarity" : "Legendary",
-  "description" : "These cosy beds can stack on top of each other. ^yellow;Crew +1^reset;",
+  "description" : "These cosy beds can stack on top of each other. ^yellow;Crew +1^reset; ^red;BYOS Only^reset;",
   "shortdescription" : "Crew Bunk (Black)",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_crewbed3/fu_crewbed3.object
+++ b/objects/ship/fu_crewbed3/fu_crewbed3.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_crewbed3",
   "colonyTags" : ["misc", "bed"],
   "rarity" : "Legendary",
-  "description" : "Fits two crew members. Installs into the wall! ^yellow;Crew +2^reset;",
+  "description" : "Fits two crew members. Installs into the wall! ^yellow;Crew +2^reset;. ^red;BYOS Only^reset;",
   "shortdescription" : "Crew Bunk (Wall)",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_crewbed4/fu_crewbed4.object
+++ b/objects/ship/fu_crewbed4/fu_crewbed4.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_crewbed4",
   "colonyTags" : ["misc", "bed"],
   "rarity" : "Legendary",
-  "description" : "I'm sure this is comfortable to someone, somewhere... ^yellow;Crew +1^reset;",
+  "description" : "I'm sure this is comfortable to someone, somewhere... ^yellow;Crew +1^reset;, ^red;BYOS Only^reset;",
   "shortdescription" : "Crew Bed (Vat)",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_crewbed5/fu_crewbed5.object
+++ b/objects/ship/fu_crewbed5/fu_crewbed5.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_crewbed5",
   "colonyTags" : ["misc", "bed"],
   "rarity" : "Legendary",
-  "description" : "Lovely wall-recessed sleepy spots. ^yellow;Crew +1^reset;",
+  "description" : "Lovely wall-recessed sleepy spots. ^yellow;Crew +1^reset;. ^red;BYOS Only^reset;",
   "shortdescription" : "Crew Bunk (Wall)",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_crewdeed/fu_crewdeed.object
+++ b/objects/ship/fu_crewdeed/fu_crewdeed.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_crewdeed",
   "colonyTags" : [],
   "rarity" : "Common",
-  "description" : "Place in an enclosed building with at least one door, a light source and some furniture to gain ^yellow;Crew +1^reset;!",
+  "description" : "Place in an enclosed building with at least one door, a light source and some furniture to gain ^yellow;Crew +1^reset;! ^red;BYOS Only^reset;",
   "shortdescription" : "^yellow;Crew Deed",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_elduukharcrewdeed/fu_elduukharcrewdeed.object
+++ b/objects/ship/fu_elduukharcrewdeed/fu_elduukharcrewdeed.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_elduukharcrewdeed",
   "colonyTags" : [ "elduukhar","common" ],
   "rarity" : "Common",
-  "description" : "Place in an enclosed building with at least one door, a light source and some furniture to gain ^yellow;Crew +1^reset;!",
+  "description" : "Place in an enclosed building with at least one door, a light source and some furniture to gain ^yellow;Crew +1^reset;! ^red;BYOS Only^reset;",
   "shortdescription" : "^yellow;Eld'uukhar Crew Deed",
   "race" : "villager",
   "printable" : false,

--- a/objects/ship/fu_ftldrive/fu_ftldrive.object
+++ b/objects/ship/fu_ftldrive/fu_ftldrive.object
@@ -3,7 +3,7 @@
   "rarity" : "essential",
   "colonyTags" : [ "science" ],
   "category" : "furniture",
-  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^yellow;Impulse Speed +25%^reset; and ^orange;Mass +3^reset;",
+  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^yellow;Impulse Speed +25%^reset; and ^orange;Mass +3^reset;. ^red;BYOS Only^reset;",
   "shortdescription" : "^cyan;FTL Drive^white;",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_ftldrive/fu_ftldriveupgrade.object
+++ b/objects/ship/fu_ftldrive/fu_ftldriveupgrade.object
@@ -3,7 +3,7 @@
   "rarity" : "essential",
   "colonyTags" : [ "science" ],
   "category" : "furniture",
-  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^yellow;Impulse Speed +50%^reset; and ^orange;Mass +3^reset;",
+  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^yellow;Impulse Speed +50%^reset; and ^orange;Mass +3^reset;. ^red;BYOS Only^reset;",
   "shortdescription" : "^cyan;FTL Drive (Upgraded)^reset;",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_ftldrive2/fu_ftldrive2.object
+++ b/objects/ship/fu_ftldrive2/fu_ftldrive2.object
@@ -3,7 +3,7 @@
   "rarity" : "essential",
   "colonyTags" : [ "science" ],
   "category" : "furniture",
-  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^yellow;Impulse Speed +50%^reset; and ^orange;Mass +3^reset;",
+  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^yellow;Impulse Speed +50%^reset; and ^orange;Mass +3^reset;. ^red;BYOS Only^reset;",
   "shortdescription" : "^cyan;FTL Drive^white;",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_ftldrive3/fu_ftldrive3.object
+++ b/objects/ship/fu_ftldrive3/fu_ftldrive3.object
@@ -3,7 +3,7 @@
   "rarity" : "essential",
   "colonyTags" : [ "science" ],
   "category" : "furniture",
-  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^yellow;Impulse Speed +50%^reset; and ^orange;Mass +3^reset;",
+  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^yellow;Impulse Speed +50%^reset; and ^orange;Mass +3^reset;. ^red;BYOS Only^reset;",
   "shortdescription" : "^cyan;FTL Drive^white;",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_ftldrivesmall/fu_ftldrivesmall.object
+++ b/objects/ship/fu_ftldrivesmall/fu_ftldrivesmall.object
@@ -3,7 +3,7 @@
   "rarity" : "essential",
   "colonyTags" : [ "science" ],
   "category" : "furniture",
-  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^orange;Mass +1^reset;",
+  "description" : "An ftl drive for a space ship. Allows you to travel through space. ^orange;Mass +1^reset;. ^red;BYOS Only^reset;",
   "shortdescription" : "^cyan;Small FTL Drive^white;",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_ftldrivesmallbroken/fu_ftldrivesmallbroken.object
+++ b/objects/ship/fu_ftldrivesmallbroken/fu_ftldrivesmallbroken.object
@@ -7,7 +7,6 @@
   "shortdescription" : "^cyan;Small FTL Drive^white;",
   "race" : "generic",
   "printable" : false,
-  "learnBlueprintsOnPickup" : [ "fu_ftldrive", "fu_ftldrive2", "fu_ftldrive3" ],
 
   "inventoryIcon" : "fu_ftldrivesmallicon.png",
   "orientations" : [
@@ -50,20 +49,5 @@
       "initialVelocity" : [0.5, 2.0],
       "position" : [0.4, 0]
     }
-  },
-  
-  "scripts" : [ "/objects/ship/fu_shipstatmodifier.lua", "/objects/ship/fu_ftldriveanimation.lua" ],
-  "scriptDelta" : 60,
-  
-  "stats" : {
-    "shipMass" : 1
-  },
-  "capabilities" : [
-    "systemTravel",
-    "planetTravel"
-  ],
-  "maxAmountGroups" : {
-    "ftlDrive" : 1
-  },
-  "byosOnly" : true
+  }
 }

--- a/objects/ship/fu_fuelpurifier/fu_fuelpurifier.object
+++ b/objects/ship/fu_fuelpurifier/fu_fuelpurifier.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "science", "machines" ],
   "printable" : false,
   "rarity" : "legendary",
-  "description" : "Purifies fuel before it reaches your ships FTL drive. Increases fuel efficiency.",
+  "description" : "Purifies fuel before it reaches your ships FTL drive. Increases fuel efficiency. ^red;BYOS Only^reset;",
   "shortdescription" : "^cyan;Fuel Purifier^reset;",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_fueltank/fu_fueltank.object
+++ b/objects/ship/fu_fueltank/fu_fueltank.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_fueltank",
   "colonyTags" : ["mechanical"],
   "rarity" : "Legendary",
-  "description" : "A tank for storing ship fuel. Holds 1000 Fuel.",
+  "description" : "A tank for storing ship fuel. Holds 1000 Fuel. ^red;BYOS Only^reset;",
   "shortdescription" : "Fuel Tank",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_fueltank2/fu_fueltank2.object
+++ b/objects/ship/fu_fueltank2/fu_fueltank2.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_fueltank2",
   "colonyTags" : ["mechanical"],
   "rarity" : "Legendary",
-  "description" : "A tank for storing ship fuel. Holds 2000 Fuel.",
+  "description" : "A tank for storing ship fuel. Holds 2000 Fuel. ^red;BYOS Only^reset;",
   "shortdescription" : "Fuel Tank MKII",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_largethruster/fu_largethruster.object
+++ b/objects/ship/fu_largethruster/fu_largethruster.object
@@ -3,7 +3,7 @@
   "colonyTags": [],
   "scannable": false,
   "rarity": "Common",
-  "description": "A thruster used for FTL travel. Reduces ship mass slightly.",
+  "description": "A thruster used for FTL travel. Reduces ship mass slightly. ^red;BYOS Only^reset;",
   "shortdescription": "Large Ship Thruster",
   "race": "generic",
   "apexDescription": "A booster. These have been known to malfunction and explode.",

--- a/objects/ship/fu_mediumthruster/fu_mediumthruster.object
+++ b/objects/ship/fu_mediumthruster/fu_mediumthruster.object
@@ -3,7 +3,7 @@
   "colonyTags": [],
   "scannable": false,
   "rarity": "Common",
-  "description": "A thruster used for FTL travel. Reduces ship mass slightly.",
+  "description": "A thruster used for FTL travel. Reduces ship mass slightly. ^red;BYOS Only^reset;",
   "shortdescription": "Medium Ship Thruster",
   "race": "generic",
   "apexDescription": "A booster. These have been known to malfunction and explode.",

--- a/objects/ship/fu_mediumthruster/fu_mediumthrusterBroken.object
+++ b/objects/ship/fu_mediumthruster/fu_mediumthrusterBroken.object
@@ -87,6 +87,5 @@
   "scripts": [
     "/objects/ship/boosters/boosterflame.lua"
   ],
-  "scriptDelta": 60,
-  "byosOnly": true
+  "scriptDelta": 60
 }

--- a/objects/ship/fu_shipengine/fu_shipengine.object
+++ b/objects/ship/fu_shipengine/fu_shipengine.object
@@ -3,7 +3,7 @@
   "rarity" : "essential",
   "colonyTags" : [ "science" ],
   "category" : "furniture",
-  "description" : "An engine for a space ship. Allows you to travel through space. Requires an FTL drive to leave the solar system.",
+  "description" : "An engine for a space ship. Allows you to travel through space. Requires an FTL drive to leave the solar system. ^red;BYOS Only^reset;",
   "shortdescription" : "^cyan;Ship Engine^white;",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_smallthruster/fu_smallthruster.object
+++ b/objects/ship/fu_smallthruster/fu_smallthruster.object
@@ -3,7 +3,7 @@
   "colonyTags": [],
   "scannable": false,
   "rarity": "Common",
-  "description": "A thruster used for non-FTL travel. Increases ship speed slightly.",
+  "description": "A thruster used for non-FTL travel. Increases ship speed slightly. ^red;BYOS Only^reset;",
   "shortdescription": "Small Ship Thruster",
   "race": "generic",
   "apexDescription": "A booster. These have been known to malfunction and explode.",

--- a/objects/ship/fu_tinycrewdeed/fu_tinycrewdeed.object
+++ b/objects/ship/fu_tinycrewdeed/fu_tinycrewdeed.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_tinycrewdeed",
   "colonyTags" : [],
   "rarity" : "Common",
-  "description" : "Place in an enclosed building with at least one door, a light source and some furniture to gain ^yellow;Crew +1^reset;!",
+  "description" : "Place in an enclosed building with at least one door, a light source and some furniture to gain ^yellow;Crew +1^reset;! ^red;BYOS Only^reset;",
   "shortdescription" : "^yellow;Crew Deed (Tiny)",
   "race" : "generic",
   "printable" : false,

--- a/objects/ship/fu_tinycrewdeedinvis/fu_tinycrewdeedinvis.object
+++ b/objects/ship/fu_tinycrewdeedinvis/fu_tinycrewdeedinvis.object
@@ -2,7 +2,7 @@
   "objectName" : "fu_tinycrewdeedinvis",
   "colonyTags" : [],
   "rarity" : "Common",
-  "description" : "Place in an enclosed building with at least one door, a light source and some furniture to gain ^yellow;Crew +1^reset;!",
+  "description" : "Place in an enclosed building with at least one door, a light source and some furniture to gain ^yellow;Crew +1^reset;! ^red;BYOS Only^reset;",
   "shortdescription" : "^yellow;Crew Deed (Tiny, Invis)",
   "race" : "generic",
   "printable" : false,


### PR DESCRIPTION
- BYOS only objects now say that they are in their descriptions
- Made the non-decorative broken small ftl drive not function as a normal small ftl drive