### PR TITLE
memento mori upgrade

### DIFF
--- a/items/active/mementomori/fumementomori.activeitem
+++ b/items/active/mementomori/fumementomori.activeitem
@@ -3,7 +3,7 @@
     "price": 0,
     "maxStack": 1,
     "rarity": "legendary",
-    "description": "This mysterious object is drawn to the site of your most recent demise.",
+    "description": "This mysterious skull leads you to the site of your most recent demise. Squeeze to teleport.",
     "shortdescription": "Crystalline Skull",
     "twoHanded": false,
     "category": "Tool",

--- a/items/active/mementomori/fumementomori.animation
+++ b/items/active/mementomori/fumementomori.animation
@@ -1,20 +1,19 @@
 {
-  "animatedParts" : {
-    
-    "parts" : {
-      "skull" : {
-        "properties" : {
-          "centered" : false,
-          "zLevel" : 1,
-          "fullbright": true
-        } 
-      },
-      "skullfullbright" : {
-        "properties" : {
-          "centered" : false,
-          "zLevel" : 2          
-        }
-      }
-    }
-  }
+	"animatedParts": {
+		"parts": {
+			"skull": {
+				"properties": {
+					"centered": false,
+					"zLevel": 1,
+					"fullbright": true
+				}
+			},
+			"skullfullbright": {
+				"properties": {
+					"centered": false,
+					"zLevel": 2
+				}
+			}
+		}
+	}
 }

--- a/items/active/mementomori/fumementomori.lua
+++ b/items/active/mementomori/fumementomori.lua
@@ -25,23 +25,23 @@ function update(dt, fireMode, shiftHeld)
 		else
 			if fireMode=="primary" then
 				if teleportTimer == 0 then
-					 if animator.hasSound("chime") then
+					 --[[if animator.hasSound("chime") then
 						animator.playSound("chime")
-					else
-						sb.logInfo("Chime missing")
-					 end
+					--else
+						--sb.logInfo("Chime missing")
+					end]]
 				end
 				teleportTimer=teleportTimer and teleportTimer+dt or dt
 				if teleportTimer >= 3 then
-					if animator.hasSound("chime") then
+					--[[if animator.hasSound("chime") then
 						animator.stopAllSounds("chime")
-					end
+					end]]
 					local buffer=status.statusProperty(mementomori.deathPositionKey)
 					firing=(not not buffer) and (world.magnitude(buffer.position,world.entityPosition(activeItem.ownerEntityId())) > 20)
 					if firing then
-						if animator.hasSound("break") then
+						--[[if animator.hasSound("break") then
 							animator.playSound("break")
-						end
+						end]]
 						status.addEphemeralEffect("blink")
 						status.addEphemeralEffect("cultistshieldAlwaysHidden",2.5)
 						status.addEphemeralEffect("nofalldamage",2.5)
@@ -54,14 +54,13 @@ function update(dt, fireMode, shiftHeld)
 						status.addEphemeralEffect("nude",2.5)
 						status.addEphemeralEffect("energy_negative_100_hidden",2.5)
 						mcontroller.setPosition(buffer.position)
-						--uncomment after testin
 						item.consume(1)
 					end
 				end
 			else
-				if animator.hasSound("chime") then
+				--[[if animator.hasSound("chime") then
 					animator.stopAllSounds("chime")
-				end
+				end]]
 				teleportTimer=0
 			end
 		end

--- a/items/active/mementomori/fumementomori.lua
+++ b/items/active/mementomori/fumementomori.lua
@@ -4,15 +4,68 @@ function init()
 	activeItem.setScriptedAnimationParameter(mementomori.deathPositionKey,status.statusProperty(mementomori.deathPositionKey))
 	script.setUpdateDelta(5)
 	promise=world.sendEntityMessage(activeItem.ownerEntityId(),"player.worldId")
+	--doesnt work...
+	--animator.setSoundPool("chime",{"/sfx/weapons/elderchime1.ogg"})
+	--animator.setSoundPool("break",{"/sfx/objects/vase_break_large1.ogg"})
 end
 
-function update(dt)
-	if promise then
-		if promise:finished() then
-			if promise:succeeded() then
-				activeItem.setScriptedAnimationParameter(mementomori.worldId,promise:result())
+function update(dt, fireMode, shiftHeld)
+	if not firing then
+		if not located then
+			if promise then
+				if promise:finished() then
+					if promise:succeeded() then
+						activeItem.setScriptedAnimationParameter(mementomori.worldId,promise:result())
+						located=true
+					else
+						promise=world.sendEntityMessage(activeItem.ownerEntityId(),"player.worldId")
+					end
+				end
 			end
-			script.setUpdateDelta(0)
+		else
+			if fireMode=="primary" then
+				if teleportTimer == 0 then
+					 if animator.hasSound("chime") then
+						animator.playSound("chime")
+					else
+						sb.logInfo("Chime missing")
+					 end
+				end
+				teleportTimer=teleportTimer and teleportTimer+dt or dt
+				if teleportTimer >= 3 then
+					if animator.hasSound("chime") then
+						animator.stopAllSounds("chime")
+					end
+					local buffer=status.statusProperty(mementomori.deathPositionKey)
+					firing=(not not buffer) and (world.magnitude(buffer.position,world.entityPosition(activeItem.ownerEntityId())) > 20)
+					if firing then
+						if animator.hasSound("break") then
+							animator.playSound("break")
+						end
+						status.addEphemeralEffect("blink")
+						status.addEphemeralEffect("cultistshieldAlwaysHidden",2.5)
+						status.addEphemeralEffect("nofalldamage",2.5)
+						status.addEphemeralEffect("breathprotectionvehicle",2.5)
+						status.addEphemeralEffect("dontstarve",2.5)
+						status.addEphemeralEffect("ghostlyglow",2.5)
+						status.addEphemeralEffect("nodamagedummy",2.5)
+						status.addEphemeralEffect("noenergyregendummy",2.5)
+						status.addEphemeralEffect("ghostlyglow",2.5)
+						status.addEphemeralEffect("nude",2.5)
+						status.addEphemeralEffect("energy_negative_100_hidden",2.5)
+						mcontroller.setPosition(buffer.position)
+						--uncomment after testin
+						item.consume(1)
+					end
+				end
+			else
+				if animator.hasSound("chime") then
+					animator.stopAllSounds("chime")
+				end
+				teleportTimer=0
+			end
 		end
+	else
+		
 	end
 end

--- a/stats/effects/fu_effects/fu_dummyeffects/nodamagedummy/nodamagedummy.statuseffect
+++ b/stats/effects/fu_effects/fu_dummyeffects/nodamagedummy/nodamagedummy.statuseffect
@@ -1,0 +1,15 @@
+{
+	"name" : "nodamagedummy",
+ 	"effectConfig": {
+		"stats": [{
+				"stat": "powerMultiplier",
+				"effectiveMultiplier": 0
+			}
+		]
+	},
+	"defaultDuration" : 0.3,
+	"scripts": [
+		"/stats/effects/fu_genericStatApplier.lua"
+	]
+  
+}

--- a/stats/effects/fu_effects/fu_dummyeffects/noenergyregendummy/noenergyregendummy.statuseffect
+++ b/stats/effects/fu_effects/fu_dummyeffects/noenergyregendummy/noenergyregendummy.statuseffect
@@ -1,0 +1,15 @@
+{
+	"name" : "noenergyregendummy",
+ 	"effectConfig": {
+		"stats": [{
+				"stat": "energyRegenBlock",
+				"amount": 1
+			}
+		]
+	},
+	"defaultDuration" : 0.3,
+	"scripts": [
+		"/stats/effects/fu_genericStatApplier.lua"
+	]
+  
+}


### PR DESCRIPTION
Crystalline skull now can be used to teleport to its most recently recorded death location by holding the fire trigger for 3 seconds, consuming the skull in the process. Teleport will not occur if within 20 tiles of destination. Teleport grants near invulnerability, drains energy and multiplies your damage by 0 for 2.5 seconds.

Unfortunately, I don't know how to handle animation/sounds. sound playing code has been commented out in the lua, and the init block's unworking attempt at setting them has the files I picked.