### PR TITLE
XCustomCodex tweaks, bookcase patches

### DIFF
--- a/interface/chests/ContainerControl.lua
+++ b/interface/chests/ContainerControl.lua
@@ -1,0 +1,68 @@
+-- Appended by Xan the Dragon
+-- Main controller script for the "Read All" button added by /chest/cdx/chest<slots>.config
+
+----------------------------------------------
+------ Duplicated from RemotePlayer.lua ------
+----------------------------------------------
+
+local function TableAlreadyContains(tbl, entry)
+	for _, value in pairs(tbl) do
+		if value[1] == entry[1] and value[2] == entry[2] then
+			return true
+		end
+	end
+	return false
+end
+
+local function LearnCodex(itemName)
+	local existingKnownEntries = player.getProperty("xcodex.knownCodexEntries") or {}
+	local data = root.itemConfig(itemName)		
+	if itemName:sub(-6) ~= "-codex" then
+		return -- Abort. Don't warn and try to continue anyway. This condition was already checked anyway.
+	else
+		itemName = itemName:sub(1, -7)
+	end
+	
+	-- Now one more thing I want to add here for ContainerControl and NOT in stock RemotePlayer is determining if the item is actually a codex.
+	-- Knowing people, some guy is gonna make a gun or something and name it "roflcopter-codex", and if that passes this gateway, shit's gonna hit the fan.
+	-- The actual codex UI protects against this but it's gonna be stored as a readable codex which means doing that check every time the player opens the UI. Not fun!
+	local foundCodexFile = pcall(function ()
+		root.assetJson(data.directory .. itemName .. ".codex")
+	end)
+	
+	if not foundCodexFile then
+		if sb then sb.logWarn("An item ended in -codex but was NOT a codex! Ignoring this item.") end
+		return
+	end
+	
+	-- This is for sanity checking. The interface itself will actually remove null codex entries from player data persistence.
+	local codexCache = {tostring(itemName), tostring(data.directory)}
+	
+	-- If our internal cache here says we don't know it then we need to learn it.
+	if not TableAlreadyContains(existingKnownEntries, codexCache) then
+		table.insert(existingKnownEntries, codexCache)
+		player.setProperty("xcodex.knownCodexEntries", existingKnownEntries)
+		if sb then sb.logInfo("Player has learned codex " .. table.concat(codexCache, ", ") .. ".") end
+	else
+		if sb then sb.logInfo("Player attempted to learn codex " .. table.concat(codexCache, ", ") .. " but they already know it in the new registry.") end
+	end
+end
+
+----------------------------------------------
+----------------------------------------------
+----------------------------------------------
+
+function CodexButtonClicked()
+	--player.interact("ScriptPane", "/interface/scripted/xcustomcodex/xcodexui.config", player.id())
+	local items = widget.itemGridItems("itemGrid")
+	for index, item in pairs(items) do
+		local itemName = item.name
+		-- Simple test: Does it end in -codex? We can easily scrap items that aren't codexes this way.
+		 if itemName:sub(-6) == "-codex" then
+			LearnCodex(itemName)
+		 end
+	end
+	widget.playSound("/sfx/interface/item_equip.ogg") -- Give the player some feedback that they learned the entries.
+end
+
+-- gg ez

--- a/interface/chests/cdx/chest1.config
+++ b/interface/chests/cdx/chest1.config
@@ -1,0 +1,64 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots1to16.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 81],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [21, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Add To Codex",
+			"position" : [82, 26],
+			"callback" : "CodexButtonClicked"
+		}
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [110, 70],
+			"dimensions" : [1, 1],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "1 SLOT",
+			"hAnchor" : "mid",
+			"position" : [120, 119]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine1to16.png",
+			"position" : [0, 2]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 135]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest12.config
+++ b/interface/chests/cdx/chest12.config
@@ -1,0 +1,64 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots1to16.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 80],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [21, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [82, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [91, 42],
+			"dimensions" : [3, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "12 SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 119]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine1to16.png",
+			"position" : [0, 2]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 135]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest16.config
+++ b/interface/chests/cdx/chest16.config
@@ -1,0 +1,64 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots1to16.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 79],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [21, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [82, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [81, 42],
+			"dimensions" : [4, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "16 SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 119]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine1to16.png",
+			"position" : [0, 2]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 135]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest24.config
+++ b/interface/chests/cdx/chest24.config
@@ -1,0 +1,72 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots17to24.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 104],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [22, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [83, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [81, 62],
+			"dimensions" : [4, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"itemGrid2" : {
+			"type" : "itemgrid",
+			"position" : [4, 43],
+			"slotOffset" : 16,
+			"dimensions" : [8, 1],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "24 SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 140]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine17to24.png",
+			"position" : [0, 3]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 156]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest32.config
+++ b/interface/chests/cdx/chest32.config
@@ -1,0 +1,72 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots25to32.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 122],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [22, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [83, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [81, 81],
+			"dimensions" : [4, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"itemGrid2" : {
+			"type" : "itemgrid",
+			"position" : [4, 43],
+			"slotOffset" : 16,
+			"dimensions" : [8, 2],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "32 SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 158]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine25to32.png",
+			"position" : [0, 2]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 174]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest40.config
+++ b/interface/chests/cdx/chest40.config
@@ -1,0 +1,72 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots33to40.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 141],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [22, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [83, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [81, 100],
+			"dimensions" : [4, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"itemGrid2" : {
+			"type" : "itemgrid",
+			"position" : [4, 43],
+			"slotOffset" : 16,
+			"dimensions" : [8, 3],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "40 SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 179]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine33to40.png",
+			"position" : [0, 2]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 194]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest48.config
+++ b/interface/chests/cdx/chest48.config
@@ -1,0 +1,72 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots41to48.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [39, 160],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [22, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [83, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [81, 119],
+			"dimensions" : [4, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"itemGrid2" : {
+			"type" : "itemgrid",
+			"position" : [4, 44],
+			"slotOffset" : 16,
+			"dimensions" : [8, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "48 SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 197]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine41to48.png",
+			"position" : [0, 3]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 213]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest56.config
+++ b/interface/chests/cdx/chest56.config
@@ -1,0 +1,72 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots49to56.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 179],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [22, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [83, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [81, 138],
+			"dimensions" : [4, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"itemGrid2" : {
+			"type" : "itemgrid",
+			"position" : [4, 44],
+			"slotOffset" : 16,
+			"dimensions" : [8, 5],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "56 SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 216]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine49andup.png",
+			"position" : [0, 20]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 232]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest60.config
+++ b/interface/chests/cdx/chest60.config
@@ -1,0 +1,72 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots57to64.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 186],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [22, 152]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [83, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [81, 145],
+			"dimensions" : [4, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"itemGrid2" : {
+			"type" : "itemgrid",
+			"position" : [4, 31],
+			"slotOffset" : 16,
+			"dimensions" : [8, 6],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "<slots> SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 222]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine49andup.png",
+			"position" : [0, 0]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 239]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest64.config
+++ b/interface/chests/cdx/chest64.config
@@ -1,0 +1,72 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots57to64.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 198],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [22, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [83, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [81, 157],
+			"dimensions" : [4, 4],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"itemGrid2" : {
+			"type" : "itemgrid",
+			"position" : [4, 43],
+			"slotOffset" : 16,
+			"dimensions" : [8, 6],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "<slots> SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 234]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine49andup.png",
+			"position" : [0, 50]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 251]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/interface/chests/cdx/chest9.config
+++ b/interface/chests/cdx/chest9.config
@@ -1,0 +1,64 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/chests/chestheader.png",
+			"fileBody" : "/interface/chests/slots1to16.png",
+			"fileFooter" : "/interface/chests/chestfooter.png"
+		},
+		"objectImage" : {
+			"type" : "image",
+			"position" : [40, 81],
+			"file" : "",
+			"centered" : true,
+			"maxSize" : [40, 40],
+			"minSize" : [40, 40]
+		},
+		"clear" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Take all",
+			"position" : [21, 26]
+		},
+		"openCodex" : {
+			"type" : "button",
+			"base" : "/interface/button.png",
+			"hover" : "/interface/buttonhover.png",
+			"press" : "/interface/buttonhover.png",
+			"caption" : "Read all",
+			"position" : [82, 26],
+			"callback" : "CodexButtonClicked"
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"position" : [91, 52],
+			"dimensions" : [3, 3],
+			"spacing" : [19, 19],
+			"backingImage" : "/interface/inventory/empty.png"
+		},
+		"count" : {
+			"type" : "label",
+			"value" : "9 SLOTS",
+			"hAnchor" : "mid",
+			"position" : [120, 119]
+		},
+		"overlay" : {
+			"type" : "image",
+			"file" : "/interface/chests/shine1to16.png",
+			"position" : [0, 2]
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"pressed" : "/interface/xpress.png",
+			"pressedOffset" : [0, 0],
+			"position" : [143, 135]
+		}
+	},
+	"scriptWidgetCallbacks" : ["CodexButtonClicked"],
+	"scripts" : ["/interface/chests/ContainerControl.lua"],
+	"scriptDelta" : 30
+}

--- a/objects/apex/apexcoolbookcase/apexcoolbookcase.object.patch
+++ b/objects/apex/apexcoolbookcase/apexcoolbookcase.object.patch
@@ -1,0 +1,7 @@
+[
+	{
+		"op": "replace",
+		"path" : "/uiConfig",
+		"value" : "/interface/chests/cdx/chest<slots>.config"
+	}
+]

--- a/objects/avian/tribalbookcase1/tribalbookcase1.object.patch
+++ b/objects/avian/tribalbookcase1/tribalbookcase1.object.patch
@@ -1,0 +1,7 @@
+[
+	{
+		"op": "replace",
+		"path" : "/uiConfig",
+		"value" : "/interface/chests/cdx/chest<slots>.config"
+	}
+]

--- a/objects/avian/tribalbookcase2/tribalbookcase2.object.patch
+++ b/objects/avian/tribalbookcase2/tribalbookcase2.object.patch
@@ -1,0 +1,7 @@
+[
+	{
+		"op": "replace",
+		"path" : "/uiConfig",
+		"value" : "/interface/chests/cdx/chest<slots>.config"
+	}
+]

--- a/objects/generic/woodenbookcase/woodenbookcase.object.patch
+++ b/objects/generic/woodenbookcase/woodenbookcase.object.patch
@@ -1,0 +1,7 @@
+[
+	{
+		"op": "replace",
+		"path" : "/uiConfig",
+		"value" : "/interface/chests/cdx/chest<slots>.config"
+	}
+]

--- a/objects/generic/woodenceilingbookcase1/woodenceilingbookcase1.object.patch
+++ b/objects/generic/woodenceilingbookcase1/woodenceilingbookcase1.object.patch
@@ -1,0 +1,7 @@
+[
+	{
+		"op": "replace",
+		"path" : "/uiConfig",
+		"value" : "/interface/chests/cdx/chest<slots>.config"
+	}
+]

--- a/objects/glitch/medievalbookcase/medievalbookcase.object.patch
+++ b/objects/glitch/medievalbookcase/medievalbookcase.object.patch
@@ -1,0 +1,7 @@
+[
+	{
+		"op": "replace",
+		"path" : "/uiConfig",
+		"value" : "/interface/chests/cdx/chest<slots>.config"
+	}
+]

--- a/objects/hylotl/hylotlclassicbookcase/hylotlclassicbookcase.object.patch
+++ b/objects/hylotl/hylotlclassicbookcase/hylotlclassicbookcase.object.patch
@@ -1,0 +1,7 @@
+[
+	{
+		"op": "replace",
+		"path" : "/uiConfig",
+		"value" : "/interface/chests/cdx/chest<slots>.config"
+	}
+]

--- a/objects/themed/gothic/gothicbookcase/gothicbookcase.object.patch
+++ b/objects/themed/gothic/gothicbookcase/gothicbookcase.object.patch
@@ -1,0 +1,7 @@
+[
+	{
+		"op": "replace",
+		"path" : "/uiConfig",
+		"value" : "/interface/chests/cdx/chest<slots>.config"
+	}
+]

--- a/scripts/xcore_customcodex/RemotePlayer.lua
+++ b/scripts/xcore_customcodex/RemotePlayer.lua
@@ -5,7 +5,7 @@ require("/scripts/messageutil.lua")
 
 local OldInit = init
 
-function TableAlreadyContains(tbl, entry)
+local function TableAlreadyContains(tbl, entry)
 	for _, value in pairs(tbl) do
 		if value[1] == entry[1] and value[2] == entry[2] then
 			return true
@@ -14,31 +14,41 @@ function TableAlreadyContains(tbl, entry)
 	return false
 end
 
+local function LearnCodex(itemName)
+	local existingKnownEntries = player.getProperty("xcodex.knownCodexEntries") or {}
+	local data = root.itemConfig(itemName)		
+	if itemName:sub(-6) ~= "-codex" then
+		if sb then sb.logWarn("Player attempted to learn codex, but held item name did not end in -codex! This could cause serious issues!") end
+	else
+		itemName = itemName:sub(1, -7)
+	end
+	
+	-- This is for sanity checking. The interface itself will actually remove null codex entries from player data persistence.
+	local codexCache = {tostring(itemName), tostring(data.directory)}
+	
+	-- If our internal cache here says we don't know it then we need to learn it.
+	if not TableAlreadyContains(existingKnownEntries, codexCache) then
+		table.insert(existingKnownEntries, codexCache)
+		player.setProperty("xcodex.knownCodexEntries", existingKnownEntries)
+		if sb then sb.logInfo("Player has learned codex " .. table.concat(codexCache, ", ") .. ".") end
+	else
+		if sb then sb.logInfo("Player attempted to learn codex " .. table.concat(codexCache, ", ") .. " but they already know it in the new registry.") end
+	end
+end
+
+
 function init()
 	if OldInit then
 		OldInit()
 	end
-	message.setHandler("xcodexLearnCodex", localHandler(function (itemName)
-		local existingKnownEntries = player.getProperty("xcodex.knownCodexEntries") or {}
-		local data = root.itemConfig(itemName)		
-		if itemName:sub(-6) ~= "-codex" then
-			if sb then sb.logWarn("Player attempted to learn codex, but held item name did not end in -codex! This could cause serious issues!") end
-		else
-			itemName = itemName:sub(1, -7)
-		end
-		
-		-- This is for sanity checking. The interface itself will actually remove null codex entries from player data persistence.
-		local codexCache = {tostring(itemName), tostring(data.directory)}
-		
-		-- If our internal cache here says we don't know it then we need to learn it.
-		if not TableAlreadyContains(existingKnownEntries, codexCache) then
-			table.insert(existingKnownEntries, codexCache)
-			player.setProperty("xcodex.knownCodexEntries", existingKnownEntries)
-			if sb then sb.logInfo("Player has learned codex " .. table.concat(codexCache, ", ") .. ".") end
-			
-			-- player.interact("ScriptPane", "/interface/scripted/xcustomcodex/xcodexui.config", player.id())
-		else
-			if sb then sb.logInfo("Player attempted to learn codex " .. table.concat(codexCache, ", ") .. " but they already know it in the new registry.") end
-		end
-	end))
+	message.setHandler("xcodexLearnCodex", localHandler(LearnCodex))
+	
+	-- NEW: I want to also try to prepopulate the player's species's known codexes.
+	local playerCfg = root.assetJson("/player.config")
+	local defaultCdxArray = playerCfg.defaultCodexes
+	local playerSpecies = player.species()
+	local speciesDefaultCdx = defaultCdxArray[playerSpecies] or {}
+	for _, cdx in pairs(speciesDefaultCdx) do
+		LearnCodex(cdx .. "-codex") -- This is so that it doesn't complain about it not being a codex item.
+	end
 end


### PR DESCRIPTION
This change does a number of tweaks to XCustomCodex (the new codex UI) as well as some changes to vanilla bookshelf containers.

The changes are as follows:
- The ambiguous race button in the codex now displays a ? instead of a *
- All codex entries under any given race will now sort alphabetically.
- The following containers have been patched and now feature a "Read All" button to automatically read + register all codexes into the new menu: `apexcoolbookcase`, `tribalbookcase1`, `tribalbookcase2`, `woodenbookcase`, `woodenceilingbookcase1`, `medievalbookcase`, `hylotlclassicbookcase`, and `gothicbookcase` (n.b. this does not register them into the vanilla codex)
- Racial default codexes will now be learned. Unlike the vanilla codex menu, this is tested on load, so any updates made to a race that define new default codexes will see that change reflected in the new menu instantly.