### PR TITLE
deathbomb fix

### DIFF
--- a/stats/effects/deathbomb/deathbomb.lua
+++ b/stats/effects/deathbomb/deathbomb.lua
@@ -1,5 +1,5 @@
 function init()
-	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or (world.entityType(entity.id())~= "monster") or (world.callScriptedEntity(entity.id(),"getClass") == 'bee') then
+	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or ((world.entityType(entity.id())== "monster") and (world.callScriptedEntity(entity.id(),"getClass") == 'bee')) then
 		effect.expire()
 	end
 

--- a/stats/effects/deathbomb/deathbombcomplextreasurepool.lua
+++ b/stats/effects/deathbomb/deathbombcomplextreasurepool.lua
@@ -2,7 +2,7 @@ require "/scripts/util.lua"
 
 function init()
 	canExplode=false
-	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or (world.entityType(entity.id())~= "monster") or (world.callScriptedEntity(entity.id(),"getClass") == 'bee') then
+	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or ((world.entityType(entity.id())== "monster") and (world.callScriptedEntity(entity.id(),"getClass") == 'bee')) then
 		return
 	end
 	poolData=config.getParameter("poolData")

--- a/stats/effects/deathbomb/deathbombitem.lua
+++ b/stats/effects/deathbomb/deathbombitem.lua
@@ -1,5 +1,5 @@
 function init()
-	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or (world.entityType(entity.id())~= "monster") or (world.callScriptedEntity(entity.id(),"getClass") == 'bee') then
+	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or ((world.entityType(entity.id())== "monster") and (world.callScriptedEntity(entity.id(),"getClass") == 'bee')) then
 		effect.expire()
 	end
 	self.blinkTimer = 0

--- a/stats/effects/deathbomb/deathbombmagma.lua
+++ b/stats/effects/deathbomb/deathbombmagma.lua
@@ -1,5 +1,5 @@
 function init()
-	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or (world.entityType(entity.id())~= "monster") or (world.callScriptedEntity(entity.id(),"getClass") == 'bee') then
+	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or ((world.entityType(entity.id())== "monster") and (world.callScriptedEntity(entity.id(),"getClass") == 'bee')) then
 		effect.expire()
 	end
 

--- a/stats/effects/deathbomb/deathbombmonsterhydra.lua
+++ b/stats/effects/deathbomb/deathbombmonsterhydra.lua
@@ -1,5 +1,5 @@
 function init()
-	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or (world.entityType(entity.id())~= "monster") or (world.callScriptedEntity(entity.id(),"getClass") == 'bee') then
+	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or ((world.entityType(entity.id())== "monster") and (world.callScriptedEntity(entity.id(),"getClass") == 'bee')) then
 		effect.expire()
 	end
 

--- a/stats/effects/deathbomb/deathbombmonsterspawnsimple.lua
+++ b/stats/effects/deathbomb/deathbombmonsterspawnsimple.lua
@@ -1,5 +1,5 @@
 function init()
-	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or (world.entityType(entity.id())~= "monster") or (world.callScriptedEntity(entity.id(),"getClass") == 'bee') then
+	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or ((world.entityType(entity.id())== "monster") and (world.callScriptedEntity(entity.id(),"getClass") == 'bee')) then
 		effect.expire()
 	end
 	

--- a/stats/effects/deathbomb/deathbombnpcsteal.lua
+++ b/stats/effects/deathbomb/deathbombnpcsteal.lua
@@ -1,7 +1,7 @@
 require "/scripts/util.lua"
 
 function init()
-	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or (world.entityType(entity.id())~= "monster") or (world.callScriptedEntity(entity.id(),"getClass") == 'bee') then
+	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or (world.entityType(entity.id())~= "npc") then
 		effect.expire()
 	end
 

--- a/stats/effects/deathbomb/deathbombsimpleprojectile.lua
+++ b/stats/effects/deathbomb/deathbombsimpleprojectile.lua
@@ -1,5 +1,5 @@
 function init()
-	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or (world.entityType(entity.id())~= "monster") or (world.callScriptedEntity(entity.id(),"getClass") == 'bee') then
+	if (status.resourceMax("health") < config.getParameter("minMaxHealth", 0)) or (not world.entityExists(entity.id())) or ((world.entityType(entity.id())== "monster") and (world.callScriptedEntity(entity.id(),"getClass") == 'bee')) then
 		effect.expire()
 	end
 	


### PR DESCRIPTION
I need to stop doing pull requests when I havent slept yet. 
Fixed: conditions on deathbomb scripts incorrect, resulting in them not working on non-monsters, where they were only supposed to not work on bees...except monster hydra and npcsteal, those were supposed to only work on monsters and npcs respectively. Oops.