### PR TITLE
lunari shard category

### DIFF
--- a/items/generic/crafting/solarishard.item
+++ b/items/generic/crafting/solarishard.item
@@ -2,7 +2,7 @@
   "itemName" : "solarishard",
   "rarity" : "Common",
   "price" : 60,
-  "category" : "craftingMaterial",
+  "category" : "craftingOre",
   "inventoryIcon" : "solarishard.png",
   "description" : "A sparkling yellow crystal shard.",
   "shortdescription" : "Lunari Shard",


### PR DESCRIPTION
lunari shards changed to be 'ore' category. for easier sorting.