### PR TITLE
Codex improvements, new status message on bookcases

### DIFF
--- a/interface/chests/cdx/chest1.config
+++ b/interface/chests/cdx/chest1.config
@@ -31,6 +31,13 @@
 			"position" : [82, 26],
 			"callback" : "CodexButtonClicked"
 		}
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [110, 70],

--- a/interface/chests/cdx/chest12.config
+++ b/interface/chests/cdx/chest12.config
@@ -31,6 +31,13 @@
 			"position" : [82, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [91, 42],

--- a/interface/chests/cdx/chest16.config
+++ b/interface/chests/cdx/chest16.config
@@ -31,6 +31,13 @@
 			"position" : [82, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [81, 42],

--- a/interface/chests/cdx/chest24.config
+++ b/interface/chests/cdx/chest24.config
@@ -31,6 +31,13 @@
 			"position" : [83, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [81, 62],

--- a/interface/chests/cdx/chest32.config
+++ b/interface/chests/cdx/chest32.config
@@ -31,6 +31,13 @@
 			"position" : [83, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [81, 81],

--- a/interface/chests/cdx/chest40.config
+++ b/interface/chests/cdx/chest40.config
@@ -31,6 +31,13 @@
 			"position" : [83, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [81, 100],

--- a/interface/chests/cdx/chest48.config
+++ b/interface/chests/cdx/chest48.config
@@ -31,6 +31,13 @@
 			"position" : [83, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [81, 119],

--- a/interface/chests/cdx/chest56.config
+++ b/interface/chests/cdx/chest56.config
@@ -31,6 +31,13 @@
 			"position" : [83, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [81, 138],

--- a/interface/chests/cdx/chest60.config
+++ b/interface/chests/cdx/chest60.config
@@ -31,6 +31,13 @@
 			"position" : [83, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [81, 145],

--- a/interface/chests/cdx/chest64.config
+++ b/interface/chests/cdx/chest64.config
@@ -31,6 +31,13 @@
 			"position" : [83, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [81, 157],

--- a/interface/chests/cdx/chest9.config
+++ b/interface/chests/cdx/chest9.config
@@ -31,6 +31,13 @@
 			"position" : [82, 26],
 			"callback" : "CodexButtonClicked"
 		},
+		"statusMessage" : {
+			"type" : "label",
+			"value" : "",
+			"hAnchor" : "mid",
+			"vAnchor" : "mid",
+			"position" : [80, 18]
+		},
 		"itemGrid" : {
 			"type" : "itemgrid",
 			"position" : [91, 52],

--- a/scripts/xcore_customcodex/LearnCodexRoutine.lua
+++ b/scripts/xcore_customcodex/LearnCodexRoutine.lua
@@ -1,0 +1,84 @@
+-- Written by Xan the Dragon // Eti the Spirit [RBX 18406183]
+-- Code to learn codex entries.
+require("/scripts/xcore_customcodex/LoggingOverride.lua") -- Very nice script!
+local HasLoggingOverride = false
+local print, warn, error, assertwarn, assert, tostring;
+
+local REMINDER_DONT_REPORT_INSIGNIFICANT_ERRORS = "\n\t >>>> THIS ERROR MESSAGE IS FOR LOGGING PURPOSES ONLY. THIS IS ***NOT*** A FATAL ERROR.\n\t >>>> If you wish to report it anyway, go to Xan the Dragon#1760 as this is his script.\n"
+
+local function GetLoggingOverridesIfNecessary()
+	if HasLoggingOverride then return end
+	print, warn, new_error, assertwarn, assert, tostring = CreateLoggingOverride("[Codex Learning Routine]")
+	
+	-- Hacky, but it ensures every error message has this without the need to paste it after every message.
+	error = function (...)
+		new_error(..., REMINDER_DONT_REPORT_INSIGNIFICANT_ERRORS)
+	end
+	
+	HasLoggingOverride = true
+end
+
+-- Does the table contain the learned codex data?
+local function TableAlreadyContains(tbl, entry)
+	for _, value in pairs(tbl) do
+		if value[1] == entry[1] and value[2] == entry[2] then
+			return true
+		end
+	end
+	return false
+end
+
+-- Attempt to learn this codex. 
+-- Returns 0 if the call was successful and we learned the codex entry, 1 if the call was successful but we already knew the entry, and 2 if something errored out.
+function LearnCodex(itemName)
+	GetLoggingOverridesIfNecessary()
+	
+	-- First sanity check: Item name OK?
+	if type(itemName) ~= "string" then
+		error("Something called LearnCodex with an item name that wasn't a string. Aborting the learning procedure. (itemName is nil? " .. tostring(itemName == nil):upper() .. ").")
+		return 2
+	end
+	if not itemName == nil or #itemName <= 6 then
+		error("Something called LearnCodex with an item name that was either nil or had a length less than or equal to 6 (and by extension, it would be impossible for its name to end in -codex and still have content beforehand as a result). Aborting the learning procedure. The item name is: " .. tostring(itemName))
+		return 2
+	end
+	if itemName:sub(-6) ~= "-codex" then
+		error("Player attempted to learn codex, but held item name did not end in -codex! Aborting the learning procedure. The item name is: " .. tostring(itemName))
+		return 2
+	end
+	------------------------------------
+	
+	-- Second sanity check: Item exists?
+	local data = root.itemConfig(itemName) -- Kind of counterintuitive but oh well.
+	if data == nil or data.directory == nil then
+		error("Player attempted to learn a codex from the item [" .. tostring(itemName) .. "], but root.itemConfig() returned nil data on this item! Aborting the learning procedure.")
+		return 2
+	end
+	
+	-- Update item name to strip it of -codex since we no longer want that suffix.
+	local itemName = itemName:sub(1, -7)
+	
+	local foundCodexFile = pcall(root.assetJson, data.directory .. itemName .. ".codex")
+	if not foundCodexFile then
+		error("An item's ID ended in -codex, but it was not located as a codex in the game data files -- this item is violating naming conventions! Aborting the learning procedure. (Attempted to locate the file [" .. data.directory .. itemName .. ".codex], which doesn't exist.")
+		return 2
+	end
+	------------------------------------
+	
+	-- This is for sanity checking. The interface itself will actually remove null codex entries from player data persistence.
+	local codexCache = {tostring(itemName), tostring(data.directory)}
+	
+	-- Get player's known codex entries.
+	local existingKnownEntries = player.getProperty("xcodex.knownCodexEntries") or {}
+	
+	-- If our internal cache here says we don't know it then we need to learn it.
+	if not TableAlreadyContains(existingKnownEntries, codexCache) then
+		table.insert(existingKnownEntries, codexCache)
+		player.setProperty("xcodex.knownCodexEntries", existingKnownEntries)
+		if sb then sb.logInfo("Player has learned codex " .. table.concat(codexCache, ", ") .. ".") end
+		return 0
+	else
+		if sb then sb.logInfo("Player attempted to learn codex " .. table.concat(codexCache, ", ") .. " but they already know it, so we don't need to learn it again.") end
+		return 1
+	end
+end

--- a/scripts/xcore_customcodex/LearnCodexRoutine.lua
+++ b/scripts/xcore_customcodex/LearnCodexRoutine.lua
@@ -4,16 +4,9 @@ require("/scripts/xcore_customcodex/LoggingOverride.lua") -- Very nice script!
 local HasLoggingOverride = false
 local print, warn, error, assertwarn, assert, tostring;
 
-local REMINDER_DONT_REPORT_INSIGNIFICANT_ERRORS = "\n\t >>>> THIS ERROR MESSAGE IS FOR LOGGING PURPOSES ONLY. THIS IS ***NOT*** A FATAL ERROR.\n\t >>>> If you wish to report it anyway, go to Xan the Dragon#1760 as this is his script.\n"
-
 local function GetLoggingOverridesIfNecessary()
 	if HasLoggingOverride then return end
-	print, warn, new_error, assertwarn, assert, tostring = CreateLoggingOverride("[Codex Learning Routine]")
-	
-	-- Hacky, but it ensures every error message has this without the need to paste it after every message.
-	error = function (...)
-		new_error(..., REMINDER_DONT_REPORT_INSIGNIFICANT_ERRORS)
-	end
+	print, warn, error, assertwarn, assert, tostring = CreateLoggingOverride("[XCustomCodex Systems] ")
 	
 	HasLoggingOverride = true
 end
@@ -35,15 +28,15 @@ function LearnCodex(itemName)
 	
 	-- First sanity check: Item name OK?
 	if type(itemName) ~= "string" then
-		error("Something called LearnCodex with an item name that wasn't a string. Aborting the learning procedure. (itemName is nil? " .. tostring(itemName == nil):upper() .. ").")
+		warn("Something called LearnCodex with an item name that wasn't a string. Aborting the learning procedure. (itemName is nil? " .. tostring(itemName == nil):upper() .. ").")
 		return 2
 	end
 	if not itemName == nil or #itemName <= 6 then
-		error("Something called LearnCodex with an item name that was either nil or had a length less than or equal to 6 (and by extension, it would be impossible for its name to end in -codex and still have content beforehand as a result). Aborting the learning procedure. The item name is: " .. tostring(itemName))
+		warn("Something called LearnCodex with an item name that was either nil or had a length less than or equal to 6 (and by extension, it would be impossible for its name to end in -codex and still have content beforehand as a result). Aborting the learning procedure. The item name is: " .. tostring(itemName))
 		return 2
 	end
 	if itemName:sub(-6) ~= "-codex" then
-		error("Player attempted to learn codex, but held item name did not end in -codex! Aborting the learning procedure. The item name is: " .. tostring(itemName))
+		warn("Player attempted to learn codex, but held item name did not end in -codex! Aborting the learning procedure. The item name is: " .. tostring(itemName))
 		return 2
 	end
 	------------------------------------
@@ -51,7 +44,7 @@ function LearnCodex(itemName)
 	-- Second sanity check: Item exists?
 	local data = root.itemConfig(itemName) -- Kind of counterintuitive but oh well.
 	if data == nil or data.directory == nil then
-		error("Player attempted to learn a codex from the item [" .. tostring(itemName) .. "], but root.itemConfig() returned nil data on this item! Aborting the learning procedure.")
+		warn("Player attempted to learn a codex from the item [" .. tostring(itemName) .. "], but root.itemConfig() returned nil data on this item! Aborting the learning procedure.")
 		return 2
 	end
 	
@@ -60,7 +53,7 @@ function LearnCodex(itemName)
 	
 	local foundCodexFile = pcall(root.assetJson, data.directory .. itemName .. ".codex")
 	if not foundCodexFile then
-		error("An item's ID ended in -codex, but it was not located as a codex in the game data files -- this item is violating naming conventions! Aborting the learning procedure. (Attempted to locate the file [" .. data.directory .. itemName .. ".codex], which doesn't exist.")
+		warn("An item's ID ended in -codex, but it was not located as a codex in the game data files -- this item is violating naming conventions! Aborting the learning procedure. (Attempted to locate the file [" .. data.directory .. itemName .. ".codex], which doesn't exist.")
 		return 2
 	end
 	------------------------------------
@@ -75,10 +68,10 @@ function LearnCodex(itemName)
 	if not TableAlreadyContains(existingKnownEntries, codexCache) then
 		table.insert(existingKnownEntries, codexCache)
 		player.setProperty("xcodex.knownCodexEntries", existingKnownEntries)
-		if sb then sb.logInfo("Player has learned codex " .. table.concat(codexCache, ", ") .. ".") end
+		print("Player has learned codex " .. table.concat(codexCache, ", ") .. ".")
 		return 0
 	else
-		if sb then sb.logInfo("Player attempted to learn codex " .. table.concat(codexCache, ", ") .. " but they already know it, so we don't need to learn it again.") end
+		print("Player attempted to learn codex " .. table.concat(codexCache, ", ") .. " but they already know it, so we don't need to learn it again.")
 		return 1
 	end
 end

--- a/scripts/xcore_customcodex/RemotePlayer.lua
+++ b/scripts/xcore_customcodex/RemotePlayer.lua
@@ -2,48 +2,22 @@
 -- Replicates ALL player functions and exposes them as a message handler.
 
 require("/scripts/messageutil.lua")
+require("/scripts/xcore_customcodex/LearnCodexRoutine.lua") -- Defines LearnCodex(string name)
 
 local OldInit = init
-
-local function TableAlreadyContains(tbl, entry)
-	for _, value in pairs(tbl) do
-		if value[1] == entry[1] and value[2] == entry[2] then
-			return true
-		end
-	end
-	return false
-end
-
-local function LearnCodex(itemName)
-	local existingKnownEntries = player.getProperty("xcodex.knownCodexEntries") or {}
-	local data = root.itemConfig(itemName)		
-	if itemName:sub(-6) ~= "-codex" then
-		if sb then sb.logWarn("Player attempted to learn codex, but held item name did not end in -codex! This could cause serious issues!") end
-	else
-		itemName = itemName:sub(1, -7)
-	end
-	
-	-- This is for sanity checking. The interface itself will actually remove null codex entries from player data persistence.
-	local codexCache = {tostring(itemName), tostring(data.directory)}
-	
-	-- If our internal cache here says we don't know it then we need to learn it.
-	if not TableAlreadyContains(existingKnownEntries, codexCache) then
-		table.insert(existingKnownEntries, codexCache)
-		player.setProperty("xcodex.knownCodexEntries", existingKnownEntries)
-		if sb then sb.logInfo("Player has learned codex " .. table.concat(codexCache, ", ") .. ".") end
-	else
-		if sb then sb.logInfo("Player attempted to learn codex " .. table.concat(codexCache, ", ") .. " but they already know it in the new registry.") end
-	end
-end
-
 
 function init()
 	if OldInit then
 		OldInit()
 	end
 	message.setHandler("xcodexLearnCodex", localHandler(LearnCodex))
-	
+end
+
+function postinit()
 	-- NEW: I want to also try to prepopulate the player's species's known codexes.
+	-- This is in postinit() because LearnCodex uses logging which requires access to sb (which is defined *after* init for some god-awful reason.)
+	-- In case you don't know -- InitializationUtility.lua adds a postinit function.
+	
 	local playerCfg = root.assetJson("/player.config")
 	local defaultCdxArray = playerCfg.defaultCodexes
 	local playerSpecies = player.species()
@@ -52,3 +26,6 @@ function init()
 		LearnCodex(cdx .. "-codex") -- This is so that it doesn't complain about it not being a codex item.
 	end
 end
+
+-- Yes, this goes down here. Don't move it or you will cause postinit() to never run.
+require("/scripts/xcore_customcodex/InitializationUtility.lua")


### PR DESCRIPTION
This patch comes with some neat changes:
- RemotePlayer.lua and ContainerControl.lua no longer have the `LearnCodex` method separately hardcoded into each of them. They both point to `LearnCodexRoutine.lua` which creates the necessary function in the environment.
- The `LearnCodex` function now has detailed catch cases to prevent issues caused by malformed data. It will report malformed data via warnings (error logging is not being used since error implies that the script is broken).
- Bookcases registered to use the custom "Read all" button now have a status message in their footer to give feedback. This message displays how many codex entries were learned, how many were already known, and how many triggered a catch case (and could not be handled as a result).
- Change credits attribution from "Xan" to "XanTheDragon".