### PR TITLE
ore category added. wired terramarts adjusted.

### DIFF
--- a/items/bees/other/beeflowerhead.item
+++ b/items/bees/other/beeflowerhead.item
@@ -6,5 +6,6 @@
   "description" : "The head of a Bee flower. Contains traces of anti-mite poison!",
   "shortdescription" : "Bee Flower Head",
   "maxStack" : 600,
+  "category" : "craftingMaterial",
   "itemTags" : [ "reagent" ]
 }

--- a/objects/generic/cropshipper/cropshipper_kheAA.object
+++ b/objects/generic/cropshipper/cropshipper_kheAA.object
@@ -6,7 +6,7 @@
 
 	"category": "shippingContainer",
 	"price": 3000,
-	"description": "Wire-controlled Terramart Shipments space-launcher.",
+	"description": "Wire-controlled Terramart Shipments space-launcher.\n^blue;Upper Input: Logic Node^reset;\n^blue;Lower Input: Item Network^reset;",
 	"shortdescription": "Terramart Shipments 3.0",
 	"race": "generic",
 
@@ -51,7 +51,7 @@
 	"openFrameIndex": 1,
 	"autoCloseCooldown": 3600,
 
-	"inputNodes": [[0, 0],[0,1]],
+	"inputNodes": [[0, 1],[0,0]],
 	"outputNodes": [[1, 0]],
 	"scripts": ["/objects/generic/cropshipper/cropshipper_kheAA.lua"],
 	"scriptDelta": 5,

--- a/objects/generic/cropshipper/cropshipper_kheAA2.object
+++ b/objects/generic/cropshipper/cropshipper_kheAA2.object
@@ -6,7 +6,7 @@
 
 	"category": "shippingContainer",
 	"price": 3000,
-	"description": "Wire-controlled Terramart Shipments teleporter.",
+	"description": "Wire-controlled Terramart Shipments teleporter.\n^blue;Upper Input: Logic Node^reset;\n^blue;Lower Input: Item Network^reset;",
 	"shortdescription": "Terramart Shipments 3.5",
 	"race": "generic",
 
@@ -51,7 +51,7 @@
 	"openFrameIndex": 1,
 	"autoCloseCooldown": 3600,
 
-	"inputNodes": [[0, 0],[0,1]],
+	"inputNodes": [[0, 1],[0,0]],
 	"outputNodes": [[1, 0]],
 	"scripts": ["/objects/generic/cropshipper/cropshipper_kheAA.lua"],
 	"scriptDelta": 5,

--- a/scripts/kheAA/transferconfig.config
+++ b/scripts/kheAA/transferconfig.config
@@ -213,6 +213,7 @@
 		// crafting stuff
 		"salvage component":"reagent",
 		"craftingmaterial" : "reagent",
+		"ore":"reagent",
 		"cookingingredient" : "reagent",
 		"fuel" : "reagent",
 		// test by orangejuice


### PR DESCRIPTION
adding Ore as a category for transferconfig, under Reagents. also swapping inputs on the wired terramart shippers and updating their descriptions to show which nodes are what.