### PR TITLE
Frontier Coffin change

### DIFF
--- a/objects/novakid/frontiercoffin/frontiercoffin.object.patch
+++ b/objects/novakid/frontiercoffin/frontiercoffin.object.patch
@@ -1,0 +1,6 @@
+[
+	{ "op" : "add",
+	  "path" : "/printable",
+	  "value" : false
+	}
+]


### PR DESCRIPTION
Made the Frontier Coffin unprintable to prevent exploits with autopsy table.