### PR TITLE
fix for sggunstaff breaking after upgrading

### DIFF
--- a/interface/scripted/weaponupgrade2/weaponupgrade2gui.lua
+++ b/interface/scripted/weaponupgrade2/weaponupgrade2gui.lua
@@ -260,7 +260,7 @@ function doUpgrade()
 					end   
 		  
 					if (itemConfig.config.primaryAbility) then	 
-						if not (itemConfig.config.category == "Gun Staff") or (itemConfig.config.category == "sggunstaff") then --exclude Shellguard gunblades from this bit to not break their rotation
+						if not (itemConfig.config.category == "Gun Staff") or not (itemConfig.config.category == "sggunstaff") then --exclude Shellguard gunblades from this bit to not break their rotation
 							-- beams and miners
 							if (itemConfig.config.primaryAbility.beamLength) then
 								upgradedItem.parameters.primaryAbility.beamLength= itemConfig.config.primaryAbility.beamLength + upgradedItem.parameters.level 


### PR DESCRIPTION
I think a "not" might be missed on line 263.
In line 195 it is:
_______________
if not (itemConfig.config.category == "Gun Staff") or not (itemConfig.config.category == "sggunstaff") then
_______________
Or should both be "and not"? I am not famillar with .lua. 
In C++ it seems should be something like ( !Gunstaff && !sggunstaff ) instead of ( !Gunstaff || !sggunstaff ).