### PR TITLE
Mech liquid submersion changes

### DIFF
--- a/vehicles/modularmech/mechparts_body.config.patch
+++ b/vehicles/modularmech/mechparts_body.config.patch
@@ -932,6 +932,14 @@
 		},
 		{
 			"op": "add",
+			"path": "/apex/partParameters/liquidImmunities",
+			"value": {
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
+		},
+		{
+			"op": "add",
 			"path": "/avian/partParameters/hazardImmunities/1",
 			"value": "radioactiveweathernew"
 		},
@@ -1004,6 +1012,14 @@
 			"op": "add",
 			"path": "/avian/partParameters/hazardImmunities/-",
 			"value": "biomepoison3"
+		},
+		{
+			"op": "add",
+			"path": "/avian/partParameters/liquidImmunities",
+			"value": {
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
 		},
 		{
 			"op": "add",
@@ -1082,6 +1098,14 @@
 		},
 		{
 			"op": "add",
+			"path": "/floran/partParameters/liquidImmunities",
+			"value": {
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
+		},
+		{
+			"op": "add",
 			"path": "/glitch/partParameters/hazardImmunities/1",
 			"value": "radioactiveweathernew"
 		},
@@ -1154,6 +1178,14 @@
 			"op": "add",
 			"path": "/glitch/partParameters/hazardImmunities/-",
 			"value": "biomepoison3"
+		},
+		{
+			"op": "add",
+			"path": "/glitch/partParameters/liquidImmunities",
+			"value": {
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
 		},
 		{
 			"op": "add",
@@ -1232,6 +1264,14 @@
 		},
 		{
 			"op": "add",
+			"path": "/hylotl/partParameters/liquidImmunities",
+			"value": {
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
+		},
+		{
+			"op": "add",
 			"path": "/human/partParameters/hazardImmunities/1",
 			"value": "radioactiveweathernew"
 		},
@@ -1307,6 +1347,14 @@
 		},
 		{
 			"op": "add",
+			"path": "/human/partParameters/liquidImmunities",
+			"value": {
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
+		},
+		{
+			"op": "add",
 			"path": "/novakid/partParameters/hazardImmunities/1",
 			"value": "radioactiveweathernew"
 		},
@@ -1379,6 +1427,14 @@
 			"op": "add",
 			"path": "/novakid/partParameters/hazardImmunities/-",
 			"value": "biomepoison3"
+		},
+		{
+			"op": "add",
+			"path": "/novakid/partParameters/liquidImmunities",
+			"value": {
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
 		},
 		{
 			"op": "add",
@@ -1492,6 +1548,16 @@
 		},
 		{
 			"op": "add",
+			"path": "/hero/partParameters/liquidImmunities",
+			"value": {
+				"fuironliquid": true,
+				"lava": true,
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
+		},
+		{
+			"op": "add",
 			"path": "/skull/partParameters/hazardImmunities/1",
 			"value": "radioactiveweathernew"
 		},
@@ -1599,6 +1665,16 @@
 			"op": "add",
 			"path": "/skull/partParameters/hazardImmunities/-",
 			"value": "biomepoison3"
+		},
+		{
+			"op": "add",
+			"path": "/skull/partParameters/liquidImmunities",
+			"value": {
+				"fuironliquid": true,
+				"lava": true,
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
 		},
 		{
 			"op": "add",
@@ -1712,6 +1788,16 @@
 		},
 		{
 			"op": "add",
+			"path": "/miniknog/partParameters/liquidImmunities",
+			"value": {
+				"fuironliquid": true,
+				"lava": true,
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
+		},
+		{
+			"op": "add",
 			"path": "/shark/partParameters/hazardImmunities/1",
 			"value": "radioactiveweathernew"
 		},
@@ -1819,6 +1905,16 @@
 			"op": "add",
 			"path": "/shark/partParameters/hazardImmunities/-",
 			"value": "biomepoison3"
+		},
+		{
+			"op": "add",
+			"path": "/shark/partParameters/liquidImmunities",
+			"value": {
+				"fuironliquid": true,
+				"lava": true,
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
 		},
 		{
 			"op": "add",
@@ -1932,6 +2028,16 @@
 		},
 		{
 			"op": "add",
+			"path": "/exodus/partParameters/liquidImmunities",
+			"value": {
+				"fuironliquid": true,
+				"lava": true,
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
+		},
+		{
+			"op": "add",
 			"path": "/iris/partParameters/hazardImmunities/1",
 			"value": "radioactiveweathernew"
 		},
@@ -2039,6 +2145,16 @@
 			"op": "add",
 			"path": "/iris/partParameters/hazardImmunities/-",
 			"value": "biomepoison3"
+		},
+		{
+			"op": "add",
+			"path": "/iris/partParameters/liquidImmunities",
+			"value": {
+				"fuironliquid": true,
+				"lava": true,
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
 		},
 		{
 			"op": "add",
@@ -2152,6 +2268,16 @@
 		},
 		{
 			"op": "add",
+			"path": "/cultist2/partParameters/liquidImmunities",
+			"value": {
+				"fuironliquid": true,
+				"lava": true,
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
+		},
+		{
+			"op": "add",
 			"path": "/protector/partParameters/hazardImmunities/1",
 			"value": "radioactiveweathernew"
 		},
@@ -2255,7 +2381,14 @@
 			"path": "/protector/partParameters/hazardImmunities/-",
 			"value": "biomepoison3"
 		},
-
+		{
+			"op": "add",
+			"path": "/protector/partParameters/liquidImmunities",
+			"value": {
+				"darkwater": true,
+				"liquidnitrogen": true
+			}
+		},
   {
     "op": "add",
     "path": "/mantiziproto",
@@ -2465,7 +2598,12 @@
 		"ffbiomeheat2",
 		"ffbiomeheat3",
 		"heatweathernew"
-	      ]
+		],
+		"liquidImmunities" : {
+			"fuironliquid": true,
+			"lava": true,
+			"liquidnitrogen": true
+		}
 	    },
 	    "partImages" : {
 	      "bodyBack" : "body/brutebottom.png",
@@ -2707,7 +2845,13 @@
 				"ffbiomeheat2",
 				"heatweathernew2",
 				"heatweathernew"
-				]
+				],
+				"liquidImmunities": {
+					"liquidaether": true,
+					"sulphuricacid": true,
+					"darkwater": true,
+					"liquidnitrogen": true
+				}
     },
 	    "partImages" : {
 	      "bodyBack" : "body/titan_back.png",
@@ -2880,7 +3024,12 @@
 		"ffbiomeheat2",
 		"ffbiomeheat3",
 		"heatweathernew"
-	      ]
+	      ],
+		"liquidImmunities": {
+			"fuironliquid": true,
+			"lava": true,
+			"liquidnitrogen": true
+		}
 	    },
 	    "partImages" : {
 	      "bodyBack" : "body/thelusianbody_back.png",
@@ -3058,7 +3207,12 @@
 		"ffbiomeheat2",
 		"ffbiomeheat3",
 		"heatweathernew"
-	      ]
+		],
+		"liquidImmunities": {
+			"fuironliquid": true,
+			"lava": true,
+			"liquidnitrogen": true
+		}
 	    },
 	    "partImages" : {
 	      "bodyBack" : "body/kirhosbody_back.png",
@@ -3105,7 +3259,12 @@
 		"ffbiomeheat2",
 		"ffbiomeheat3",
 		"heatweathernew"
-	      ]
+		],
+		"liquidImmunities": {
+			"fuironliquid": true,
+			"lava": true,
+			"liquidnitrogen": true
+		}
 	    },
 	    "partImages" : {
 	      "bodyBack" : "body/drakaet_front.png",
@@ -3151,7 +3310,10 @@
 		"ffbiomeheat1",
 		"ffbiomeheat2",
 		"heatweathernew"
-	      ]
+		],
+		"liquidImmunities": {
+			"liquidnitrogen": true
+		}
 	    },
 	    "partImages" : {
 	      "bodyBack" : "body/chinookback.png",
@@ -3236,7 +3398,12 @@
 		"ffbiomeheat2",
 		"ffbiomeheat3",
 		"heatweathernew"
-	      ]
+		],
+		"liquidImmunities": {
+			"fuironliquid": true,
+			"lava": true,
+			"liquidnitrogen": true
+		}
 	    },
 	    "partImages" : {
 	      "bodyBack" : "body/fuOrbus_back.png",
@@ -3297,7 +3464,15 @@
 						"ffbiomeheat3",
 						"heatweathernew2",
 						"heatweathernew"
-					]
+					],
+					"liquidImmunities": {
+						"liquidaether": true,
+						"sulphuricacid": true,
+						"fuironliquid": true,
+						"lava": true,
+						"darkwater": true,
+						"liquidnitrogen": true
+					}
 				},
 				"partImages": {
 					"bodyBack": "body/fuobserver_back.png",

--- a/vehicles/modularmech/modularmech.vehicle.patch
+++ b/vehicles/modularmech/modularmech.vehicle.patch
@@ -365,7 +365,7 @@
     "path": "/liquidVulnerabilities/protociteliquid",
     "value": {
       "energyDrain": -1,
-      "message": "lava_mech"
+      "message": "proto_mech"
     }
   },
   {
@@ -373,6 +373,7 @@
     "path": "/liquidVulnerabilities/fuironliquid",
     "value": {
       "energyDrain": 42.5,
+      "healthDrain": 42.5,
       "message": "lava_mech"
     }
   },
@@ -381,6 +382,7 @@
     "path": "/liquidVulnerabilities/lava",
     "value": {
       "energyDrain": 42.5,
+      "healthDrain": 42.5,
       "message": "lava_mech"
     }
   },
@@ -397,6 +399,7 @@
     "path": "/liquidVulnerabilities/elderfluid",
     "value": {
       "energyDrain": 30,
+      "healthDrain": 30,
       "message": "elder_mech"
     }
   },


### PR DESCRIPTION
- some liquids now drain energy instead of health, and some liquids now drain both.
- some mechs are now immune to the effects of some liquids.

The motivation is that I want to be able to mine every FU ore using a mech. Xithricite is a problem, since mechs in aether take damage and I'm sick of getting out every fifteen seconds to repair it. With this change, I can build the right mech for the environment and get on with my life.

I tried to match up liquid immunities with hazard immunities, i.e. ffbiomeheat3 immunity generally means liquid iron and lava immunities. There's some exceptions, like I didn't make the first brute lava proof (since it's low tier) even though it's immune to ffbiomeheat3.

This does mean that no vanilla mechs are aether-proof, since none of them have aetherweathernew immunity. It's basically just observer and titan that are now aether-safe.

lava, liquid iron, and elder fluid damage both energy and health. Draining just energy didn't seem extreme enough.

No mechs are immune to liquid protocite, since it's a positive effect.

No mechs are immune to elder fluid.

I didn't touch mechs I didn't recognize (e.g. zaku, dvamech), but there shouldn't be any game-breaking changes for them; it's just still a bad idea to take them into lava or aether.

A couple things I noticed while digging around the mechparts_body.config.patch:
- fubrute and fubrute3 are immune to ffbiomeheat3, but fubrute2 is not. Seems odd.
- the non-prototype mantizi (Il Ventuno) is afaik the only upgraded race mech without cold3 and heat3 resistance.
- avikan hazardImmunities is there three times, looks like it was copypasted and then accidentally unchanged when creating trink and aegi?
- There's some mixed indentation that upsets my sensitive ocd code monkey brain.

