### PR TITLE
Name change for "Argenttip".

### DIFF
--- a/_FUversioning.config
+++ b/_FUversioning.config
@@ -23,9 +23,9 @@ __________________________________________________
   
   * Reduced the overall damage output of Friendmaker, as it was over-performing by a large margin. It's stats remain the same, but the explosion no longer doubles output.
   
-  * added Irradium themed guards (argenttip)
+  * added Irradium themed guards (Silvertip)
   
-  * added new npc statuses (argenttip)
+  * added new npc statuses (Silvertip)
   
   * added some Elduukhar clothing (Shinigami Apples)
 __________________________________________________


### PR DESCRIPTION
Silvertip and Argenttip are the same person. 

Silvertip is the preferred name as that is the name used on the FU Discord.