### PR TITLE
Fluid name clean up

### DIFF
--- a/codex/documents/scienceoutpost_kevin.codex
+++ b/codex/documents/scienceoutpost_kevin.codex
@@ -19,7 +19,7 @@
 "Jul 1 - No matter how much evidence we provide, Kevin is unwilling to accept that the universe contains more than one odor. He insists it is all simply varition of the same scent. To prove it, he keeps randomly farting at our stations. I really hate this idiot. I honestly want him dead.",
 "Jul 8 - Once again, every last sample in the lab gene storage has been removed and in their place are test tubes with googly-eyes glued to them.",
 "June 9 - Kevin has broken into Dr. Lesley's computer. Kevin found out many people keep notes of him. Kevin is popular. This pleases Kevin.",
-"Jul 7 - Twice this week the backup generator fuel was siphoned and completely replaced with elder fluid, causing station-wide hallucinations. Where this fluid was even *obtained* is a question in and of itself.",
+"Jul 7 - Twice this week the backup generator fuel was siphoned and completely replaced with Essentia Obscura, causing station-wide hallucinations. Where this fluid was even *obtained* is a question in and of itself.",
 "Jul 17 - Ten days of glorious prank-free nonsense...and then I open up my Plasmic Fluid sample fridge and inside...no samples. There is a note, however, that thanks me for donating to the Juice Salvation Society.",
 "Jul 18 - Woke up to my eyelids glued together. Thanks, Kevin.",
 "Jul 21 - I cannot even begin to imagine how long it took Kevin to construct this statue of Kluex composed entirely of severed Poptop penises. If it weren't so horrific and apalling, I might actually be impressed. I'm less than pleased that he chose to do it on the long weekend, as it has been festering in the lobby for four days.",

--- a/items/active/weapons/melee/dagger/advalloydagger.activeitem
+++ b/items/active/weapons/melee/dagger/advalloydagger.activeitem
@@ -4,7 +4,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "Sturdy, and keeps a keen edge.",
-  "shortdescription" : "Masters Knife",
+  "shortdescription" : "Master's Knife",
   "tooltipKind" : "sword2",
   "category" : "dagger",
   "twoHanded" : false,

--- a/objects/vanity/lights/fulavalamps/alienjuicelavalamp.object
+++ b/objects/vanity/lights/fulavalamps/alienjuicelavalamp.object
@@ -4,7 +4,7 @@
   "rarity" : "Rare",
   "category" : "light",
   "price" : 60,
-  "description" : "A lamp filled with alien juice. It looks like milk.",
+  "description" : "A lamp filled with plasmic fluid. It looks like milk.",
   "shortdescription" : "Plasmic Lava Lamp",
   "race" : "generic",
 

--- a/radiomessages/mech.radiomessages.patch
+++ b/radiomessages/mech.radiomessages.patch
@@ -241,7 +241,7 @@
     "path": "/elder_mech",
     "value": {
       "unique": false,
-      "text": "DANGER! The Elder Fluid is rapidly turning your mech into pudding! Get out swiftly!",
+      "text": "DANGER! Essentia Obscura is rapidly turning your mech into pudding! Get out swiftly!",
       "portraitImage": "yell.<frame>",
       "textSpeed": 70
     }

--- a/treasure/cropharvest.treasurepools.patch
+++ b/treasure/cropharvest.treasurepools.patch
@@ -17,7 +17,7 @@
 	"value" : [ [0, {
 			"pool" : [
 			{"weight" : 0.90, "item" : "violiroot"},
-			{"weight" : 0.06, "item" : "violirootseed"},
+			{"weight" : 0.50, "item" : "violirootseed"},
 			{"weight" : 0.04, "item" : "phasematter"}
                           ],
 			"poolRounds" : [ [0.2, 1], [0.6, 2], [0.2, 3] ] 
@@ -29,7 +29,7 @@
 	"value" : [ [0, {
 			"pool" : [
 			{"weight" : 0.92, "item" : "plasmango"},
-			{"weight" : 0.06, "item" : "plasmangoseed"},
+			{"weight" : 0.50, "item" : "plasmangoseed"},
 			{"weight" : 0.02, "item" : "durasteelore"}
                           ],
 			"poolRounds" : [ [0.2, 1], [0.6, 2], [0.2, 3] ] 

--- a/treasure/cropharvest.treasurepools.patch
+++ b/treasure/cropharvest.treasurepools.patch
@@ -895,7 +895,7 @@
 
  {"op":"add",
  	"path":"/fucrystalplantHarvest", 
- 	"value":[[0, {"fill":[{"item":"crystalplantedible"}, {"item":"plantfibre"} ],
+ 	"value":[[0, {"fill":[{"item":"crystalplantedible"}, {"item":"plantfibre"}, {"item":"crystalplantseed"],
  	"pool":[ {"weight":0.45, "item":"crystalplantseed"},{"weight":0.5, "item":"crystalplantedible"} ],
  	"poolRounds":[[0.5,0],[0.5,1]]}
  		]]

--- a/treasure/cropharvest.treasurepools.patch
+++ b/treasure/cropharvest.treasurepools.patch
@@ -1041,8 +1041,7 @@
 		"value" : [
 			[0, {
 			  "fill":[
-			    {"item":"bolbohn"},
-			    {"item":"bolbohnseed"}
+			    {"item":"bolbohn"}
 			  ],			
 			  "pool" : [
 				{"weight" : 0.45, "item" : "bolbohnseed"},
@@ -1060,8 +1059,7 @@
 		"value" : [
 			[0, {
 			  "fill":[
-			    {"item":"dunestalk"},
-			    {"item":"dunestalkseed"}
+			    {"item":"dunestalk"}
 			  ],			
 			  "pool" : [
 				{"weight" : 0.45, "item" : "dunestalkseed"},

--- a/treasure/cropharvest.treasurepools.patch
+++ b/treasure/cropharvest.treasurepools.patch
@@ -1041,7 +1041,8 @@
 		"value" : [
 			[0, {
 			  "fill":[
-			    {"item":"bolbohn"}
+			    {"item":"bolbohn"},
+			    {"item":"bolbohnseed"}
 			  ],			
 			  "pool" : [
 				{"weight" : 0.45, "item" : "bolbohnseed"},
@@ -1059,7 +1060,8 @@
 		"value" : [
 			[0, {
 			  "fill":[
-			    {"item":"dunestalk"}
+			    {"item":"dunestalk"},
+			    {"item":"dunestalkseed"}
 			  ],			
 			  "pool" : [
 				{"weight" : 0.45, "item" : "dunestalkseed"},


### PR DESCRIPTION
Removes all mention of deprecated liquid names in descriptions and codices.

Fixed typo in Master's Dagger that was missed in last patch.

Fixed Bolbohn and Dunestalk not dropping seeds when harvested. 