### PR TITLE
change price of minecart w/ ores from gen goods store to intended value (300 -> 3000)

### DIFF
--- a/recipes/generalgoodsstore/minecartores.recipe
+++ b/recipes/generalgoodsstore/minecartores.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-		{ "item" : "money", "count" : 300 }
+		{ "item" : "money", "count" : 3000 }
 ],
   "output" : {
     "item" : "minecartores",


### PR DESCRIPTION
the minecarts at the general goods store follow the following general tier list:
normal - price 1000 value 1000
ores - price 300 value 3000
treasure - price 5000 value 5000

the ores minecart can currently be bought and sold for infinite pixel gain, as it sells to NPCs for ~600 pixels (base) and only costs the user 300 at the general goods store. following the pricing of the other carts, it can be deduced that the item was intended to cost 3000, rather than 300 pixels.