### PR TITLE
Avian Greeting Converse Fix

### DIFF
--- a/dialog/converse.config.patch
+++ b/dialog/converse.config.patch
@@ -1809,18 +1809,18 @@
     },
     {
         "op": "add",
-        "path": "/greeting/avian",
-        "value": {
-            "fukirhos": [
-                "Greetings, Kirhos."
-            ],
-            "elduukhar": [
-                "Hello, my friend.",
-                "I wish you a safe journey, friend."
- 
-            ]
- 
-        }
+        "path": "/greeting/avian/fukirhos",
+        "value": [
+            "Greetings, Kirhos."
+        ]
+    },
+    {
+        "op": "add",
+        "path": "/greeting/avian/elduukhar",
+        "value": [
+            "Hello, my friend.",
+            "I wish you a safe journey, friend."
+        ]
     },
     {
         "op": "add",


### PR DESCRIPTION
Replacing a batch add patch with instead two seperated patches with altered paths to not overwrite the default dialog of an Avian greeting.