### PR TITLE
Added integration with "EE for Starbound"

### DIFF
--- a/EES_transmutationstudylist.config.patch
+++ b/EES_transmutationstudylist.config.patch
@@ -1,0 +1,52 @@
+[
+    // Farm - T1
+    { "op": "add", "path": "/farm/T1/cinnamon", "value": true},
+    { "op": "add", "path": "/farm/T1/erithianalgae", "value": true},
+    { "op": "add", "path": "/farm/T1/hops", "value": true},
+    { "op": "add", "path": "/farm/T1/dragonsbeard", "value": true},
+    { "op": "add", "path": "/farm/T1/jillyroot", "value": true},
+    { "op": "add", "path": "/farm/T1/littlerascal", "value": true},
+    { "op": "add", "path": "/farm/T1/solusberry", "value": true},
+    { "op": "add", "path": "/farm/T1/blisterbushplantfood", "value": true},
+    { "op": "add", "path": "/farm/T1/energiflower", "value": true},
+    { "op": "add", "path": "/farm/T1/leafshell", "value": true},
+    { "op": "add", "path": "/farm/T1/miraclegrass", "value": true},
+    { "op": "add", "path": "/farm/T1/slimeleaf", "value": true},
+    { "op": "add", "path": "/farm/T1/varanberry", "value": true},
+    { "op": "add", "path": "/farm/T1/vextonguestamen", "value": true},
+    { "op": "add", "path": "/farm/T1/wubstem", "value": true},
+    { "op": "add", "path": "/farm/T1/tearnut", "value": true},
+
+    // Hunt - T1
+    { "op": "add", "path": "/hunt/T1/monsterplating", "value": true},
+
+    // Mine - T1
+    { "op": "add", "path": "/mine/T1/bone", "value": true},
+    { "op": "add", "path": "/mine/T1/lead", "value": true},
+    { "op": "add", "path": "/mine/T1/magnesiumore", "value": true},
+    { "op": "add", "path": "/mine/T1/moonstoneore", "value": true},
+    { "op": "add", "path": "/mine/T1/solarishard", "value": true},
+    { "op": "add", "path": "/mine/T1/sulphur", "value": true},
+    
+    // Mine - T2
+    { "op": "add", "path": "/mine/T2/corruptionore", "value": true},
+    { "op": "add", "path": "/mine/T2/irradiumore", "value": true},
+    { "op": "add", "path": "/mine/T2/neptuniumore", "value": true},
+    { "op": "add", "path": "/mine/T2/penumbriteore", "value": true},
+    { "op": "add", "path": "/mine/T2/platinumore", "value": true},
+    { "op": "add", "path": "/mine/T2/prisiliteore", "value": true},
+    { "op": "add", "path": "/mine/T2/protociteore", "value": true},
+    { "op": "add", "path": "/mine/T2/quietusore", "value": true},
+    { "op": "add", "path": "/mine/T2/thoriumore", "value": true},
+    { "op": "add", "path": "/mine/T2/triangliumore", "value": true},
+    { "op": "add", "path": "/mine/T2/zerchesiumore", "value": true},
+    
+    // Mine - T3
+    { "op": "add", "path": "/mine/T3/blooddiamond", "value": true},
+    { "op": "add", "path": "/mine/T3/densiniumore", "value": true},
+    { "op": "add", "path": "/mine/T3/effigiumore", "value": true},
+    { "op": "add", "path": "/mine/T3/isogenore", "value": true},
+    { "op": "add", "path": "/mine/T3/nocxiumore", "value": true},
+    { "op": "add", "path": "/mine/T3/pyreiteore", "value": true},
+    { "op": "add", "path": "/mine/T3/xithriciteore", "value": true}
+]


### PR DESCRIPTION
Hello!

I'm the author of **"Equivalent Exchange For Starbound"** ([Steam](https://steamcommunity.com/sharedfiles/filedetails/?id=1790667104), [GitHub](https://github.com/AlbertoRota/EquivalentExchangeForStarbound), [ChucklefishForums](https://community.playstarbound.com/resources/equivalent-exchange-for-starbound.5780/)), a mod targeted to reduce the amount of grind in the medium/late game while keeping the "exploration" and "crafting" relevant during the whole gameplay.

Up until now, I handled the integration between your mod (A mod that I'm enjoying a lot) with mine on my side.
To simplify this on my side, and because no one knows your mod better than you, here you have a "pull request" to switch this to your mod.

This way you have full control over _what_, _where_ and _when_ the integration will take place.
Also, since you know your mod better than I'll never do, for you will be a breeze to keet the list updated with your latest developments.

If you have any doubt, I've created the following thread in Steam to try explain how this file works:
[Tutorial: How to add support between your mod and this one.](https://steamcommunity.com/workshop/filedetails/discussion/1790667104/1642042464747956675/)

Regards!