### PR TITLE
Differentiating rarity color on atmosfilter/regulator items, correcti…

### DIFF
--- a/objects/power/fu_atmosfilter/fu_atmosfilter.object
+++ b/objects/power/fu_atmosfilter/fu_atmosfilter.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "fu_atmosfilter",
-  "rarity" : "legendary",
+  "rarity" : "rare",
   "colonyTags" : [ "science" ],
   "description" : "Filters most environment effects. Can broadcast augment effects to radius. Requires 60W of power.",
   "shortdescription" : "^cyan;Atmospheric Filter^white;",

--- a/objects/power/isn_atmosregulator/isn_atmosregulatorwarped.object
+++ b/objects/power/isn_atmosregulator/isn_atmosregulatorwarped.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "isn_atmosregulatorwarped",
-  "rarity" : "legendary",
-    "colonyTags" : [ "science" ],
+  "rarity" : "essential",
+  "colonyTags" : [ "science" ],
   "description" : "Generates a mysterious field at significantly higher range. Requires 240W of power.",
   "shortdescription" : "^cyan;Warped Regulator^reset;",
   "race" : "generic",
@@ -10,7 +10,6 @@
   "printable" : false,
   "health" : 30,
   "rooting" : true,
-
   "inventoryIcon" : "isn_atmosregulator_inv.png",
   "orientations" : [
     {
@@ -69,5 +68,5 @@
 
   "inputNodes" : [ [1, 2] ],
   "powertype" : "input",
-  "isn_requiredPower" : 120
+  "isn_requiredPower" : 240
 }


### PR DESCRIPTION
…ng warped regulator required power.

Sets atmospheric filter rarity to rare, warped regulator to essential, allowing all three filter items to be distinguished by their inventory icons.

This rarity progression makes sense as these are a chain of three crafted items, in which the previous is an ingredient in the next.

This changelist also corrects the required power input of the Warped Regulator to 240, matching the description.