### PR TITLE
Update heatweathernew2.statuseffect

### DIFF
--- a/stats/effects/fu_weathereffects/new/heat/heatweathernew2.statuseffect
+++ b/stats/effects/fu_weathereffects/new/heat/heatweathernew2.statuseffect
@@ -6,7 +6,7 @@
     "resistanceTypes" : {
       "fireResistance" : 1.0
     },
-    "resistanceThreshold" : 0.25,
+    "resistanceThreshold" : 0.45,
     "immunityStats" : [
       "biomeheatImmunity",
       "ffextremeheatImmunity"


### PR DESCRIPTION
Fixed for typo. Increases in weather effects have a 20% increase in general. heaweathernew.statuseffect is 25%heat resist, so this one most likely need to be up at 45% to be consistent