### PR TITLE
Fixed sleepAction.lua missing sleepSpot args case

### DIFF
--- a/monsters/pets/actions/sleepAction.lua
+++ b/monsters/pets/actions/sleepAction.lua
@@ -4,7 +4,7 @@ sleepAction = {
 
 function sleepAction.enterWith(args)
 
-  if not args.sleepAction and not args.sleepTarget then return nil end
+  if not args.sleepAction and not args.sleepTarget and not args.sleepSpot then return nil end
 
   if args.sleepAction and status.resourcePercentage("sleepy") < 1 then
     return nil


### PR DESCRIPTION
not passing sleepSpot as an argument will not cause an exception anymore, hopefully