### PR TITLE
Add an indicator property to tell other mods if BYOS no-gravity is in effect

### DIFF
--- a/quests/scripts/fu_shipupgrades.lua
+++ b/quests/scripts/fu_shipupgrades.lua
@@ -108,15 +108,18 @@ function lifeSupport(isOn)
 	if isOn then
 		mcontroller.clearControls()
 		status.removeEphemeralEffect("fu_nooxygen")
+		status.setStatusProperty("fu_byosnogravity", false)
 		lifeSupportInit = false
 	else
 		if status.statusProperty("fu_byosgravgenfield", 0) > 0 then
 			mcontroller.clearControls()
+			status.setStatusProperty("fu_byosnogravity", false)
 			lifeSupportInit = false
 		else
 			mcontroller.controlParameters({gravityEnabled = false})
 			if not lifeSupportInit then
 				mcontroller.setVelocity({0, 0})
+				status.setStatusProperty("fu_byosnogravity", true)
 				lifeSupportInit = true
 			end
 		end


### PR DESCRIPTION
Without this, there's no practical way for a flight tech or similar to tell if there's no gravity in the environment if the tech itself disables gravity.