### PR TITLE
Typo/category fix

### DIFF
--- a/objects/crafting/handmill/handmill.object
+++ b/objects/crafting/handmill/handmill.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "fu", "science", "farm" ],
   "rarity" : "Essential",
   "race" : "generic",
-  "category" : "crafting",
+  "category" : "^orange;Extraction Device^reset;",
   "printable" : false,
   "objectType" : "container",
   "learnBlueprintsOnPickup" : [ "nanofabricator" ], 

--- a/spawners/madness/gene/madnesseyejelly/madnesseyejelly.object
+++ b/spawners/madness/gene/madnesseyejelly/madnesseyejelly.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "madnesseyejelly",
   "rarity" : "uncommon",
-  "description" : "A pleasnt-smelling creation that can liquify flesh.",
+  "description" : "A pleasant-smelling creation that can liquify flesh.",
   "shortdescription" : "Gelatinous Eye",
   "race" : "generic",
   "category" : "decorative",

--- a/spawners/madness/gene/madnesseyeslime/madnesseyejelly2.object
+++ b/spawners/madness/gene/madnesseyeslime/madnesseyejelly2.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "madnesseyeslime",
   "rarity" : "uncommon",
-  "description" : "A pleasnt-smelling creation that can liquify flesh.",
+  "description" : "A pleasant-smelling creation that can liquify flesh.",
   "shortdescription" : "Gelatinous Eye",
   "race" : "generic",
   "category" : "decorative",


### PR DESCRIPTION
I changed the category of the handmill from: "crafting" to "^orange;Extraction Device^reset;"
and I fixed a typo in spawners/madness/gene/madnesseyejelly/madnesseyejelly.object and spawners/madness/gene/madnesseyeslime/madnesseyejelly2.object .