### PR TITLE
Bootup Fixes

### DIFF
--- a/interface/ai/fu_byosai.lua
+++ b/interface/ai/fu_byosai.lua
@@ -103,15 +103,6 @@ function byos()
 end
 
 function racial()
-	local teleporters = world.entityQuery(world.entityPosition(player.id()), 100, {includedTypes = {"object"}})
-    teleporters = util.filter(teleporters, function(entityId)
-		if string.find(world.entityName(entityId), "teleporterTier0") then
-			return true
-		end
-    end)
-    if #teleporters > 0 then
-		player.lounge(teleporters[1])
-    end
 	race = player.species()
 	count = racialiserBootUp()
 	parameters = getBYOSParameters("techstation", true, _)

--- a/quests/scripts/story/bootship.lua
+++ b/quests/scripts/story/bootship.lua
@@ -39,15 +39,19 @@ function update(dt)
   
   promises:update()
   
-  if self.questComplete then
+  if self.questComplete and not self.techstationFound then
     promises:add(world.sendEntityMessage(self.techstationUid, "activateShip"), function()
-      quest.complete()
+      self.techstationFound = true
 	end)
     if self.activationTimer <= 0 then
-      quest.complete()
+      self.techstationFound = true
     else
       self.activationTimer = self.activationTimer - dt
     end	
+  end
+  
+  if self.techstationFound then
+    quest.complete()
   end
 end
 
@@ -82,13 +86,12 @@ function wakeSail(dt)
     local shipUpgrades = player.shipUpgrades()
     if shipUpgrades.shipLevel > 0 or player.hasQuest("fu_byos") then
         self.questComplete = true
-	  --quest.complete()
-	  --world.sendEntityMessage(self.techstationUid, "activateShip")
     end
     coroutine.yield()
   end
 end
 
 function questComplete()
+  status.addEphemeralEffect("fu_byosfindship", 10)
   questutil.questCompleteActions()
 end

--- a/stats/effects/fu_effects/fu_byosfindship/fu_byosfindship.lua
+++ b/stats/effects/fu_effects/fu_byosfindship/fu_byosfindship.lua
@@ -1,0 +1,20 @@
+require "/scripts/messageutil.lua"
+
+function init()
+	self.techstationUid = config.getParameter("techstationUid")
+	if world.pointTileCollision(entity.position()) then
+		promises:add(world.findUniqueEntity(self.techstationUid), function(position)
+			self.techstationLocation = position
+		end)
+	else
+		effect.expire()
+	end
+end
+
+function update(dt)
+	promises:update()
+	if self.techstationLocation then
+		mcontroller.setPosition(self.techstationLocation)
+		effect.expire()
+	end
+end

--- a/stats/effects/fu_effects/fu_byosfindship/fu_byosfindship.statuseffect
+++ b/stats/effects/fu_effects/fu_byosfindship/fu_byosfindship.statuseffect
@@ -1,0 +1,11 @@
+{
+  "name" : "fu_byosfindship",
+  "effectConfig" : {
+    "techstationUid" : "techstation"
+  },
+  "defaultDuration" : 10,
+
+  "scripts" : [
+    "fu_byosfindship.lua"
+  ]
+}


### PR DESCRIPTION
- Fixes the issue where the bootup quest can sometimes get completed multiple times
- Stopped the player from being teleported to the teleporter when they select the racial ship and instead made the player teleport to SAIL if there is a tile at their position