### PR TITLE
scan tooltips

### DIFF
--- a/objects/crafting/farmwell/farmwell.object
+++ b/objects/crafting/farmwell/farmwell.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "farmwell",
   "rarity" : "Common",
-  "description" : "Generates water for use around your home. Stores up to 200 water.",
+  "description" : "Generates water for use around your home. Stores up to 200 water. Less effective when stacked. Scan for Info.",
   "shortdescription" : "Well",
   "race" : "generic",
   "category" : "decorative",

--- a/objects/crafting/liquidpumpwell/liquidpumpwell.object
+++ b/objects/crafting/liquidpumpwell/liquidpumpwell.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "liquidpumpwell",
   "rarity" : "Common",
-  "description" : "Generates water better than a Well. Stores up to 1000 water.",
+  "description" : "Generates water better than a Well. Stores up to 1000 water. Less effective when stacked. Scan for Info.",
   "shortdescription" : "Water Generator",
   "race" : "generic",
   "category" : "decorative",

--- a/objects/power/fu_liquidcondenser/fu_liquidcondenser.object
+++ b/objects/power/fu_liquidcondenser/fu_liquidcondenser.object
@@ -2,7 +2,7 @@
 	"objectName": "fu_liquidcondenser",
 	"rarity": "rare",
 	"colonyTags": ["science", "wired", "lab"],
-	"description": "Condenses liquid from biome atmosphere. Requires 4W of power. Scan for more Info.",
+	"description": "Condenses liquid from biome atmosphere. Requires 4W of power. Less effective when stacked. Scan for Info.",
 	"shortdescription": "^cyan;Liquid Collector^white;",
 	"race": "generic",
 	"category": "wire",

--- a/objects/power/fu_liquidcondenser/isn_resource_generator.lua
+++ b/objects/power/fu_liquidcondenser/isn_resource_generator.lua
@@ -36,11 +36,11 @@ function init()
 	storage.timer = storage.timer or 1
 	power.init()
 	power.update()
-	setDesc()
 	storage.outputPos=entity.position()
 	storage.outputPos[1]=storage.outputPos[1]+2+util.clamp(object.direction(),-1,0)
 	wellRange=config.getParameter("airWellRange",20)
 	wellInit()
+	setDesc()
 end
 
 function update(dt)
@@ -106,7 +106,7 @@ function setDesc()
 			info="Atmosphere: "..color..info.name.."^reset;"
 		end
 	end
-	object.setConfigParameter('description',baseMessage.."\n"..info)
+	object.setConfigParameter('description',baseMessage.."\n"..info.."\n^red;Range:^gray; "..wellRange.."^reset;")
 end
 
 function toHex(num)

--- a/objects/power/isn_atmoscondenser/isn_atmoscondenser.object
+++ b/objects/power/isn_atmoscondenser/isn_atmoscondenser.object
@@ -2,7 +2,7 @@
     "objectName" : "isn_atmoscondenser",
     "rarity" : "rare",
     "colonyTags" : [ "science" ],
-    "description" : "Condenses the atmosphere into usable reagents. Requires 15W of power.",
+    "description" : "Condenses the atmosphere into usable reagents. Requires 15W of power. Less effective when stacked. Scan for Info.",
     "shortdescription" : "^cyan;Atmospheric Condenser^white;",
     "race" : "generic",
     "category" : "storage",
@@ -43,6 +43,9 @@
         "uncommon" : 20,
         "rare" : 1
     },
+	
+	//rarities to show up to, on the scan tooltip. 0=none,1=common,2=uncommon,3=rare
+	"rarityInfoLevel":2,
 
     // Outputs per biome
     "outputs" : {

--- a/objects/power/isn_atmoscondenser/isn_atmoscondensermadness.object
+++ b/objects/power/isn_atmoscondenser/isn_atmoscondensermadness.object
@@ -2,7 +2,7 @@
     "objectName" : "atmoscondensermadness",
     "rarity" : "rare",
     "colonyTags" : [ "science","elder","macabre","genetics" ],
-    "description" : "Siphons and warps the atmosphere into usable reagents. Requires 42W of power.",
+    "description" : "Siphons and warps the atmosphere into usable reagents. Requires 42W of power. Less effective when stacked. Scan for Info.",
     "shortdescription" : "Entropic Converter",
     "race" : "generic",
     "category" : "storage",
@@ -22,6 +22,9 @@
 	
 	"airWellRange":30,
 	"productionTime":520,
+
+	//rarities to show up to, on the scan tooltip. 0=none,1=common,2=uncommon,3=rare
+	"rarityInfoLevel":1,
 
     "namedWeights" : {
         "common" : 79,

--- a/objects/power/isn_atmoscondenser/isn_resource_generator.lua
+++ b/objects/power/isn_atmoscondenser/isn_resource_generator.lua
@@ -21,6 +21,10 @@ function init()
     self.outputMap = {}
 
     initMap(world.type())
+	wellRange=config.getParameter("wellRange",20)
+	wellInit()
+	self.rarityInfoLevel=config.getParameter("rarityInfoLevel",0)
+	setDesc()
 end
 
 function initMap(worldtype)
@@ -33,10 +37,10 @@ function initMap(worldtype)
     local weights = config.getParameter("namedWeights")
     self.maxWeight[worldtype] = 0
     self.outputMap[worldtype] = {}
-    for _,table in ipairs(outputTable or {}) do
-        local weight = weights[table.weight] or table.weight
+    for _,myTable in ipairs(outputTable or {}) do
+        local weight = weights[myTable.weight] or myTable.weight
         self.maxWeight[worldtype] = self.maxWeight[worldtype] + weight
-        self.outputMap[worldtype][weight] = table.items
+        self.outputMap[worldtype][weight] = myTable.items
     end
 end
 
@@ -46,8 +50,8 @@ function update(dt)
 	-- Notify ITD but no faster than once per second.
 	if not deltaTime or (deltaTime > 1) then
 		transferUtil.loadSelfContainer()
-		wellRange=config.getParameter("wellRange",20)
 		wellInit()
+		setDesc()
 		deltaTime = 0
 	else
 		deltaTime=deltaTime+dt
@@ -72,10 +76,10 @@ function update(dt)
 		-- Goes through the list adding values to the range as it goes.
 		-- This keeps the chance ratios while allowing the list to be in any order.
 		local total = 0
-		for weight,table in pairs(self.outputMap[worldtype]) do
+		for weight,myTable in pairs(self.outputMap[worldtype]) do
 			total = total + weight
 			if rarityroll <= total then
-				output = util.randomFromList(table)
+				output = util.randomFromList(myTable)
 				break
 			end
 		end
@@ -97,9 +101,77 @@ function clearSlotCheck(checkname)
 end
 
 
+function setDesc()
+	local color="^yellow;"
+	local info="Standby."
+
+
+	local worldtype = world.type()
+	if worldtype == 'unknown' then
+		worldtype = world.getProperty("ship.celestial_type") or worldtype
+	end
+	
+	local buffer={}
+    local outputConfig = config.getParameter("outputs")
+    local outputTable = outputConfig[worldtype] or outputConfig["default"] or {}
+	
+	--sb.logInfo("%s",outputTable)
+	
+	if type(outputTable) == "string" then
+		outputTable = outputConfig[outputTable] or outputConfig["default"] or {}
+	end
+	
+	local buffer2=""
+	
+	if self.rarityInfoLevel > 0 then
+		buffer2={}
+		for _,myTable in pairs(outputTable) do
+			local weight=myTable.weight
+			if weight=="common" then
+				local items=myTable.items
+				buffer[weight]={}
+				for _,item in pairs(items) do
+					local dummy=string.gsub(root.itemConfig(item).config.shortdescription,"%^.-;","")
+					table.insert(buffer[weight],dummy)
+				end
+				buffer[weight]=table.concat(buffer[weight],", ")
+				buffer2[1]="^white;"..firstToUpper(weight).."^gray;: "..buffer[weight].."^reset;"
+			elseif weight=="uncommon" and self.rarityInfoLevel > 1 then
+				local items=myTable.items
+				buffer[weight]={}
+				for _,item in pairs(items) do
+					local dummy=string.gsub(root.itemConfig(item).config.shortdescription,"%^.-;","")
+					table.insert(buffer[weight],dummy)
+				end
+				buffer[weight]=table.concat(buffer[weight],", ")
+				buffer2[2]="^green;"..firstToUpper(weight).."^gray;: "..buffer[weight].."^reset;"
+			elseif weight=="rare" and self.rarityInfoLevel > 2 then
+				local items=myTable.items
+				buffer[weight]={}
+				for _,item in pairs(items) do
+					local dummy=string.gsub(root.itemConfig(item).config.shortdescription,"%^.-;","")
+					table.insert(buffer[weight],dummy)
+				end
+				buffer[weight]=table.concat(buffer[weight],", ")
+				buffer2[3]="^cyan;"..firstToUpper(weight).."^gray;: "..buffer[weight].."^reset;"
+			end
+		end
+		buffer=table.concat(buffer2,"\n")
+		buffer2="^blue;Outputs:^reset;\n"..buffer.."\n"
+	end
+
+	object.setConfigParameter('description',buffer2.."^red;Well Range:^gray; "..wellRange.."\n^red;Wells in range:^gray; "..((wellsDrawing or 0)-1).."^reset;")
+end
+
 
 function wellInit()
+	if not wellRange then wellRange=config.getParameter("wellRange",20) end
 	wellsDrawing=1+#(world.entityQuery(entity.position(),wellRange,{includedTypes={"object"},withoutEntityId = entity.id(),callScript="fu_isAirWell"}) or {})
 end
 
 function fu_isAirWell() return (animator.animationState("machineState")=="active") end
+
+function firstToUpper(str)
+	--sb.logInfo("%s",str)
+    return (str:gsub("^%l", string.upper))
+end

--- a/scripts/well.lua
+++ b/scripts/well.lua
@@ -4,7 +4,7 @@ function init()
   transferUtil.init()
 	wellRange=config.getParameter("wellRange",20)
   wellInit()
-
+	setDesc()
 end
 
 function update(dt)
@@ -13,6 +13,7 @@ function update(dt)
 			deltaTime=0
 			transferUtil.loadSelfContainer()
 			wellInit()
+			setDesc()
 		else
 			deltaTime=deltaTime+dt
 		end
@@ -62,3 +63,7 @@ function wellInit()
 end
 
 function fu_isWell() return true end
+
+function setDesc()
+	object.setConfigParameter('description',"^red;Range:^gray; "..wellRange.."\n^red;Wells in range:^gray; "..((wellsDrawing or 0)-1).."^reset;")
+end


### PR DESCRIPTION
Wells, Water Generators, Atmospheric Condensers and Entropic Converters now have scan tooltips that display their range and how many of their type are in range.
Atmospheric Condensers and Entropic Converters will also display some of their produce. Condensers will display common and uncommon, while entropic converters will only display common.
see commits for more details.