### PR TITLE
Add StardustLib shims for new functionality

### DIFF
--- a/stats/monster_primary.lua
+++ b/stats/monster_primary.lua
@@ -18,6 +18,10 @@ function init()
   message.setHandler("applyStatusEffect", function(_, _, effectConfig, duration, sourceEntityId)
       status.addEphemeralEffect(effectConfig, duration, sourceEntityId)
     end)
+	
+	if root.hasTech("stardustlib:enable-extenders") then -- stardustlib shim
+    require "/sys/stardust/statusext.lua"
+  end
 end
 
 function applyDamageRequest(damageRequest)
@@ -188,7 +192,7 @@ function inLiquid() --no fall damage while submerged in liquids
     local liquidID = 0
     if mcontroller.liquidPercentage() > 0.1 then
     liquidID = mcontroller.liquidId()
-       liquidID = excludeLiquidIds[liquidID] and 0 or liquidID 
+       liquidID = excludeLiquidIds[liquidID] and 0 or liquidID
     end
     return liquidID > 0
 end

--- a/stats/npc_primary.lua
+++ b/stats/npc_primary.lua
@@ -18,6 +18,10 @@ function init()
   message.setHandler("applyStatusEffect", function(_, _, effectConfig, duration, sourceEntityId)
       status.addEphemeralEffect(effectConfig, duration, sourceEntityId)
     end)
+	
+	if root.hasTech("stardustlib:enable-extenders") then -- stardustlib shim
+    require "/sys/stardust/statusext.lua"
+  end
 end
 
 function applyDamageRequest(damageRequest)


### PR DESCRIPTION
Adds checks to `weapon.lua` and `*_primary.lua` which load in StardustLib scripts if present.

This is needed in order to allow certain StardustLib features to function with FU present, as they override a few of the same scripts.

For the curious, the relevant features are:
- Status tags (tagging a damage request with arbitrary data, which may be used to, for example, modify damage depending on the enemy hit)
- Status imbuement (globally adding specific status effects/tags to all weapon attacks by an entity, queried from all message targets on said entity)

(note that if you override `spacemonster_primary.lua` later, it will need a similar shim; refer to the same file in stardustlib)