### PR TITLE
fix and scan tooltip thing

### DIFF
--- a/objects/power/isn_atmoscondenser/isn_atmoscondenser.object
+++ b/objects/power/isn_atmoscondenser/isn_atmoscondenser.object
@@ -44,8 +44,9 @@
         "rare" : 1
     },
 	
-	//rarities to show up to, on the scan tooltip. 0=none,1=common,2=uncommon,3=rare
+	//rarities to show up to, on the scan tooltip, others will simply not display. 0=none (script default),1=common,2=uncommon,3=rare
 	"rarityInfoLevel":2,
+	"overrideScanTooltip":true,
 
     // Outputs per biome
     "outputs" : {

--- a/objects/power/isn_atmoscondenser/isn_atmoscondensermadness.object
+++ b/objects/power/isn_atmoscondenser/isn_atmoscondensermadness.object
@@ -22,6 +22,16 @@
 	
 	"airWellRange":30,
 	"productionTime":520,
+	
+	//rarities to show up to, on the scan tooltip, others will simply not display. 0=none (script default),1=common,2=uncommon,3=rare
+	"rarityInfoLevel":0,
+	"overrideScanTooltip":false,
+
+    "namedWeights" : {
+        "common" : 79,
+        "uncommon" : 20,
+        "rare" : 1
+    },
 
     "outputs" : {
         "default" : [

--- a/objects/power/isn_atmoscondenser/isn_resource_generator.lua
+++ b/objects/power/isn_atmoscondenser/isn_resource_generator.lua
@@ -24,6 +24,7 @@ function init()
 	wellRange=config.getParameter("wellRange",20)
 	wellInit()
 	self.rarityInfoLevel=config.getParameter("rarityInfoLevel",0)
+	self.overrideScanTooltip=config.getParameter("overrideScanTooltip",false)
 	setDesc()
 end
 
@@ -102,6 +103,8 @@ end
 
 
 function setDesc()
+	if not self.overrideScanTooltip then return end
+	
 	local color="^yellow;"
 	local info="Standby."
 


### PR DESCRIPTION
re-adds removed namedweights, which shouldn't have been removed.
re-added displayedRarity to entropic converter, set to 0 (meaning it won't show anything)
added config parameter to simply not override the tooltip for scans, default of false, and set to false on entropic converter. entropic converter will remain mysterious.