### PR TITLE
fringe case fix

### DIFF
--- a/objects/minibiome/lush/poptopcavern.lua
+++ b/objects/minibiome/lush/poptopcavern.lua
@@ -2,73 +2,87 @@ require "/scripts/util.lua"
 require "/scripts/messageutil.lua"
 
 function init()
-  self.detectArea = config.getParameter("detectArea")
-  self.detectArea[1] = object.toAbsolutePosition(self.detectArea[1])
-  self.detectArea[2] = object.toAbsolutePosition(self.detectArea[2])
-  
-  storage.uuid = storage.uuid or sb.makeUuid()
-  storage.tricorder = storage.tricorder or {}
-  object.setInteractive(true)
-  
-  message.setHandler("onTeleport", function(message, isLocal, data)
-      if not storage.vanishTime then
-        storage.vanishTime = world.time() + config.getParameter("vanishTime")
-      end
-    end)
+	self.warnOnce={}
+	--unnecessary,unused
+	--self.detectArea = config.getParameter("detectArea")
+	--self.detectArea[1] = object.toAbsolutePosition(self.detectArea[1])
+	--self.detectArea[2] = object.toAbsolutePosition(self.detectArea[2])
+
+	storage.uuid = storage.uuid or sb.makeUuid()
+	storage.tricorder = storage.tricorder or {}
+	object.setInteractive(true)
+
+	message.setHandler("onTeleport",
+		function(message, isLocal, data)
+			if not storage.vanishTime then
+				storage.vanishTime = world.time() + config.getParameter("vanishTime")
+			end
+		end
+	)
 end
 
 function update(dt)
-  promises:update()
+	promises:update()
 
-  local messagePlayers = world.playerQuery(object.position(), config.getParameter("tricorderCheckRange"))
-  if messagePlayers then
-    for _, playerId in pairs (messagePlayers) do
-      promises:add(world.sendEntityMessage(playerId, "fu_key", "statustablet"), function(successful)
-	    if successful then
-	      storage.tricorder[world.entityUniqueId(playerId)] = true
-            else
-	      storage.tricorder[world.entityUniqueId(playerId)] = false
-	    end
-      end, function()
-	    sb.logWarn("Either the player query is detecting some non-players or the message can't be recieved.")
-      end)
+	local messagePlayers = world.playerQuery(object.position(), config.getParameter("tricorderCheckRange"))
+	if messagePlayers then
+		for _, playerId in pairs (messagePlayers) do
+			promises:add(
+				world.sendEntityMessage(playerId, "fu_key", "statustablet"),
+				function(successful)
+					if world.entityUniqueId(playerId) then
+						if successful then
+							storage.tricorder[world.entityUniqueId(playerId)] = true
+						else
+							storage.tricorder[world.entityUniqueId(playerId)] = false
+						end
+					else
+						if not self.warnOnce[playerId] then
+							sb.logWarn("Poptop Cavern Door: Player with ID %s has no unique ID.",playerId)
+							self.warnOnce[playerId]=true
+						end
+					end
+				end,
+				function()
+					sb.logWarn("Poptop Cavern Door:  Either the player query is detecting some non-players or the message can't be received.")
+				end
+			)
+		end
 	end
-  end
-  
-  local players = world.entityQuery(self.detectArea[1], self.detectArea[2], {
-      includedTypes = {"player"},
-      boundMode = "CollisionArea"
-    })
+	--unnecessary, unused
+	--local players = world.playerQuery(self.detectArea[1], self.detectArea[2], {boundMode = "CollisionArea"})
 end
 
 function onInteraction(args)
-  if storage.tricorder[world.entityUniqueId(args.sourceId)] == true then
-    if config.getParameter("returnDoor") then
-      return { "OpenTeleportDialog", {
-          canBookmark = false,
-          includePlayerBookmarks = false,
-          destinations = { {
-            name = "Departure Radar",
-            planetName = "Beam back...hopefully!",
-            icon = "return",
-            warpAction = "Return"
-          } }
-        }
-      }
-    else
-      return { "OpenTeleportDialog", {
-          canBookmark = false,
-          includePlayerBookmarks = false,
-          destinations = { {
-            name = "???",
-            planetName = "Dark Cavern",
-            icon = "default",
-            warpAction = string.format(config.getParameter("destination"), storage.uuid, world.threatLevel())
-          } }
-        }
-      }
-    end
-  else
-    return {config.getParameter("noTricorderInteractAction"), config.getParameter("noTricorderInteractData")}
-  end
+	if args.sourceId and world.entityUniqueId(args.sourceId) and storage.tricorder[world.entityUniqueId(args.sourceId)] == true then
+		if config.getParameter("returnDoor") then
+			return { "OpenTeleportDialog",
+				{
+					canBookmark = false,
+					includePlayerBookmarks = false,
+					destinations = {{
+						name = "Departure Radar",
+						planetName = "Beam back...hopefully!",
+						icon = "return",
+						warpAction = "Return"
+					}}
+				}
+			}
+		else
+			return { "OpenTeleportDialog",
+				{
+					canBookmark = false,
+					includePlayerBookmarks = false,
+					destinations = {{
+						name = "???",
+						planetName = "Dark Cavern",
+						icon = "default",
+						warpAction = string.format(config.getParameter("destination"), storage.uuid, world.threatLevel())
+					}}
+				}
+			}
+		end
+	else
+		return {config.getParameter("noTricorderInteractAction"), config.getParameter("noTricorderInteractData")}
+	end
 end

--- a/scripts/golemancer/gol_monstermain.lua
+++ b/scripts/golemancer/gol_monstermain.lua
@@ -10,7 +10,8 @@ function init()
   self.evolutions = config.getParameter("evolutions")
   self.tickEvoTime = config.getParameter("tickEvoTime") or 5.0
   self.tickEvoTimer = self.tickEvoTime
-  self.tickEvoTimerAging = config.getParameter("agingEvoTime") or 5000
+  self.baseEvoTime=config.getParameter("agingEvoTime") or 5000
+  self.tickEvoTimerAging = self.baseEvoTime
   self.consumedTable = {}
 end
 

--- a/scripts/golemancer/gol_monstermain.lua
+++ b/scripts/golemancer/gol_monstermain.lua
@@ -27,7 +27,7 @@ function update(dt)
     end
   end
   if self.tickEvoTimerAging <= 0 then
-    self.tickEvoTimerAging = self.tickEvoTimerAging
+    self.tickEvoTimerAging = self.baseEvoTime
     self.position = mcontroller.position()
     for _, v in ipairs(self.evolutions) do
       local evolution = root.assetJson(v)


### PR DESCRIPTION
tentative fix for a fringe case error with the poptop cavern door which occurred when a player somehow didn't have a unique ID. Instead of erroring, it will just print a warning to the log. Also commented out an unused scan from the update block and its variables from init, and prettied up indentation.