### PR TITLE
crew contract update

### DIFF
--- a/items/active/crewcontracts/crewcontract_arctic.activeitem
+++ b/items/active/crewcontracts/crewcontract_arctic.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "Hires an arctic explorer that can help combat deadly cold and increase ship fuel efficiency by 8%.",
+  "description" : "Hires an arctic explorer that provides ^cyan;Deadly Cold Immunity^reset; and increase ship fuel efficiency by 8%.",
   "shortdescription" : "Arctic Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_biohazard.activeitem
+++ b/items/active/crewcontracts/crewcontract_biohazard.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Hires a Biohazard specialist who can protect against radiation and increase your ship's fuel capacity.",
+  "description" : "Hires a Biohazard specialist who provides ^yellow;Deadly Radiation and Rad Burn Immunity^reset;, and increase your ship's fuel capacity by 340.",
   "shortdescription" : "Biohazard Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_chef.activeitem
+++ b/items/active/crewcontracts/crewcontract_chef.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires an apprentice chef to keep you fed and slightly improve fuel efficiency.",
+  "description" : "Hires an apprentice chef to keep you slightly fed and improve fuel efficiency by 4%.",
   "shortdescription" : "Chef Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_chef2.activeitem
+++ b/items/active/crewcontracts/crewcontract_chef2.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires a Line Chef to keep you fed and slightly improve fuel efficiency.",
+  "description" : "Hires a Line Chef to keep you fed and improve fuel efficiency by 6%.",
   "shortdescription" : "Line Chef Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_chef3.activeitem
+++ b/items/active/crewcontracts/crewcontract_chef3.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires a Sous Chef to keep you fed and slightly improve fuel efficiency.",
+  "description" : "Hires a Sous Chef to keep you stuffed and improve fuel efficiency by 8%.",
   "shortdescription" : "Sous Chef Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_collector.activeitem
+++ b/items/active/crewcontracts/crewcontract_collector.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "Loves to hurl his balls at things until they crawl inside.",
+  "description" : "Loves to hurl his balls at things until they crawl inside. Also provides 6% fuel efficiency and a useful ^green;Thorns effect.^reset;",
   "shortdescription" : "Collector Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_counsellor.activeitem
+++ b/items/active/crewcontracts/crewcontract_counsellor.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "Counsellor are quite useful - they can keep madness at bay!",
+  "description" : "Counsellor are quite useful - they can keep madness at bay! They also provide 4% fuel efficiency.",
   "shortdescription" : "Counsellor Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_counsellor2.activeitem
+++ b/items/active/crewcontracts/crewcontract_counsellor2.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Mental health expert. Reduces madness effects up to 40%.",
+  "description" : "Mental health expert. Reduces madness effects up to 40%. Increases fuel efficiency by 4%.",
   "shortdescription" : "Ship Psychologist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_counsellor3.activeitem
+++ b/items/active/crewcontracts/crewcontract_counsellor3.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "legendary",
   "category" : "mysteriousReward",
-  "description" : "Master brain-healer-guy. Reduces madness effects up to 65%.",
+  "description" : "Master brain-healer-guy. Reduces madness effects up to 65%. Increases fuel efficiency by 4%.",
   "shortdescription" : "Ship Psychiatrist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_cultist.activeitem
+++ b/items/active/crewcontracts/crewcontract_cultist.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Hires a flesh-hungry cultist. He increases max ship fuel via dark sacrifice. He also helps protect you against insanity.",
+  "description" : "Hires a flesh-hungry cultist. He increases max ship fuel by 150 via dark sacrifice and provides ^pink;Insanity Immunity^reset; and ^green;Moderate Poison Protection.^reset;",
   "shortdescription" : "Cultist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_cyborg.activeitem
+++ b/items/active/crewcontracts/crewcontract_cyborg.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "Hires a deadly cyborg. Reduces ship mass by 10%, increases ship speed by +1.25 and grants ^pink;Aether Immunity^reset;.",
+  "description" : "Hires a deadly cyborg. Reduces ship mass by 10%, increases ship speed by 1.25 and grants ^pink;Aether Immunity^reset;.",
   "shortdescription" : "Cyborg Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_cyborg.activeitem
+++ b/items/active/crewcontracts/crewcontract_cyborg.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "Hires a deadly cyborg. Grants increased ship speed and Aether protection.",
+  "description" : "Hires a deadly cyborg. Reduces ship mass by 10%, increases ship speed by +1.25 and grants ^pink;Aether Immunity^reset;.",
   "shortdescription" : "Cyborg Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_engineer.activeitem
+++ b/items/active/crewcontracts/crewcontract_engineer.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires an engineer to give a large boost to ship speed and +20% fuel efficiency.",
+  "description" : "Hires an engineer to give +3.75 to ship speed and +20% fuel efficiency.",
   "shortdescription" : "Engineer Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_engineer.activeitem
+++ b/items/active/crewcontracts/crewcontract_engineer.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires an engineer to give +3.75 to ship speed and +20% fuel efficiency.",
+  "description" : "Hires an engineer to increase ship speed by 3.75 and fuel efficiency by 20%.",
   "shortdescription" : "Engineer Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_engineer2.activeitem
+++ b/items/active/crewcontracts/crewcontract_engineer2.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Provides increased fuel efficiency and ship speed.",
+  "description" : "Provides 40% increased fuel efficiency and +3.75 ship speed.",
   "shortdescription" : "Engineer II Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_engineer2.activeitem
+++ b/items/active/crewcontracts/crewcontract_engineer2.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Provides 40% increased fuel efficiency and +3.75 ship speed.",
+  "description" : "Provides 40% increased fuel efficiency and 3.75 ship speed.",
   "shortdescription" : "Engineer II Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_fubees.activeitem
+++ b/items/active/crewcontracts/crewcontract_fubees.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "BZZ BZZZ!",
+  "description" : "BZZ BZZZ! +2 ship speed BEE ENGINES! ^yellow;Bee Sting Immunity^reset; BEE HUGS!",
   "shortdescription" : "Beeguy Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_fubees.activeitem
+++ b/items/active/crewcontracts/crewcontract_fubees.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "BZZ BZZZ! +2 ship speed BEE ENGINES! ^yellow;Bee Sting Immunity^reset; BEE HUGS!",
+  "description" : "BZZ BZZZ! BEE ENGINES PROVIDE 2 SHIP SPEED! ^yellow;BEES DON'T STING^reset;",
   "shortdescription" : "Beeguy Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_fuhunter.activeitem
+++ b/items/active/crewcontracts/crewcontract_fuhunter.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires a hunter to help you collect resources and hunt enemies.",
+  "description" : "Hires a hunter to help you collect resources and hunt enemies. Provides ^red;Fire Status^reset;, ^yellow;Proto Poison^reset;, jungle and mud slow immmunities.",
   "shortdescription" : "Hunter Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_gas.activeitem
+++ b/items/active/crewcontracts/crewcontract_gas.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Hires a gas specialist to boost ship fuel and grant immunity to gas.",
+  "description" : "Hires a gas specialist to boost max ship fuel by 200 and grant ^pink;Gas Immunity^reset;.",
   "shortdescription" : "Gas Specialist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_guardian.activeitem
+++ b/items/active/crewcontracts/crewcontract_guardian.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Impressive defensive crewmates able to take a pounding.",
+  "description" : "Impressive defensive crewmate. Provides a massive ^green;Defense Boost^reset; and 5% increased fuel efficiency.",
   "shortdescription" : "Guardian Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_hobo.activeitem
+++ b/items/active/crewcontracts/crewcontract_hobo.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "Hires... a homeless guy that pukes on things. He also helps fuel your ship, but constantly makes you drunk.",
+  "description" : "Hires... a homeless guy that pukes on things. Increases max fuel by 250, but constantly makes you drunk.",
   "shortdescription" : "Hobo Contract",
   "twoHanded" : true,
   "learnBlueprintsOnPickup" : [ "crewcontract_hobo" ],

--- a/items/active/crewcontracts/crewcontract_janitor.activeitem
+++ b/items/active/crewcontracts/crewcontract_janitor.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Has a mop. Sweeps.",
+  "description" : "Has a mop. Sweeps. Reduces ship mass by 10%.",
   "shortdescription" : "Custodian Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_magicalgirl.activeitem
+++ b/items/active/crewcontracts/crewcontract_magicalgirl.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "A magic girl with a staff that vanquishes evil",
+  "description" : "A magic girl with a staff. Provides ^indigo;Shadow and Shadow Gas Immunity^reset;, and 25% fuel efficiency.",
   "shortdescription" : "Magical Girl Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_mechanic.activeitem
+++ b/items/active/crewcontracts/crewcontract_mechanic.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires a mechanic to increase fuel efficiency and maximum fuel capacity.",
+  "description" : "Hires a mechanic to increase fuel efficiency by 10% and reduce ship mass by 20%.",
   "shortdescription" : "Mechanic Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_mechanic2.activeitem
+++ b/items/active/crewcontracts/crewcontract_mechanic2.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Provides increased fuel efficiency and decreased ship mass.",
+  "description" : "Increases fuel efficiency by 25% and decreases ship mass by 20%.",
   "shortdescription" : "Mechanic II Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_metalhead.activeitem
+++ b/items/active/crewcontracts/crewcontract_metalhead.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Dude.",
+  "description" : "Dude. 4% fuel efficiency. Rock on.",
   "shortdescription" : "80s Metalhead Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_plur.activeitem
+++ b/items/active/crewcontracts/crewcontract_plur.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "The danciest companion in the universe.",
+  "description" : "The danciest companion in the universe, with booze and 4% fuel efficiency.",
   "shortdescription" : "PLUR Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_radien.activeitem
+++ b/items/active/crewcontracts/crewcontract_radien.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "Hires a unique, powerful crew member that provides a huge boost to fuel efficiency and immunity to radiation. And packs a punch.",
+  "description" : "Hires a unique, powerful crew member that provides a huge 75% boost to fuel efficiency and ^yellow;Deadly Radiation Immunity^reset;. And packs a punch.",
   "shortdescription" : "Radien Explorer Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_sciencedrug.activeitem
+++ b/items/active/crewcontracts/crewcontract_sciencedrug.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "Hires a drug specialist to increase jump height, speed, and your ship's fuel efficiency.",
+  "description" : "Hires a drug specialist to increase jump height and speed, and your ship's fuel efficiency by 25%.",
   "shortdescription" : "Drug Specialist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_sciencegas.activeitem
+++ b/items/active/crewcontracts/crewcontract_sciencegas.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "Hires a toxin specialist to provide gas immunity and increase your ship's fuel efficiency.",
+  "description" : "Hires a toxin specialist to provide ^pink;Gas Immunity^reset;, and increase your ship's fuel efficiency by 10%.",
   "shortdescription" : "Toxin Specialist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_stealth.activeitem
+++ b/items/active/crewcontracts/crewcontract_stealth.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Hires a deadly assassin. Can prevent poisons and increase ship maximum fuel.",
+  "description" : "Hires a deadly assassin. Grants ^green;Poison and Bio Ooze Immunity^reset;, and 160 ship maximum fuel.",
   "shortdescription" : "Assassin Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_volcanologist.activeitem
+++ b/items/active/crewcontracts/crewcontract_volcanologist.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "Hires a volcanologist to protect against heat and reduce ship mass.",
+  "description" : "Hires a volcanologist to provide ^red;Moderate Heat Protection^reset; and reduce ship mass by 20%.",
   "shortdescription" : "Volcanologist Contract",
   "twoHanded" : true,
 

--- a/npcs/crew/crewmemberengineer2.npctype
+++ b/npcs/crew/crewmemberengineer2.npctype
@@ -34,7 +34,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll keep your engines in good shape. Thrust velocity is up by 75% and Fuel efficiency is up 40%."
+              "I'll keep your engines in good shape. Thrust velocity is up by 25% and Fuel efficiency is up 40%."
             ]
           }
         }


### PR DESCRIPTION
crew contract descriptions updated to detail the crew member's benefits. 
notes:
-fix: engineer 2 quote stated it increased speed by 75% but it only actually increased by 25%. NPC quote changed to correct value. if 75% is the desired value, ship speed should be increased to 11.25, and quote reverted.
-fix: mechanic incorrectly stated that it increased fuel capacity, instead of reducing ship mass.
-question: why does the hunter provide a defense boost on the ship?