### PR TITLE
Questgen kill target - Precursor

### DIFF
--- a/quests/generated/pools/npcthreats.config.patch
+++ b/quests/generated/pools/npcthreats.config.patch
@@ -113,6 +113,18 @@
 		  [
 			[ "generic" ],
 			{
+			  "name" : "^cyan;mysterious and deadly^reset; aliens",
+			  "species" : "precursor",
+			  "typeName" : "precursormob"
+			}
+		  ]
+	},
+	{"op" : "add",
+		"path" : "/0/1/-",
+		"value" : 
+		  [
+			[ "generic" ],
+			{
 			  "name" : "super-fun cannibals",
 			  "species" : "human",
 			  "typeName" : "fucannibal"

--- a/quests/generated/pools/singlenpcthreats.config.patch
+++ b/quests/generated/pools/singlenpcthreats.config.patch
@@ -148,6 +148,19 @@
 		  [
 			[ "generic" ],
 			{
+			  "name" : "^cyan;mysterious and deadly^reset; alien",
+			  "species" : "precursor",
+			  "typeName" : "precursormob",
+			  "seed" : "stable"
+			}
+		  ]
+	},	
+	{"op" : "add",
+		"path" : "/0/1/-",
+		"value" : 
+		  [
+			[ "generic" ],
+			{
 			  "name" : "^cyan;elite^reset; Bounty Hunter",
 			  "species" : "human",
 			  "typeName" : "elitebountyhunter",


### PR DESCRIPTION
This adds a quest generation kill target of Precursors, described as 'mysterious and deadly aliens'.