### PR TITLE
shinyish

### DIFF
--- a/quests/fu_questlines/tutorial/vinj/fu_scienceoutpost.questtemplate
+++ b/quests/fu_questlines/tutorial/vinj/fu_scienceoutpost.questtemplate
@@ -1,28 +1,28 @@
 {
-  "id" : "fu_scienceoutpost",
-  "mainQuest" : true,
-  "title" : "The Science Outpost",
-  "prerequisites" : [ ],
-  "text" : "As thanks for your help, ^orange;Vinalisj^reset; hands you a well designed informational pamphlet.",
-  "completionText" : "^orange;Vinalisj^reset; has transmitted the location of the ^orange;Science Outpost^reset; to me. I've marked the location ^green;in my ships SAIL^reset;.",
+	"id": "fu_scienceoutpost",
+	"prerequisites": [],
+	"mainQuest" : true,
+	"showInLog" : false,
+	"showAcceptDialog" : false,
+	"showCompleteDialog" : true,
+	"showFailDialog" : false,
+	"canBeAbandoned" : false,
+	"title": "The Science Outpost",
+	"text": "^orange;Vinalisj^reset; has transmitted the location of the ^orange;Science Outpost^reset; to me. I've marked the location ^green;in my ships SAIL^reset;.",
+	"completionText": "^orange;Vinalisj^reset; has transmitted the location of the ^orange;Science Outpost^reset; to me. I've marked the location ^green;in my ships SAIL^reset;.",
+	"moneyRange": [50, 50],
+	"rewards": [],
+	"speaker": "questGiver",
 
-  "moneyRange" : [50, 50],
-  "rewards" : [ ],
-  
-  "updateDelta" : 10,
-  "script" : "/quests/scripts/main.lua",
-  "scriptConfig" : {
-    "portraits" : {
-      "questStarted" : "questGiver"
-    },
-
-    "descriptions" : {
-      "findScienceOutpost" : "^green;Visit ^orange;Corvex Research Labs^reset; on ^orange;Epsilon Gamma IV^reset;",
-      "turnIn" : "^green;Visit the^reset; ^orange;Science Outpost^reset;."
-    },
-
-    "compassUpdate" : 0.2,
-
-    "associatedMission" : "scienceoutpostfu"
-  }
+	"updateDelta": 10,
+	"script": "/quests/scripts/main.lua",
+	"scriptConfig": {
+		"portraits": {
+			"questStarted": "questGiver",
+			"questComplete": "questGiver"
+		},
+		"requireTurnIn": false,
+		"conditions": [],
+		"associatedMission": "scienceoutpostfu"
+	}
 }

--- a/quests/scripts/story/gaterepair.lua
+++ b/quests/scripts/story/gaterepair.lua
@@ -236,7 +236,7 @@ function gateRepaired()
 
   player.radioMessage("gaterepair-gateOpened1")
   player.radioMessage("gaterepair-gateOpened2")
-  player.giveItem("sciencebrochure")
+  player.startQuest("fu_scienceoutpost")
   player.addTeleportBookmark(config.getParameter("outpostBookmark2"))
   player.radioMessage("fu_outpost1")  
   player.radioMessage("fu_outpost2")  

--- a/recipes/armory/ranged/guns/explosive/slimegrenadelauncher.recipe
+++ b/recipes/armory/ranged/guns/explosive/slimegrenadelauncher.recipe
@@ -1,12 +1,15 @@
 {
-  "input" : [
-   { "item" : "slimegoo", "count" : 8 },
-   { "item" : "endomorphicjelly", "count" : 4 },
-   { "item" : "slime", "count" : 12 }
-  ],
-  "output" : {
-    "item" : "slimegrenadelauncher",
-    "count" : 1
-  },
-  "groups" : [ "armory2", "rocket", "all" ]
+	"input" : [
+		{ "item" : "slimegoo", "count" : 2 },
+		{ "item" : "endomorphicjelly", "count" : 4 },
+		{ "item" : "slime", "count" : 12 },
+		{ "item" : "corruptionseed", "count" : 4 },
+		{ "item" : "mutagene4", "count" : 1 },
+		{ "item" : "slimelauncher", "count" : 1 }
+	],
+	"output" : {
+		"item" : "slimegrenadelauncher",
+		"count" : 1
+	},
+	"groups" : [ "armory2", "rocket", "all" ]
 }


### PR DESCRIPTION
adjusted science outpost unlock. Brochure left in for compatiblity, as fix isn't retroactive. gate repair Quest now directly triggers quest that unlocks science outpost in nav console, instead of giving brochure. brochure quest is automatically accepted and completed. only the completion text is displayed.

slime grenade launcher recipe adjusted.