### PR TITLE
Madness condenser -> consumer recipe group

### DIFF
--- a/recipes/madness/atmoscondensermadness.recipe
+++ b/recipes/madness/atmoscondensermadness.recipe
@@ -11,6 +11,6 @@
     "item" : "atmoscondensermadness",
     "count" : 1
   },
-  "groups" : [ "powerstation2", "power", "all"  ],
+  "groups" : [ "powerstation2", "consumer", "all"  ],
   "duration" : 0.01
 }


### PR DESCRIPTION
I believe this object belongs in the 'consumer' group, with the regular condenser, since it requires power rather than produces it.