### PR TITLE
Update fuguard_effigium.tenant

### DIFF
--- a/tenants/guards/fuguard_effigium.tenant
+++ b/tenants/guards/fuguard_effigium.tenant
@@ -14,7 +14,7 @@
       "spawn": "npc",
       "species": ["human", "shadow", "nightar"],
       "level": 4,
-      "type": "fuseffigiumguard",
+      "type": "fueffigiumguard",
       "overrides": {
         "damageTeamType" : "friendly"
        }


### PR DESCRIPTION
Typo fix, so tenant file references a valid NPC (found after seeing "Error loading tenant file /npcs/fueffigiumguard.tenant: (JsonException) No such key in Json::get("name")" logged)