### PR TITLE
Protocite Fuel Canister - Capitalization fix

### DIFF
--- a/items/generic/crafting/chemlab/biofuelcannistermax.item
+++ b/items/generic/crafting/chemlab/biofuelcannistermax.item
@@ -4,7 +4,7 @@
   "category" : "fuel",
   "price" : 330,
   "inventoryIcon" : "biofuelcannistermax.png",
-  "description" : "a truly amazing fuel source.",
+  "description" : "A truly amazing fuel source.",
   "shortdescription" : "Protocite Fuel Canister",
   "fuelAmount" : 25,
   "itemTags" : [ "reagent" ],


### PR DESCRIPTION
Changed the first word of the description from 'a' to 'A'