### PR TITLE
Add “slime” itemTags to the following weapons:

### DIFF
--- a/items/active/weapons/melee/broadsword/slimesword.activeitem
+++ b/items/active/weapons/melee/broadsword/slimesword.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimesword", "slimesword2" ],
   "category" : "broadsword",
   "twoHanded" : true,
-  "itemTags" : ["weapon","melee","broadsword","upgradeableWeapon"],
+  "itemTags" : ["weapon","melee","slime","bioweapon","broadsword","upgradeableWeapon"],
 
   "inventoryIcon" : "slimesword.png",
 

--- a/items/active/weapons/other/tentaclegun/electricslimetendrils.activeitem
+++ b/items/active/weapons/other/tentaclegun/electricslimetendrils.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils", "electricslimetendrils", "electricslimetendrils2" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "electricslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/electricslimetendrils2.activeitem
+++ b/items/active/weapons/other/tentaclegun/electricslimetendrils2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "electricslimetendrils2", "electricslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "electricslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/electricslimetendrils3.activeitem
+++ b/items/active/weapons/other/tentaclegun/electricslimetendrils3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "electricslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "electricslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/fireslimetendrils.activeitem
+++ b/items/active/weapons/other/tentaclegun/fireslimetendrils.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils", "fireslimetendrils", "fireslimetendrils2" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "fireslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/fireslimetendrils2.activeitem
+++ b/items/active/weapons/other/tentaclegun/fireslimetendrils2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "fireslimetendrils2", "fireslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "fireslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/fireslimetendrils3.activeitem
+++ b/items/active/weapons/other/tentaclegun/fireslimetendrils3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "fireslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "fireslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/guslimetendrils.activeitem
+++ b/items/active/weapons/other/tentaclegun/guslimetendrils.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "guslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/iceslimetendrils.activeitem
+++ b/items/active/weapons/other/tentaclegun/iceslimetendrils.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils", "iceslimetendrils", "iceslimetendrils2" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "iceslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/iceslimetendrils2.activeitem
+++ b/items/active/weapons/other/tentaclegun/iceslimetendrils2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "iceslimetendrils2", "iceslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "iceslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/iceslimetendrils3.activeitem
+++ b/items/active/weapons/other/tentaclegun/iceslimetendrils3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "iceslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "iceslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/impactslimetendrils.activeitem
+++ b/items/active/weapons/other/tentaclegun/impactslimetendrils.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils", "impactslimetendrils", "impactslimetendrils2" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "impactslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/impactslimetendrils2.activeitem
+++ b/items/active/weapons/other/tentaclegun/impactslimetendrils2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "impactslimetendrils2", "impactslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "impactslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/impactslimetendrils3.activeitem
+++ b/items/active/weapons/other/tentaclegun/impactslimetendrils3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "impactslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "impactslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/poisonslimetendrils.activeitem
+++ b/items/active/weapons/other/tentaclegun/poisonslimetendrils.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils", "poisonslimetendrils", "poisonslimetendrils2" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "poisonslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/poisonslimetendrils2.activeitem
+++ b/items/active/weapons/other/tentaclegun/poisonslimetendrils2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "poisonslimetendrils2", "poisonslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "poisonslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/poisonslimetendrils3.activeitem
+++ b/items/active/weapons/other/tentaclegun/poisonslimetendrils3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "poisonslimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "poisonslimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/slimetendrils.activeitem
+++ b/items/active/weapons/other/tentaclegun/slimetendrils.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils", "slimetendrils2", "electricslimetendrils", "fireslimetendrils", "iceslimetendrils", "poisonslimetendrils" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "slimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/slimetendrils2.activeitem
+++ b/items/active/weapons/other/tentaclegun/slimetendrils2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils2", "slimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "slimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/slimetendrils3.activeitem
+++ b/items/active/weapons/other/tentaclegun/slimetendrils3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils3" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "slimetendrilsicon.png",
 

--- a/items/active/weapons/other/tentaclegun/xelslimetendrils.activeitem
+++ b/items/active/weapons/other/tentaclegun/xelslimetendrils.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimetendrils" ],
   "category" : "uniqueWeapon",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","livingweapon","upgradeableWeapon","slime"],
 
   "inventoryIcon" : "xelslimetendrilsicon.png",
 

--- a/items/active/weapons/whip/electricslimeconcwhip.activeitem
+++ b/items/active/weapons/whip/electricslimeconcwhip.activeitem
@@ -9,7 +9,7 @@
   "tooltipKind" : "sword",
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "electricslimeconcwhip.png:extend.1",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/electricslimewhip.activeitem
+++ b/items/active/weapons/whip/electricslimewhip.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "electricslimewhip2" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "electricslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/electricslimewhip2.activeitem
+++ b/items/active/weapons/whip/electricslimewhip2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "electricslimewhip3" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "electricslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/electricslimewhip3.activeitem
+++ b/items/active/weapons/whip/electricslimewhip3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "electricslimeconcwhip" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "electricslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/fireslimeconcwhip.activeitem
+++ b/items/active/weapons/whip/fireslimeconcwhip.activeitem
@@ -9,7 +9,7 @@
   "tooltipKind" : "sword",
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "fireslimeconcwhip.png:extend.1",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/fireslimewhip.activeitem
+++ b/items/active/weapons/whip/fireslimewhip.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "fireslimewhip2" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "fireslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/fireslimewhip2.activeitem
+++ b/items/active/weapons/whip/fireslimewhip2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "fireslimewhip3" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "fireslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/fireslimewhip3.activeitem
+++ b/items/active/weapons/whip/fireslimewhip3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "fireslimeconcwhip" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "fireslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/iceslimeconcwhip.activeitem
+++ b/items/active/weapons/whip/iceslimeconcwhip.activeitem
@@ -9,7 +9,7 @@
   "tooltipKind" : "sword",
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "iceslimeconcwhip.png:extend.1",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/iceslimewhip.activeitem
+++ b/items/active/weapons/whip/iceslimewhip.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "iceslimewhip2" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "iceslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/iceslimewhip2.activeitem
+++ b/items/active/weapons/whip/iceslimewhip2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "iceslimewhip3" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "iceslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/iceslimewhip3.activeitem
+++ b/items/active/weapons/whip/iceslimewhip3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "iceslimeconcwhip" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "iceslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/poisonslimeconcwhip.activeitem
+++ b/items/active/weapons/whip/poisonslimeconcwhip.activeitem
@@ -9,7 +9,7 @@
   "tooltipKind" : "sword",
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "poisonslimeconcwhip.png:extend.1",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/poisonslimewhip.activeitem
+++ b/items/active/weapons/whip/poisonslimewhip.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "poisonslimewhip2" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "poisonslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/poisonslimewhip2.activeitem
+++ b/items/active/weapons/whip/poisonslimewhip2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "poisonslimewhip3" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "poisonslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/poisonslimewhip3.activeitem
+++ b/items/active/weapons/whip/poisonslimewhip3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "poisonslimeconcwhip" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "poisonslimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/slimeconcwhip.activeitem
+++ b/items/active/weapons/whip/slimeconcwhip.activeitem
@@ -9,7 +9,7 @@
   "tooltipKind" : "sword",
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "slimeconcwhip.png:extend.1",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/slimewhip.activeitem
+++ b/items/active/weapons/whip/slimewhip.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimewhip", "slimewhip2", "poisonslimewhip", "electricslimewhip", "fireslimewhip", "iceslimewhip" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "slimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/slimewhip2.activeitem
+++ b/items/active/weapons/whip/slimewhip2.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimewhip3" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "slimewhip.png:idle",
   "animation" : "whip.animation",

--- a/items/active/weapons/whip/slimewhip3.activeitem
+++ b/items/active/weapons/whip/slimewhip3.activeitem
@@ -10,7 +10,7 @@
   "learnBlueprintsOnPickup" : [ "slimeconcwhip" ],
   "category" : "whip",
   "twoHanded" : false,
-  "itemTags" : ["weapon", "whip", "upgradeableWeapon"],
+  "itemTags" : ["weapon", "whip", "upgradeableWeapon", "slime"],
 
   "inventoryIcon" : "slimewhip.png:idle",
   "animation" : "whip.animation",


### PR DESCRIPTION
- electricslimewhip
- electricslimewhip2
- electricslimewhip3
- fireslimewhip
- fireslimewhip2
- fireslimewhip3
- iceslimewhip
- iceslimewhip2
- iceslimewhip3
- poisonslimewhip
- poisonslimewhip2
- poisonslimewhip3
- slimewhip
- slimewhip2
- slimewhip3
- electricslimetendrils
- electricslimetendrils2
- electricslimetendrils3
- fireslimetendrils
- fireslimetendrils2
- fireslimetendrils3
- guslimetendrils *maybe not needed on this one*
- iceslimetendrils
- iceslimetendrils2
- iceslimetendrils3
- impactslimetendrils
- impactslimetendrils2
- impactslimetendrils3
- poisonslimetendrils
- poisonslimetendrils2
- poisonslimetendrils3
- slimetendrils
- slimetendrils2
- slimetendrils3
- xelslimetendrils *maybe not needed on this one*
- slimesword *add “slime” and “bioweapon” to make similar to slimesword2 and slimesword3*