### PR TITLE
Update fupyreite.chest

### DIFF
--- a/items/armors/tier6/fupyreitearmor/fupyreite.chest
+++ b/items/armors/tier6/fupyreitearmor/fupyreite.chest
@@ -7,7 +7,7 @@
   "rarity" : "Rare",
    "description" : "Set Bonus:
 ^cyan;Immune: Cold, Ice Slip, Snow, Freeze, Nitrogen^reset;
-^#e43774;60% Ice Resist^reset;
+^#e43774;20% Ice Resist^reset;
 ^green;+25% Damage (Pyreite weapons)^reset;", 
   "shortdescription" : "Pyreite Chestplate",
   "category" : "t6armor",


### PR DESCRIPTION
The description of all isogen armor pieces tell how much % resistance they give,summing up 60% if you equip all three.But this is not the same with the pyreite armour,all of the descriptions of its pieces tell the final value but not how much they give individually.