### PR TITLE
Addition and reorganization of core colors

### DIFF
--- a/species/radien.species
+++ b/species/radien.species
@@ -214,22 +214,44 @@
   ],
  
   "undyColor" : [
-     // Blue
-    { "951500" : "2a323c", "dc1f00" : "95c2ff" },
-    // Green
-    { "951500" : "2a3c2c", "dc1f00" : "95ffa0" },
-    // Orange
-    { "951500" : "3c332a", "dc1f00" : "f8b77a" },
+     // White
+    { "951500" : "292d3b", "dc1f00" : "ebf7fa" },
+    // Gray
+    { "951500" : "363e46", "dc1f00" : "b7b7b7" },
     // Pink
     { "951500" : "3c2a3b", "dc1f00" : "ff94f9" },
     // Purple
     { "951500" : "372a3c", "dc1f00" : "cc94ff" },
+    // Beyond the Cosmos
+    { "951500" : "292444", "dc1f00" : "7224ff" },
+    // Cornflower
+    { "951500" : "3b3e6d", "dc1f00" : "858bff" },
+    // Deep blue
+    { "951500" : "1f2c47", "dc1f00" : "4650f9" },
+    // Blue
+    { "951500" : "2a323c", "dc1f00" : "95c2ff" },
+    // Volatile Memory
+    { "951500" : "264f4e", "dc1f00" : "00fffa" },
+    // Aquamarine
+    { "951500" : "293b36", "dc1f00" : "4ceec5" },
+    // Green
+    { "951500" : "2a3c2c", "dc1f00" : "95ffa0" },
+    // Nuclear Dusk
+    { "951500" : "364c1a", "dc1f00" : "c7fc83" },
+    // Yellow
+    { "951500" : "3b3c2a", "dc1f00" : "e3ff94" },
+    // True Yellow
+    { "951500" : "595723", "dc1f00" : "f3ff57" },
+    // Midas' Gaze
+    { "951500" : "463a1c", "dc1f00" : "fcde43" },
+    // Orange
+    { "951500" : "3c332a", "dc1f00" : "f8b77a" },
+    // Eos' Dawn
+    { "951500" : "4f3429", "dc1f00" : "f78e3e" },
     // Red
     { "951500" : "3c2a2a", "dc1f00" : "f87a7a" },
-    // White
-    { "951500" : "292d3b", "dc1f00" : "ebf7fa" },
-    // Yellow
-    { "951500" : "3b3c2a", "dc1f00" : "e3ff94" }
+    // Starless
+    { "951500" : "3c2a2a", "dc1f00" : "f87a7a" }
   ],
  
   "hairColor" : [


### PR DESCRIPTION
Added a total of 11 new core colors to the Radien/X'i and reorganized the undycolor section so the colors would be in order per hue.