### PR TITLE
Fixed mispelling of tungstenore

### DIFF
--- a/objects/generic/centrifuge_recipes.config
+++ b/objects/generic/centrifuge_recipes.config
@@ -422,7 +422,7 @@
       "lead": ["rare", 3],
 
       "corefragmentore": ["uncommon", 3],
-      "tunstenore": ["uncommon", 3],
+      "tungstenore": ["uncommon", 3],
       "fu_salt": ["uncommon", 3],
 
       "ironore": ["common", 5],
@@ -441,7 +441,7 @@
       "lead": ["rare", 3],
 
       "corefragmentore": ["uncommon", 3],
-      "tunstenore": ["uncommon", 3],
+      "tungstenore": ["uncommon", 3],
       "fu_salt": ["uncommon", 3],
 
       "ironore": ["common", 5],


### PR DESCRIPTION
Just fixing a little bug I encountered