### PR TITLE
quest fixes

### DIFF
--- a/bees/apiary.lua
+++ b/bees/apiary.lua
@@ -985,6 +985,7 @@ function areRivals(name1, name2)
 	-- Return false if the bees are of the same family
 	if name1 == name2 then return false end
 	
+	--sb.logInfo("names: %s",{name1,name2})
 	if string.find(name1, "_") then
 		name1 = family(name1)
 	end
@@ -992,14 +993,14 @@ function areRivals(name1, name2)
 	if string.find(name2, "_") then
 		name2 = family(name2)
 	end
-	
+	--sb.logInfo("families: %s",{name1,name2})
 	-- Check if the first bee is the rival for the second
-	if type(beeData.beeFamilyRivalries[name1]) == "string" then
-		if beeData.beeFamilyRivalries[name1][name1] == name2 then
+	if type(beeData.rivals[name1]) == "string" then
+		if beeData.rivals[name1] == name2 then
 			return true
 		end
-	elseif type(beeData.beeFamilyRivalries[name1][name1]) == "table" then
-		for _, rival in ipairs(beeData.beeFamilyRivalries[name1][name1]) do
+	elseif type(beeData.rivals[name1]) == "table" then
+		for _, rival in ipairs(beeData.rivals[name1]) do
 			if name2 == rival then
 				return true
 			end
@@ -1007,12 +1008,12 @@ function areRivals(name1, name2)
 	end
 	
 	-- Check if the second bee is the rival to the first
-	if type(beeData.beeFamilyRivalries[name1][name2]) == "string" then
-		if beeData.beeFamilyRivalries[name1][name2] == name1 then
+	if type(beeData.rivals[name2]) == "string" then
+		if beeData.rivals[name2] == name1 then
 			return true
 		end
-	elseif type(beeData.beeFamilyRivalries[name1][name2]) == "table" then
-		for _, rival in ipairs(beeData.beeFamilyRivalries[name1][name1]) do
+	elseif type(beeData.rivals[name2]) == "table" then
+		for _, rival in ipairs(beeData.rivals[name2]) do
 			if name1 == rival then
 				return true
 			end

--- a/items/generic/crafting/chemlab/fu_mulch.item
+++ b/items/generic/crafting/chemlab/fu_mulch.item
@@ -4,7 +4,7 @@
   "price": 6,
   "category": "craftingMaterial",
   "inventoryIcon": "fu_mulch.png",
-  "description": "Great for fertilizing a hydroponics tray.\n^green;Grows +^white;1.25 ^green;produce^reset;",
+  "description": "Great for fertilizing a hydroponics tray.\n^green;Grows +^white;1.25 ^green;produce^gray; & ^cyan;-^white;1 ^cyan;seeds^reset;",
   "radioMessagesOnPickup": ["pickupMulch"],
   "shortdescription": "Mulch",
   "itemTags": ["reagent"],

--- a/quests/fu_questlines/battle/gear/create_armcannon.questtemplate
+++ b/quests/fu_questlines/battle/gear/create_armcannon.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "turnInDescription" : "Bring the ^orange;arm cannon^reset; to the ^green;annoying guy^reset; at the ^orange;Science Outpost^reset;",
 

--- a/quests/fu_questlines/battle/gear/create_energyassault.questtemplate
+++ b/quests/fu_questlines/battle/gear/create_energyassault.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
         "turnInDescription" : "Bring the ^orange;f4 Energy Rifle^reset; to the scientist.",
 
     "conditions" : [

--- a/quests/fu_questlines/battle/gear/create_laspistol.questtemplate
+++ b/quests/fu_questlines/battle/gear/create_laspistol.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "conditions" : [
       {

--- a/quests/fu_questlines/battle/gear/create_steelwarblade.questtemplate
+++ b/quests/fu_questlines/battle/gear/create_steelwarblade.questtemplate
@@ -18,8 +18,8 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
-    "turnInDescription" : "Bring the ^orange;steel warblade^reset; to me at the ^orange;Science Outpost^reset;",
+    "requireTurnIn" : true,
+    "turnInDescription" : "Bring the ^orange;steel warblade^reset; to the scientist at the ^orange;Science Outpost^reset;",
 
     "conditions" : [
       {

--- a/quests/fu_questlines/battle/gear/create_warcleaver.questtemplate
+++ b/quests/fu_questlines/battle/gear/create_warcleaver.questtemplate
@@ -20,8 +20,8 @@
 
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
-        "turnInDescription" : "Bring the ^orange;Ferozium Cleaver^reset; to me.",
+    "requireTurnIn" : true,
+        "turnInDescription" : "Bring the ^orange;Ferozium Cleaver^reset; to the scientist at the ^orange;Science Outpost^reset;.",
 
     "conditions" : [
       {

--- a/quests/fu_questlines/deprecated/create_designlab.questtemplate
+++ b/quests/fu_questlines/deprecated/create_designlab.questtemplate
@@ -18,9 +18,9 @@
     },
     
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
     
-    "turnInDescription" : "Bring the ^green;Greenhouse^reset; to me at the ^orange;Science Outpost^reset;",
+    "turnInDescription" : "Bring the ^green;Greenhouse^reset; to the scientist at the ^orange;Science Outpost^reset;",
 
     "conditions" : [
       {

--- a/quests/fu_questlines/deprecated/create_quietus.questtemplate
+++ b/quests/fu_questlines/deprecated/create_quietus.questtemplate
@@ -18,8 +18,8 @@
     },
     
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
-        "turnInDescription" : "Bring the ^orange;5 Quietus Bars^reset; to me at the ^orange;Science Outpost^reset;",
+    "requireTurnIn" : true,
+        "turnInDescription" : "Bring the ^orange;5 Quietus Bars^reset; to the ^orange;Science Outpost^reset;",
 
     "conditions" : [
       {

--- a/quests/fu_questlines/other/create_densinium.questtemplate
+++ b/quests/fu_questlines/other/create_densinium.questtemplate
@@ -18,8 +18,8 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
-        "turnInDescription" : "Bring the ^orange;Densinium Helm^reset; to me!;",
+    "requireTurnIn" : true,
+        "turnInDescription" : "Deliver the ^orange;Densinium Helm^reset;!",
 
     "conditions" : [
       {

--- a/quests/fu_questlines/other/create_hydrotray.questtemplate
+++ b/quests/fu_questlines/other/create_hydrotray.questtemplate
@@ -18,7 +18,7 @@
     },
     
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,  
+    "requireTurnIn" : true,  
         "turnInDescription" : "Deliver the ^orange;Hydroponics Tray^reset;.",
 
     "conditions" : [

--- a/quests/fu_questlines/other/frozenwastes/shoggoth_unlock.questtemplate
+++ b/quests/fu_questlines/other/frozenwastes/shoggoth_unlock.questtemplate
@@ -18,14 +18,14 @@
     },
 
     "requireTurnIn" : true,
-    "turnInDescription" : "Bring the ^orange;Molten Core^reset; to me at the ^orange;Science Outpost^reset;",
+    "turnInDescription" : "Bring the ^orange;Molten Core^reset; to the ^orange;Science Outpost^reset;",
 
     "conditions" : [
       {
         "type" : "gatherItem",
         "itemName" : "moltencore",
         "count" : 1,
-        "consume" : false
+        "consume" : true
       }
     ],
 

--- a/quests/fu_questlines/other/frozenwastes/shoggoth_wagner.questtemplate
+++ b/quests/fu_questlines/other/frozenwastes/shoggoth_wagner.questtemplate
@@ -19,7 +19,7 @@
     },
 
     "requireTurnIn" : true,
-    "turnInDescription" : "Return ^orange;Wagner's ID^reset; to me at the ^orange;Science Outpost^reset;",
+    "turnInDescription" : "Return ^orange;Wagner's ID^reset; to the ^orange;Science Outpost^reset;",
     "conditions" : [
       {
         "type" : "gatherItem",

--- a/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator.questtemplate
+++ b/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "turnInDescription" : "Bring the ^orange;Booster Croptop^reset; to ^red;Kevin^reset; at the ^orange;Science Outpost^reset;",
 

--- a/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator2.questtemplate
+++ b/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator2.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "turnInDescription" : "Bring the Glorious ^red;Kevin^reset; 5 ^orange;Biofuel Canisters^reset;",
 

--- a/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3.questtemplate
+++ b/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "turnInDescription" : "Bring ^red;Kevin, your overlord^reset; 5 ^orange;Alien Compound^reset;",
 

--- a/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3b.questtemplate
+++ b/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3b.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "turnInDescription" : "Bring ^red;Kevin, your overlord^reset; 200 ^orange;Baby Heads on Sticks^reset;",
 

--- a/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3c.questtemplate
+++ b/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3c.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "turnInDescription" : "Bring ^red;Kevin^reset; 1 ^orange;orange fruit^reset;.",
 

--- a/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3d.questtemplate
+++ b/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3d.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "turnInDescription" : "Bring ^red;Kevin^reset; 20 ^orange;Plasmic Crystals^reset;.",
 

--- a/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3e.questtemplate
+++ b/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator3e.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "turnInDescription" : "Bring ^red;Kevin^reset; 50 ^orange;Brains^reset; of average quality.",
 

--- a/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator4.questtemplate
+++ b/quests/fu_questlines/outpost/kevin_tasks/create_clothingfabricator4.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "turnInDescription" : "Bring ^red;Kevin^reset; 1 ^orange;Neutronium and Anti-Neutronium^reset;",
 

--- a/quests/fu_questlines/science/chemistry/create_fertilizer.questtemplate
+++ b/quests/fu_questlines/science/chemistry/create_fertilizer.questtemplate
@@ -18,9 +18,9 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
-    "turnInDescription" : "Bring the ^orange;Fertilizer^reset; to me at the ^orange;Science Outpost^reset;",
+    "turnInDescription" : "Bring the ^orange;Fertilizer^reset; to <questGiver> at the ^orange;Science Outpost^reset;",
 
 
     "conditions" : [

--- a/quests/fu_questlines/science/chemistry/create_methanol.questtemplate
+++ b/quests/fu_questlines/science/chemistry/create_methanol.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
 
     "conditions" : [
       {

--- a/quests/fu_questlines/science/chemistry/create_methyliodide.questtemplate
+++ b/quests/fu_questlines/science/chemistry/create_methyliodide.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,
+    "requireTurnIn" : true,
     "turnInDescription" : "Bring the ^orange;Methyl Iodide^reset; to the ^green;purple-armored scientist^reset; at the top floor of the ^orange;Science Outpost^reset;.",
 
     "conditions" : [

--- a/quests/fu_questlines/science/electronics/create_aichip.questtemplate
+++ b/quests/fu_questlines/science/electronics/create_aichip.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,  
+    "requireTurnIn" : true,  
 
     "turnInDescription" : "Bring the ^orange;AI Chip^reset; to the scientist at the ^orange;Science Outpost^reset;",
 

--- a/quests/fu_questlines/science/electronics/create_powdersifter.questtemplate
+++ b/quests/fu_questlines/science/electronics/create_powdersifter.questtemplate
@@ -19,7 +19,7 @@
     
     "canBeAbandoned" : true,
     "requireTurnIn" : false,  
-        "turnInDescription" : "Bring the ^orange;Powder Sifter^reset; to me at the ^orange;Science Outpost^reset;",
+        "turnInDescription" : "Bring the ^orange;Powder Sifter^reset; to the scientist at the ^orange;Science Outpost^reset;",
 
     "conditions" : [
       {

--- a/quests/fu_questlines/science/genetics/create_ignuschili.questtemplate
+++ b/quests/fu_questlines/science/genetics/create_ignuschili.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,  
+    "requireTurnIn" : true,  
 
     "turnInDescription" : "Bring the ^orange;Ignus Chili Seeds^reset; to the scientist at the ^orange;Science Outpost^reset;",
 

--- a/quests/fu_questlines/science/genetics/create_mutavisk.questtemplate
+++ b/quests/fu_questlines/science/genetics/create_mutavisk.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,  
+    "requireTurnIn" : true,  
         "turnInDescription" : "Bring the ^orange;Mutavisk Helm^reset; to the scientist at the ^orange;Science Outpost^reset;",
 
     "conditions" : [

--- a/quests/fu_questlines/science/genetics/create_radleaf.questtemplate
+++ b/quests/fu_questlines/science/genetics/create_radleaf.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,  
+    "requireTurnIn" : true,  
         "turnInDescription" : "Bring the 3 ^orange;Rad Leaf^reset; to the scientist at the ^orange;Science Outpost^reset;",
 
     "conditions" : [

--- a/quests/fu_questlines/science/genetics/create_regengene.questtemplate
+++ b/quests/fu_questlines/science/genetics/create_regengene.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,  
+    "requireTurnIn" : true,  
 
     "turnInDescription" : "Bring a ^orange;Regenerative^reset; gene to the scientist at the ^orange;Science Outpost^reset;",
 

--- a/quests/fu_questlines/science/physics/create_protocite.questtemplate
+++ b/quests/fu_questlines/science/physics/create_protocite.questtemplate
@@ -18,7 +18,7 @@
     },
     
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,  
+    "requireTurnIn" : true,  
     "turnInDescription" : "Bring the ^orange;Protocite Bars^reset; to the scientist at the ^orange;Science Outpost^reset;",
 
     

--- a/quests/fu_questlines/tutorial/extractor/extractor6.questtemplate
+++ b/quests/fu_questlines/tutorial/extractor/extractor6.questtemplate
@@ -18,7 +18,7 @@
     },
 
     "canBeAbandoned" : true,
-    "requireTurnIn" : false,  
+    "requireTurnIn" : true,  
     "turnInDescription" : "Bring the ^green;Hydrogen^reset; to me at the ^orange;Science Outpost^reset;",
 
 


### PR DESCRIPTION
Changed most of the FU quests that consume items to require the player to turn them in to the quest-giving NPC, to prevent a vanilla bug that resulted in the quest consuming the item without progressing if you had it when picking up the quest.