### PR TITLE
autobeamer uncrafters

### DIFF
--- a/objects/power/isn_atmoscondenser/isn_atmoscondensermadness.object
+++ b/objects/power/isn_atmoscondenser/isn_atmoscondensermadness.object
@@ -25,7 +25,7 @@
 	
 	//rarities to show up to, on the scan tooltip, others will simply not display. 0=none (script default),1=common,2=uncommon,3=rare
 	"rarityInfoLevel":0,
-	"overrideScanTooltip":false,
+	"overrideScanTooltip":true,
 
     "namedWeights" : {
         "common" : 79,

--- a/recipes/powerstation/convert/khe_autoBeamer1Unmake.recipe
+++ b/recipes/powerstation/convert/khe_autoBeamer1Unmake.recipe
@@ -1,0 +1,10 @@
+{
+  "input" : [
+   { "item" : "fu_autoBeamer", "count" : 1 }
+  ],
+  "output" : {
+    "item" : "HarvesterBeam",
+    "count" : 1
+  },
+  "groups" : [ "powerstation2", "convert", "all", "nouncrafting" ]
+}

--- a/recipes/powerstation/convert/khe_autoBeamer2Unmake.recipe
+++ b/recipes/powerstation/convert/khe_autoBeamer2Unmake.recipe
@@ -1,0 +1,10 @@
+{
+  "input" : [
+   { "item" : "fu_autoBeamer2", "count" : 1 }
+  ],
+  "output" : {
+    "item" : "HarvesterBeam2",
+    "count" : 1
+  },
+  "groups" : [ "powerstation2", "convert", "all", "nouncrafting" ]
+}

--- a/recipes/powerstation/convert/khe_autoBeamer3Unmake.recipe
+++ b/recipes/powerstation/convert/khe_autoBeamer3Unmake.recipe
@@ -1,0 +1,10 @@
+{
+  "input" : [
+   { "item" : "fu_autoBeamer3", "count" : 1 }
+  ],
+  "output" : {
+    "item" : "HarvesterBeam3",
+    "count" : 1
+  },
+  "groups" : [ "powerstation2", "convert", "all", "nouncrafting" ]
+}


### PR DESCRIPTION
Added recipes to break down harvest beamgun turrets. Turret base is lost. Allows upgrading beamgun to make next turret, for unlocks.