### PR TITLE
Fixed E.V.A. set bonus effect

### DIFF
--- a/stats/effects/fu_armoreffects/set_bonuses/evasetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/evasetbonuseffect.lua
@@ -4,7 +4,7 @@ weaponBonus={}
 
 armorBonus={
 	{stat = "pusImmunity", amount = 1},
-	{stat = "biomeradiationImmunity", amount = 1},
+	{stat = "liquidnitrogenImmunity", amount = 1},
 	{stat = "biomeradiationImmunity", amount = 1},
 	{stat = "radiationburnImmunity", amount = 1}	
 }


### PR DESCRIPTION
As stated in evasetbonuseffect.statuseffect, this armor set should provide a liquid nitrogen immunity.