### PR TITLE
Crew Deed Quest Fix

### DIFF
--- a/quests/fu_questlines/byos/fu_byoscrewdeed.questtemplate
+++ b/quests/fu_questlines/byos/fu_byoscrewdeed.questtemplate
@@ -22,7 +22,7 @@
     "conditions" : [
       {
         "type" : "gatherItem",
-        "itemName" : "fu_crewbed0",
+        "itemName" : "fu_crewdeed",
         "count" : 1,
         "consume" : false
       }


### PR DESCRIPTION
- The crew deed BYOS quest should now require a crew deed instead of a crappy crew bed