### PR TITLE
Falling Out of Ship World

### DIFF
--- a/quests/scripts/byos/fu_shipupgrades.lua
+++ b/quests/scripts/byos/fu_shipupgrades.lua
@@ -49,7 +49,7 @@ function update(dt)
 			local bottomPosition = entity.position()
 			bottomPosition[2] = 0
 			if world.polyContains(mcontroller.collisionBody(), bottomPosition) then
-				status.addEphemeralEffect("fu_byosbeamdown", 60)
+				status.addEphemeralEffect("fu_byosbeamdown", 10)
 				player.warp("OrbitedWorld")
 				beamDownTimer = 10
 			end

--- a/quests/scripts/byos/fu_shipupgrades.lua
+++ b/quests/scripts/byos/fu_shipupgrades.lua
@@ -11,6 +11,8 @@ function init()
 	maxFuelShipOld = 0
 	fuelEfficiencyShipOld = 0
 	shipSpeedShipOld = 0
+	counter = 1
+	beamDownTimer = 0
 end
 
 function update(dt)
@@ -42,6 +44,17 @@ function update(dt)
 			end
 		else
 			lifeSupport(true)
+		end
+		if beamDownTimer <= 0 then
+			local bottomPosition = entity.position()
+			bottomPosition[2] = 0
+			if world.polyContains(mcontroller.collisionBody(), bottomPosition) then
+				status.addEphemeralEffect("fu_byosbeamdown", 60)
+				player.warp("OrbitedWorld")
+				beamDownTimer = 10
+			end
+		else
+			beamDownTimer = beamDownTimer - dt
 		end
 	end
 	

--- a/quests/scripts/byos/fu_shipupgrades.lua
+++ b/quests/scripts/byos/fu_shipupgrades.lua
@@ -11,7 +11,6 @@ function init()
 	maxFuelShipOld = 0
 	fuelEfficiencyShipOld = 0
 	shipSpeedShipOld = 0
-	counter = 1
 	beamDownTimer = 0
 end
 

--- a/stats/effects/fu_effects/fu_byosbeamdown/fu_byosbeamdown.lua
+++ b/stats/effects/fu_effects/fu_byosbeamdown/fu_byosbeamdown.lua
@@ -1,0 +1,16 @@
+function init()
+	counter = 0
+	worldType = world.type()
+end
+
+function update(dt)
+	if worldType ~= "unknown" then
+		if counter == 1 then
+			local worldHeight = world.size()[2]
+			mcontroller.setYPosition(worldHeight)
+			effect.expire()
+		else
+			counter = 1
+		end
+	end
+end

--- a/stats/effects/fu_effects/fu_byosbeamdown/fu_byosbeamdown.statuseffect
+++ b/stats/effects/fu_effects/fu_byosbeamdown/fu_byosbeamdown.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "fu_byosbeamdown",
   "effectConfig" : {},
-  "defaultDuration" : 60,
+  "defaultDuration" : 10,
 
   "scripts" : [
     "fu_byosbeamdown.lua"

--- a/stats/effects/fu_effects/fu_byosbeamdown/fu_byosbeamdown.statuseffect
+++ b/stats/effects/fu_effects/fu_byosbeamdown/fu_byosbeamdown.statuseffect
@@ -1,0 +1,9 @@
+{
+  "name" : "fu_byosbeamdown",
+  "effectConfig" : {},
+  "defaultDuration" : 60,
+
+  "scripts" : [
+    "fu_byosbeamdown.lua"
+  ]
+}


### PR DESCRIPTION
- Makes it so that if you hit the bottom of the ship world you get warped to the top of the place you're orbiting (has a 10 second timer between trys to lower log spam when above Nowhere)
- Note: for some reason you don't get fall damage when you hit the ground after this happens