### PR TITLE
Update beammasterhelm.head

### DIFF
--- a/items/armors/uniques/beammasterhelm/beammasterhelm.head
+++ b/items/armors/uniques/beammasterhelm/beammasterhelm.head
@@ -17,9 +17,9 @@
 
   "leveledStatusEffects" : [
     {
-      "levelFunction" : "standardArmorLevelProtectionMultiplier",
+      "levelFunction" : "standardArmorLevelPowerMultiplierMultiplier",
       "stat" : "powerMultiplier",
-      "amount" : 1.12
+      "baseMultiplier" : 1.12
     },  
     {
       "levelFunction" : "standardArmorLevelProtectionMultiplier",


### PR DESCRIPTION
Hi satyer,

The current version makes the mask add massive amount of damage (it seems apply as an effective multiplier after other damage buff source). 
I think the first "standardArmorLevelProtectionMultiplier" should be change back to "standardArmorLevelPowerMultiplierMultiplier", and "amount" in damage part should be replaced by "baseMultiplier", just similar to other leveled armor gears already proved to be work fine (for example, items/armors/tier6/assassini/mantizitier6accelerator.head).


Moreover, current file after fixing make the beammasterhelm stats to be +96% damage, +48 protection, +80 energy and +40 health at level 8. I think the damage might need to be buffed a little bit, like "baseMultiplier" : 1.2 (+ 160% damage at level 8, as (1.2-1)*8=160% ); and other stats might need to be slightly reduced. Just a suggestion, I didn't touch any numbers in the files.