### PR TITLE
Update beammasterhelm.head

### DIFF
--- a/items/armors/uniques/beammasterhelm/beammasterhelm.head
+++ b/items/armors/uniques/beammasterhelm/beammasterhelm.head
@@ -19,7 +19,7 @@
     {
       "levelFunction" : "standardArmorLevelProtectionMultiplier",
       "stat" : "powerMultiplier",
-      "amount" : 1.12
+      "baseMultiplier" : 1.12
     },  
     {
       "levelFunction" : "standardArmorLevelProtectionMultiplier",


### PR DESCRIPTION
Hi satyer,

The current version makes the mask add massive amount of damage. I think "amount" in damage field should be replaced by "baseMultiplier", like other leveled armor gears (for example, items/armors/tier6/assassini/mantizitier6accelerator.head).

Also the first "standardArmorLevelProtectionMultiplier" should be change back to "standardArmorLevelPowerMultiplierMultiplier".

Moreover, current file after fixing make the helm stat to be +96% damage, +48 protection, +80 energy and +40 health at level 8. I think the damage might need to be raised a little bit, like "baseMultiplier" : 1.2 (+ 160% damage at level 8); and other stats might need to be slightly reduced. Just a suggestion, I didn't touch any numbers in the file.