### PR TITLE
Atom smasher loot pool fix.

### DIFF
--- a/treasure/fftreasure.treasurepools
+++ b/treasure/fftreasure.treasurepools
@@ -529,7 +529,6 @@
           {"weight" : 0.01, "item" : ["mobiusrifle", 1]},
           {"weight" : 0.01, "item" : ["mobiusrailgun", 1]},
           {"weight" : 0.01, "item" : ["tristab", 1]},
-          {"weight" : 0.0005, "item" : ["atomsmasher", 1]},
       	  {"weight" : 0.01, "item" : "razorneedler"},
       	  {"weight" : 0.01, "item" : "scorchneedler"},
       	  {"weight" : 0.01, "item" : "shockneedler"},

--- a/treasure/futreasurepools.treasurepools
+++ b/treasure/futreasurepools.treasurepools
@@ -1846,7 +1846,6 @@
         {"weight" : 0.001, "item" : ["fupixelbreaker", 1]},
         {"weight" : 0.001, "item" : ["fugjallarhorn", 1]},
         {"weight" : 0.001, "item" : [ "skullreaperhelm3", 1]},
-        {"weight" : 0.0005, "item" : ["atomsmasher", 1]},
         {"weight" : 0.1, "pool" : "fucodexRandom" },
         {"weight" : 0.003, "item" : "mrscorchy"},
         {"weight" : 0.001, "item" : "marinerspear"},


### PR DESCRIPTION
Probably unnecessary because it was so rare anyways, but you said you forgot to remove them on discord so I did it for you.