### PR TITLE
Medics aren't useless anymore.

### DIFF
--- a/items/active/crewcontracts/crewcontract_medic2.activeitem
+++ b/items/active/crewcontracts/crewcontract_medic2.activeitem
@@ -1,0 +1,23 @@
+{
+  "itemName" : "crewcontract_medic2",
+  "price" : 0,
+  "level" : 1,
+  "maxStack" : 1,
+  "rarity" : "rare",
+  "category" : "mysteriousReward",
+  "description" : "Hires a combat medic to help keep you alive and kicking. Heals more quickly, but less on-ship regen.",
+  "shortdescription" : "Medic Contract II",
+  "twoHanded" : true,
+
+  "inventoryIcon" : "crewcontract.png",
+  "animation" : "crewcontract.animation",
+  "animationCustom" : {},
+  "scripts" : ["crewcontract.lua"],
+
+  "fireTime" : 2.0,
+  "fireOffset" : [1.0, 0.0],
+
+  "crewtype" : {
+    "crewname" : "crewmembermedic2"
+  }
+}

--- a/npcs/crew/crewmembermedic.npctype.patch
+++ b/npcs/crew/crewmembermedic.npctype.patch
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/scriptConfig/crew/role/benefits/0/value",
+    "value": "1"
+  }
+]

--- a/npcs/crew/crewmembermedic2.npctype
+++ b/npcs/crew/crewmembermedic2.npctype
@@ -1,0 +1,118 @@
+{
+  "type" : "crewmembermedic2",
+  "baseType" : "crewmember",
+
+  "scriptConfig" : {
+    "behaviorConfig" : {
+      "emptyHands" : true
+    },
+
+    "crew" : {
+      "defaultUniform" : {
+        "head" : "medichead",
+        "chest" : "medicchest",
+        "legs" : "mediclegs"
+      },	
+      "role" : {
+        "type" : "medic",
+        "name" : "Field Medic",
+        "field" : "Medical Combat",
+        "uniformColorIndex" : 2,
+
+// what I'd like to do is be able to reduce the on-ship regen to 1, but in field regen to 12-15, to seperate it from the surgeon (who is more for on-ship regen.)
+        "benefits" : [
+          {
+            "type" : "Regeneration",
+            "value" : 2
+          }
+        ]
+      }
+    },
+
+    "dialog" : {
+      "crewmember" : {
+        "roleDescription" : {
+          "default" : {
+            "default" : [
+              "I'll heal you whenever we're on the ship."
+            ]
+          },
+          "floran" : {
+            "default" : [
+              "Floran will heal you whenever we're on the ship!"
+            ]
+          },
+          "glitch" : {
+            "default" : [
+              "Helpful. I'll heal you whenever we're on the ship!"
+            ]
+          }
+        },
+        "fieldBenefit" : {
+          "default" : {
+            "default" : [
+              "You look hurt. Let me help you out!",
+              "Let me help you out!",
+              "You look like you wouldn't mind some healing. Here!",
+              "Hey, I can heal you! Just hold still!"
+            ]
+          },
+          "floran" : {
+            "default" : [
+              "You look wounded. Floran can help!",
+              "Floran is medic! Trust Floran!",
+              "You look hurt. Floran can help you!"
+            ]
+          },
+          "glitch" : {
+            "default" : [
+              "Concerned. You look like you could do with some healing!",
+              "Caring. Perhaps you could do with some healing?",
+              "Helpful. You look like you could be in better shape. Let me assist you!"
+            ]
+          }
+        },
+        "combatBenefit" : {
+          "default" : {
+            "default" : [
+              "You look like you could use some healing!",
+              "Let me help you out!",
+              "I'm a combat medic - let me help you!",
+              "Looks like you could use my assistance!",
+              "I can heal you! Come to me, quickly!"
+            ]
+          },
+          "floran" : {
+            "default" : [
+              "Floran hasss things to help out!",
+              "Floran can help out!",
+              "Floran hasss things to help!"
+            ]
+          },
+          "glitch" : {
+            "default" : [
+              "Eager. I can help you out!",
+              "Excited. Perhaps you could do with some healing?",
+              "Helpful. This should heal you!",
+              "Helpful. Take this, it will help!"
+            ]
+          }
+        }
+      }
+    }
+  },
+
+  "items" : {
+    "default" : [
+      [0, [
+          {
+		    "head" : [ { "name" : "medichead", "count" :1, "parameters" : { "colorIndex" : 2 } } ],
+            "chest" : [ { "name" : "medicchest", "count" :1, "parameters" : { "colorIndex" : 2 } } ],
+            "legs" : [ { "name" : "medicpants", "count" :1, "parameters" : { "colorIndex" : 2 } } ],
+            "alt" : [ "medkit" ],
+            "primary" : [ "npcmachinepistol", "npcmachinepistol", "npcmachinepistol", "npcmachinepistol", "zerchesiumsmg", "lunarismg", "telebriummachinepistol" ]
+          }
+        ] ]
+    ]
+  }
+}

--- a/player.config.patch
+++ b/player.config.patch
@@ -1138,3 +1138,71 @@
     { "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "slimenpchangstorage"} },
     { "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "slimegem"} }    
 ]
+
+// Crew Medic changes
+ {
+    "op": "replace",
+    "path": "/companionsConfig/crewBenefits/shipRegeneration/0",
+    "value": "fucrewmedicshipregeneration2"
+  },
+  {
+    "op": "replace",
+    "path": "/companionsConfig/crewBenefits/shipRegeneration/1",
+    "value": "fucrewmedicshipregeneration1"
+  },
+  {
+    "op": "remove",
+    "path": "/companionsConfig/crewBenefits/shipRegeneration/2"
+  },
+  {
+    "op": "remove",
+    "path": "/companionsConfig/crewBenefits/shipRegeneration/2"
+  },
+  {
+    "op": "remove",
+    "path": "/companionsConfig/crewBenefits/shipRegeneration/2"
+  },
+  {
+    "op": "replace",
+    "path": "/companionsConfig/crewBenefits/combatRegeneration/0",
+    "value": "fucrewmedicregeneration1"
+  },
+  {
+    "op": "replace",
+    "path": "/companionsConfig/crewBenefits/combatRegeneration/1",
+    "value": "fucrewmedicregeneration2"
+  },
+  {
+    "op": "remove",
+    "path": "/companionsConfig/crewBenefits/combatRegeneration/2"
+  },
+  {
+    "op": "remove",
+    "path": "/companionsConfig/crewBenefits/combatRegeneration/2"
+  },
+  {
+    "op": "remove",
+    "path": "/companionsConfig/crewBenefits/combatRegeneration/2"
+  },
+  {
+    "op": "replace",
+    "path": "/companionsConfig/crewBenefits/fieldRegeneration/0",
+    "value": "fucrewmedicregeneration1"
+  },
+  {
+    "op": "replace",
+    "path": "/companionsConfig/crewBenefits/fieldRegeneration/1",
+    "value": "fucrewmedicregeneration2"
+  },
+  {
+    "op": "remove",
+    "path": "/companionsConfig/crewBenefits/fieldRegeneration/2"
+  },
+  {
+    "op": "remove",
+    "path": "/companionsConfig/crewBenefits/fieldRegeneration/2"
+  },
+  {
+    "op": "remove",
+    "path": "/companionsConfig/crewBenefits/fieldRegeneration/2"
+  }

--- a/recipes/crewcontracts/crewcontract_medic2.recipe
+++ b/recipes/crewcontracts/crewcontract_medic2.recipe
@@ -1,0 +1,12 @@
+{
+  "input" : [
+    { "item" : "money", "count" : 30000 }
+  ],
+  "output" : { 
+    "item" : "crewcontract_medic2", 
+    "count" : 1 
+  },
+  
+  "groups" : [ "crewcontract","bars", "all" ],
+  "duration" : 0.2
+}

--- a/stats/effects/regeneration/fucrewmedicregeneration1.statuseffect
+++ b/stats/effects/regeneration/fucrewmedicregeneration1.statuseffect
@@ -1,0 +1,18 @@
+{
+  "name" : "fucrewmedicregeneration1",
+  "blockingStat" : "healingStatusImmunity",
+
+  "effectConfig" : {
+    "healTime" : 25
+  },
+  "defaultDuration" : 10,
+
+  "scripts" : [
+    "regeneration.lua"
+  ],
+
+  "animationConfig" : "regeneration.animation",
+
+  "label" : "Medic Healing",
+  "icon" : "/interface/statuses/heal.png"
+}

--- a/stats/effects/regeneration/fucrewmedicregeneration2.statuseffect
+++ b/stats/effects/regeneration/fucrewmedicregeneration2.statuseffect
@@ -1,0 +1,18 @@
+{
+  "name" : "fucrewmedicregeneration2",
+  "blockingStat" : "healingStatusImmunity",
+
+  "effectConfig" : {
+    "healTime" : 3.5
+  },
+  "defaultDuration" : 2,
+
+  "scripts" : [
+    "regeneration.lua"
+  ],
+
+  "animationConfig" : "regeneration.animation",
+
+  "label" : "Medic Field Healing",
+  "icon" : "/interface/statuses/heal.png"
+}

--- a/stats/effects/regeneration/fucrewmedicshipregeneration1.statuseffect
+++ b/stats/effects/regeneration/fucrewmedicshipregeneration1.statuseffect
@@ -1,0 +1,17 @@
+{
+  "name" : "fucrewmedicshipregeneration1",
+  "effectConfig" : {
+    "healTime" : 60,
+    "particles" : false
+  },
+  "defaultDuration" : 5,
+
+  "scripts" : [
+    "regeneration.lua"
+  ],
+
+  "animationConfig" : "regeneration.animation",
+
+  "label" : "Medic Regeneration",
+  "icon" : "/interface/statuses/heal.png"
+}

--- a/stats/effects/regeneration/fucrewmedicshipregeneration2.statuseffect
+++ b/stats/effects/regeneration/fucrewmedicshipregeneration2.statuseffect
@@ -1,0 +1,17 @@
+{
+  "name" : "fucrewmedicshipregeneration2",
+  "effectConfig" : {
+    "healTime" : 200,
+    "particles" : false
+  },
+  "defaultDuration" : 5,
+
+  "scripts" : [
+    "regeneration.lua"
+  ],
+
+  "animationConfig" : "regeneration.animation",
+
+  "label" : "Minor Ship Regeneration",
+  "icon" : "/interface/statuses/heal.png"
+}


### PR DESCRIPTION
- New Crewmember type: Combat Medic (upgrade over regular medic.) It comes with a medic armor, and weilds a submg instead of a shortsword or pistol. However, it does not heal nearly as much when on ship.
- New Crew Contract for Combat Medic (although ATM, nothing unlocks it. I'm not sure what you wanted to unlock it.)
- Vanilla Medic heals more over 10 seconds instead of 5 (like a medkit minus the status fixes).
- Combat Medic heals quickly over 2 seconds.
- Custom statuseffects for medics (so they dont' mess up the vanilla ones.)

I've balanced this to what I think is good, but since balancing can be largely opinion-based, tweaking might be required on your end.

Note: Heal threshold and cooldown duration remain unchanged. It's still 10-20% health and 120 seconds respectively.