### PR TITLE
Byos Crew Deed Fix

### DIFF
--- a/objects/atropus/atropusbed/atropusbed.object
+++ b/objects/atropus/atropusbed/atropusbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "atropusbed",
-  "colonyTags" : ["atropus"],
+  "colonyTags" : ["atropus", "bed"],
   "printable" : false,
   "rarity" : "legendary",
   "description" : "A bed made from flesh and organs.",

--- a/objects/elduucrystal/exonite/exonitebed/exonitebed.object
+++ b/objects/elduucrystal/exonite/exonitebed/exonitebed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "exonitebed",
-  "colonyTags" : ["exonite"],
+  "colonyTags" : ["exonite", "bed"],
   "printable" : false,
   "rarity" : "uncommon",
   "description" : "A bed made from exonite.",

--- a/objects/flowerpots/cactusflowerbed/cactusflowerbed.object
+++ b/objects/flowerpots/cactusflowerbed/cactusflowerbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "cactusflowerbed",
-  "colonyTags" : ["generic","nature","pretty"],
+  "colonyTags" : ["generic","nature","pretty", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "category" : "furniture",

--- a/objects/flowerpots/seaflowerbed/seaflowerbed.object
+++ b/objects/flowerpots/seaflowerbed/seaflowerbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "seaflowerbed",
-  "colonyTags" : ["sea","nature","pretty"],
+  "colonyTags" : ["sea","nature","pretty", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "category" : "furniture",

--- a/objects/flowerpots/toxicseaflowerbed/toxicseaflowerbed.object
+++ b/objects/flowerpots/toxicseaflowerbed/toxicseaflowerbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "toxicseaflowerbed",
-  "colonyTags" : ["toxic","nature","pretty"],
+  "colonyTags" : ["toxic","nature","pretty", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "category" : "furniture",

--- a/objects/irradium/irradiumbed/irradiumbed.object
+++ b/objects/irradium/irradiumbed/irradiumbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "irradiumbed",
-  "colonyTags" : ["irradium"],
+  "colonyTags" : ["irradium", "bed"],
   "printable" : false,
   "rarity" : "rare",
   "description" : "A bed made from irradium.",

--- a/objects/nightar/nightarmedievalcellbed/nightarmedievalcellbed.object
+++ b/objects/nightar/nightarmedievalcellbed/nightarmedievalcellbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "nightarmedievalcellbed",
-  "colonyTags" : ["nightar","glitchvillage"],
+  "colonyTags" : ["nightar","glitchvillage", "bed"],
   "rarity" : "Common",
   "description" : "An extremely basic bed of hay.",
   "shortdescription" : "Medieval Hay Bed",

--- a/objects/novakid/frontierbunkbed/frontierbunkbed.object
+++ b/objects/novakid/frontierbunkbed/frontierbunkbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "frontierbunkbed",
-  "colonyTags" : ["novakid","novakidvillage","misc"],
+  "colonyTags" : ["novakid","novakidvillage","misc", "bed"],
   "rarity" : "Common",
   "category" : "furniture",
   "price" : 125,

--- a/objects/peglaci/loungeables/peglacibed/peglacibed.object
+++ b/objects/peglaci/loungeables/peglacibed/peglacibed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "peglacibed",
-  "colonyTags" : [ "peglaci", "peglacivillage" ],
+  "colonyTags" : ["peglaci", "peglacivillage", "bed"],
   "rarity" : "Common",
   "description" : "A bed recessed in a back wall to take up less space.",
   "shortdescription" : "Alloy Wall Bed",

--- a/objects/peglaci/loungeables/peglacibed2/peglacibed2.object
+++ b/objects/peglaci/loungeables/peglacibed2/peglacibed2.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "peglacibed2",
-  "colonyTags" : [ "peglaci", "peglacivillage" ],
+  "colonyTags" : ["peglaci", "peglacivillage", "bed"],
   "rarity" : "Common",
   "description" : "A force-field generator that holds the user floating restfully in the air.",
   "shortdescription" : "Alloy Force-field Bed",

--- a/objects/proppack/astrobed/astrobed.object
+++ b/objects/proppack/astrobed/astrobed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "astrobed",
-  "colonyTags" : ["astro"],
+  "colonyTags" : ["astro", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "description" : "An astro themed bed.",

--- a/objects/proppack/stationbunk/stationbunk.object
+++ b/objects/proppack/stationbunk/stationbunk.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "stationbunk",
-  "colonyTags" : ["station","misc"],
+  "colonyTags" : ["station","misc", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "race" : "generic",

--- a/objects/ship/shipbeds/apexshipbed/apexshipbed.object
+++ b/objects/ship/shipbeds/apexshipbed/apexshipbed.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "apexshipbed",
   "printable" : false,
-  "colonyTags" : ["apex"],
+  "colonyTags" : ["apex", "bed"],
   "rarity" : "Common",
   "description" : "A standard Apex ship bunk bed.",
   "shortdescription" : "Apex Ship Bunk Bed",

--- a/objects/ship/shipbeds/apexshipbed2/apexshipbed2.object
+++ b/objects/ship/shipbeds/apexshipbed2/apexshipbed2.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "apexshipbed2",
   "printable" : false,
-  "colonyTags" : ["apex"],
+  "colonyTags" : ["apex", "bed"],
   "rarity" : "Common",
   "description" : "A standard Apex ship bunk bed.",
   "shortdescription" : "Apex Ship Bunk Bed",

--- a/objects/ship/shipbeds/avianshipbed/avianshipbed.object
+++ b/objects/ship/shipbeds/avianshipbed/avianshipbed.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "avianshipbed",
   "printable" : false,
-  "colonyTags" : ["avian"],
+  "colonyTags" : ["avian", "bed"],
   "rarity" : "Common",
   "description" : "A standard Avian ship bunk bed.",
   "shortdescription" : "Avian Ship Bunk Bed",

--- a/objects/ship/shipbeds/avianshipbed2/avianshipbed2.object
+++ b/objects/ship/shipbeds/avianshipbed2/avianshipbed2.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "avianshipbed2",
   "printable" : false,
-  "colonyTags" : ["avian"],
+  "colonyTags" : ["avian", "bed"],
   "rarity" : "Common",
   "description" : "A standard Avian ship bunk bed.",
   "shortdescription" : "Avian Ship Bunk Bed",

--- a/objects/ship/shipbeds/floranshipbed/floranshipbed.object
+++ b/objects/ship/shipbeds/floranshipbed/floranshipbed.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "floranshipbed",
   "printable" : false,
-  "colonyTags" : ["floran"],
+  "colonyTags" : ["floran", "bed"],
   "rarity" : "Common",
   "description" : "A standard Floran ship bunk bed.",
   "shortdescription" : "Floran Ship Bunk Bed",

--- a/objects/ship/shipbeds/floranshipbed2/floranshipbed2.object
+++ b/objects/ship/shipbeds/floranshipbed2/floranshipbed2.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "floranshipbed2",
   "printable" : false,
-  "colonyTags" : ["floran"],
+  "colonyTags" : ["floran", "bed"],
   "rarity" : "Common",
   "description" : "A standard Floran ship bunk bed.",
   "shortdescription" : "Floran Ship Bunk Bed",

--- a/objects/ship/shipbeds/glitchshipbed/glitchshipbed.object
+++ b/objects/ship/shipbeds/glitchshipbed/glitchshipbed.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "glitchshipbed",
   "printable" : false,
-  "colonyTags" : ["glitch"],
+  "colonyTags" : ["glitch", "bed"],
   "rarity" : "Common",
   "description" : "A standard Glitch ship bunk bed.",
   "shortdescription" : "Glitch Ship Bunk Bed",

--- a/objects/ship/shipbeds/glitchshipbed2/glitchshipbed2.object
+++ b/objects/ship/shipbeds/glitchshipbed2/glitchshipbed2.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "glitchshipbed2",
   "printable" : false,
-  "colonyTags" : ["glitch"],
+  "colonyTags" : ["glitch", "bed"],
   "rarity" : "Common",
   "description" : "A standard Glitch ship bunk bed.",
   "shortdescription" : "Glitch Ship Bunk Bed",

--- a/objects/ship/shipbeds/humanshipbed/humanshipbed.object
+++ b/objects/ship/shipbeds/humanshipbed/humanshipbed.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "humanshipbed",
   "printable" : false,
-  "colonyTags" : ["human"],
+  "colonyTags" : ["human", "bed"],
   "rarity" : "Common",
   "description" : "A standard Human ship bunk bed.",
   "shortdescription" : "Human Bunk Ship Bed",

--- a/objects/ship/shipbeds/humanshipbed2/humanshipbed2.object
+++ b/objects/ship/shipbeds/humanshipbed2/humanshipbed2.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "humanshipbed2",
   "printable" : false,
-  "colonyTags" : ["human"],
+  "colonyTags" : ["human", "bed"],
   "rarity" : "Common",
   "description" : "A standard Human ship bunk bed.",
   "shortdescription" : "Human Ship Bunk Bed",

--- a/objects/ship/shipbeds/hylotlshipbed/hylotlshipbed.object
+++ b/objects/ship/shipbeds/hylotlshipbed/hylotlshipbed.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "hylotlshipbed",
   "printable" : false,
-  "colonyTags" : ["hylotl"],
+  "colonyTags" : ["hylotl", "bed"],
   "rarity" : "Common",
   "description" : "A standard Hylotl ship bunk bed.",
   "shortdescription" : "Hylotl Bunk Ship Bed",

--- a/objects/ship/shipbeds/hylotlshipbed2/hylotlshipbed2.object
+++ b/objects/ship/shipbeds/hylotlshipbed2/hylotlshipbed2.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "hylotlshipbed2",
   "printable" : false,
-  "colonyTags" : ["hylotl"],
+  "colonyTags" : ["hylotl", "bed"],
   "rarity" : "Common",
   "description" : "A standard Hylotl ship bunk bed.",
   "shortdescription" : "Hylotl Ship Bunk Bed",

--- a/objects/ship/shipbeds/novakidshipbed/novakidshipbed.object
+++ b/objects/ship/shipbeds/novakidshipbed/novakidshipbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "novakidshipbed",
-  "colonyTags" : ["novakid"],
+  "colonyTags" : ["novakid", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "description" : "A standard Novakid ship bunk bed.",

--- a/objects/ship/shipbeds/novakidshipbed2/novakidshipbed2blue.object
+++ b/objects/ship/shipbeds/novakidshipbed2/novakidshipbed2blue.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "novakidshipbed2blue",
   "printable" : false,
-  "colonyTags" : ["apex"],
+  "colonyTags" : ["novakid", "bed"],
   "rarity" : "Common",
   "description" : "A standard Novakid ship bunk bed.",
   "shortdescription" : "Novakid Ship Bunk Bed",

--- a/objects/ship/shipbeds/novakidshipbed2/novakidshipbed2cream.object
+++ b/objects/ship/shipbeds/novakidshipbed2/novakidshipbed2cream.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "novakidshipbed2cream",
   "printable" : false,
-  "colonyTags" : ["apex"],
+  "colonyTags" : ["novakid", "bed"],
   "rarity" : "Common",
   "description" : "A standard Novakid ship bunk bed.",
   "shortdescription" : "Novakid Ship Bunk Bed",

--- a/objects/ship/shipbeds/novakidshipbed2/novakidshipbed2green.object
+++ b/objects/ship/shipbeds/novakidshipbed2/novakidshipbed2green.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "novakidshipbed2green",
   "printable" : false,
-  "colonyTags" : ["apex"],
+  "colonyTags" : ["novakid", "bed"],
   "rarity" : "Common",
   "description" : "A standard Novakid ship bunk bed.",
   "shortdescription" : "Novakid Ship Bunk Bed",

--- a/objects/ship/shipbeds/novakidshipbed2/novakidshipbed2red.object
+++ b/objects/ship/shipbeds/novakidshipbed2/novakidshipbed2red.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "novakidshipbed2red",
   "printable" : false,
-  "colonyTags" : ["apex"],
+  "colonyTags" : ["novakid", "bed"],
   "rarity" : "Common",
   "description" : "A standard Novakid ship bunk bed.",
   "shortdescription" : "Novakid Ship Bunk Bed",

--- a/objects/ship/shipbeds/protectorateshipbed/protectorateshipbed.object
+++ b/objects/ship/shipbeds/protectorateshipbed/protectorateshipbed.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "protectorateshipbed",
   "printable" : false,
-  "colonyTags" : ["protectorate"],
+  "colonyTags" : ["protectorate", "bed"],
   "rarity" : "Common",
   "description" : "A standard Protectorate ship bunk bed.",
   "shortdescription" : "P. Ship Bunk Bed",

--- a/objects/ship/shipbeds/protectorateshipbed2/protectorateshipbed2.object
+++ b/objects/ship/shipbeds/protectorateshipbed2/protectorateshipbed2.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "protectorateshipbed2",
   "printable" : false,
-  "colonyTags" : ["protectorate"],
+  "colonyTags" : ["protectorate", "bed"],
   "rarity" : "Common",
   "description" : "A standard Protectorate ship bunk bed.",
   "shortdescription" : "Protectorate Ship Bunk Bed",

--- a/objects/skath/skathbed/skathbed.object
+++ b/objects/skath/skathbed/skathbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "skathbed",
-  "colonyTags" : ["skath"],
+  "colonyTags" : ["skath", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "description" : "A rather sturdy looking bed, made by the Skath.",

--- a/objects/telebrium/telebriumbed/telebriumbed.object
+++ b/objects/telebrium/telebriumbed/telebriumbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "telebriumbed",
-  "colonyTags" : ["telebrium"],
+  "colonyTags" : ["telebrium", "bed"],
   "printable" : false,
   "rarity" : "uncommon",
   "description" : "A bed made from Telebrium.",

--- a/objects/themed/barracks/barracksbed/barracksbed.object
+++ b/objects/themed/barracks/barracksbed/barracksbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "barracksbed",
-  "colonyTags" : ["barracks","combat"],
+  "colonyTags" : ["barracks","combat", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "description" : "A standard military bed. You could bounce a coin off those sheets!",

--- a/objects/themed/barracks/barracksbunkbed/barracksbunkbed.object
+++ b/objects/themed/barracks/barracksbunkbed/barracksbunkbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "barracksbunkbed",
-  "colonyTags" : ["barracks","combat"],
+  "colonyTags" : ["barracks","combat", "bed"],
   "rarity" : "Common",
   "category" : "furniture",
   "price" : 0,

--- a/objects/themed/barracks/barracksbunkbed/barracksbunkbedbottom.object
+++ b/objects/themed/barracks/barracksbunkbed/barracksbunkbedbottom.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "barracksbunkbedbottom",
-  "colonyTags" : ["barracks","combat"],
+  "colonyTags" : ["barracks","combat", "bed"],
   "rarity" : "Common",
   "category" : "furniture",
   "price" : 0,

--- a/objects/themed/barracks/barracksbunkbed/barracksbunkbedtop.object
+++ b/objects/themed/barracks/barracksbunkbed/barracksbunkbedtop.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "barracksbunkbedtop",
-  "colonyTags" : ["barracks","combat"],
+  "colonyTags" : ["barracks","combat", "bed"],
   "rarity" : "Common",
   "category" : "furniture",
   "price" : 0,

--- a/objects/themed/boreal/borealbed/borealbed.object
+++ b/objects/themed/boreal/borealbed/borealbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "borealbed",
-  "colonyTags" : ["boreal"],
+  "colonyTags" : ["boreal", "bed"],
   "printable" : false,
   "rarity" : "Uncommon",
   "description" : "A lovingly carved pine wood bed. Its downy comforter is invaluable on frigid nights.",

--- a/objects/themed/bunny/bunnybed/bunnybed.object
+++ b/objects/themed/bunny/bunnybed/bunnybed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "bunnybed",
-  "colonyTags" : ["bunny"],
+  "colonyTags" : ["bunny", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "description" : "Hop on off to dreamland in this adorable bunny themed bed!",

--- a/objects/themed/corsair/corsairsbed/corsairsbed.object
+++ b/objects/themed/corsair/corsairsbed/corsairsbed.object
@@ -1,6 +1,6 @@
 {
   "objectName": "corsairsbed",
-  "colonyTags": [ "corsair" ],
+  "colonyTags": ["corsair", "bed"],
   "rarity": "Uncommon",
   "race": "generic",
   "category": "furniture",

--- a/objects/themed/hospital/hospitalbed/hospitalbed.object
+++ b/objects/themed/hospital/hospitalbed/hospitalbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "hospitalbed",
-  "colonyTags" : ["hospital","medical"],
+  "colonyTags" : ["hospital","medical", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "description" : "Just your standard hospital bed.",

--- a/objects/themed/modernalpine/modernalpinebed/modernalpinebed.object
+++ b/objects/themed/modernalpine/modernalpinebed/modernalpinebed.object
@@ -1,6 +1,6 @@
 {
   "objectName": "modernalpinebed",
-  "colonyTags": [ "modernalpine" ],
+  "colonyTags": ["modernalpine", "bed"],
   "rarity": "Uncommon",
   "race": "generic",
   "category": "furniture",

--- a/objects/themed/moderncheckered/moderncheckeredbed/moderncheckeredbed.object
+++ b/objects/themed/moderncheckered/moderncheckeredbed/moderncheckeredbed.object
@@ -1,6 +1,6 @@
 {
   "objectName": "moderncheckeredbed",
-  "colonyTags": [ "moderncheckered" ],
+  "colonyTags": ["moderncheckered", "bed"],
   "rarity": "Uncommon",
   "race": "generic",
   "category": "furniture",

--- a/objects/themed/neon/neonbed/neonbed.object
+++ b/objects/themed/neon/neonbed/neonbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "neonbed",
-  "colonyTags" : ["neon"],
+  "colonyTags" : ["neon", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "description" : "A bright and sturdy neon bed.",

--- a/objects/themed/pristine/pristinebed/pristinebed.object
+++ b/objects/themed/pristine/pristinebed/pristinebed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "pristinebed",
-  "colonyTags" : ["pristine","pretty"],
+  "colonyTags" : ["pristine","pretty", "bed"],
   "printable" : false,
   "rarity" : "Uncommon",
   "description" : "A prim and proper bed. The sheets are silky smooth.",

--- a/objects/themed/rococo/rococobed/rococobed.object
+++ b/objects/themed/rococo/rococobed/rococobed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "rococobed",
-  "colonyTags" : ["rococo","pretty","valuable"],
+  "colonyTags" : ["rococo","pretty","valuable", "bed"],
   "printable" : false,
   "rarity" : "Rare",
   "description" : "A fancy vintage bed.",

--- a/objects/themed/rounded/roundedbed/roundedbed.object
+++ b/objects/themed/rounded/roundedbed/roundedbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "roundedbed",
-  "colonyTags" : ["Rounded"],
+  "colonyTags" : ["Rounded", "bed"],
   "printable" : false,
   "rarity" : "Uncommon",
   "description" : "A minimalistic bed, stylistically limited in palette and rounded at the edges.",

--- a/objects/themed/sloppy/sloppybed/sloppybed.object
+++ b/objects/themed/sloppy/sloppybed/sloppybed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "sloppybed",
-  "colonyTags" : ["sloppy"],
+  "colonyTags" : ["sloppy", "bed"],
   "printable" : false,
   "rarity" : "Common",
   "description" : "You're just going to get back in it later - what's the point of making it up?",

--- a/objects/themed/sweets/sweetsbed/sweetsbed.object
+++ b/objects/themed/sweets/sweetsbed/sweetsbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "sweetsbed",
-  "colonyTags" : ["sweets"],
+  "colonyTags" : ["sweets", "bed"],
   "printable" : false,
   "rarity" : "Rare",
   "category" : "furniture",

--- a/objects/themed/weathered/weatheredbed/weatheredbed.object
+++ b/objects/themed/weathered/weatheredbed/weatheredbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "weatheredbed",
-  "colonyTags" : ["weathered"],
+  "colonyTags" : ["weathered", "bed"],
   "printable" : false,
   "rarity" : "Uncommon",
   "category" : "furniture",

--- a/objects/themed/wizard/wizardsbed/wizardsbed.object
+++ b/objects/themed/wizard/wizardsbed/wizardsbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "wizardsbed",
-  "colonyTags" : ["wizard"],
+  "colonyTags" : ["wizard", "bed"],
   "printable" : false,
   "rarity" : "Rare",
   "description" : "A dreamy silk bed for weary wizards.",

--- a/objects/trianglium/triangliumbed/triangliumbed.object
+++ b/objects/trianglium/triangliumbed/triangliumbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "triangliumbed",
-  "colonyTags" : ["trianglium"],
+  "colonyTags" : ["trianglium", "bed"],
   "printable" : false,
   "rarity" : "rare",
   "description" : "A bed made from trianglium.",

--- a/objects/veluuish/cardboardbed/cardboardbed.object
+++ b/objects/veluuish/cardboardbed/cardboardbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "cardboardbed",
-  "colonyTags" : ["misc"],
+  "colonyTags" : ["misc", "bed"],
   "rarity" : "Common",
   "description" : "The best toys and beds in life weren't meant to be toys or beds.",
   "shortdescription" : "Cardboard Box Bed",

--- a/objects/xithricite/xithricitebed/xithricitebed.object
+++ b/objects/xithricite/xithricitebed/xithricitebed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "xithricitebed",
-  "colonyTags" : ["xithricite"],
+  "colonyTags" : ["xithricite", "bed"],
   "printable" : false,
   "rarity" : "legendary",
   "description" : "A bed made from xithricite.",

--- a/objects/zerchesiumalt/zerchbed/zerchbed.object
+++ b/objects/zerchesiumalt/zerchbed/zerchbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "zerchbed",
-  "colonyTags" : ["zerchesium"],
+  "colonyTags" : ["zerchesium", "bed"],
   "printable" : false,
   "rarity" : "rare",
   "description" : "A bed made from polished zerchesium.",


### PR DESCRIPTION
I added bed tags to beds that were missing them so that the byos crew deed can recognise them as beds. After a while I got too lazy to add a description to my changes and just hit merge. Hope that isn't too big a deal.