### PR TITLE
Correcting Randolph Carter Hat's power multiplier

### DIFF
--- a/items/armors/uniques/randolphcarterhat/randolphcarterhat.head
+++ b/items/armors/uniques/randolphcarterhat/randolphcarterhat.head
@@ -9,7 +9,7 @@
 ^green;20%^reset; Mental Resistance",
   "shortdescription" : "Randolph Carter Hat",
   "tooltipKind" : "armor",
-
+  "itemTags" : [ "upgradeableWeapon" ],
   "maleFrames" : "head.png",
   "femaleFrames" : "head.png",
   "mask" : "mask.png",
@@ -18,7 +18,7 @@
     {
       "levelFunction" : "standardArmorLevelProtectionMultiplier",
       "stat" : "powerMultiplier",
-      "amount" : 1.05
+      "baseMultiplier" : 1.05
     },  
     {
       "levelFunction" : "standardArmorLevelProtectionMultiplier",


### PR DESCRIPTION
Randolph Carter's Hat had it's power set to amount in a changelist a few days ago with other unique hats, but was missed in the followup PR fixing them back to baseMultiplier.
Also adding the upgradableWeapon tag.