### PR TITLE
a fix to armor resistance

### DIFF
--- a/items/armors/uniques/murdermask/murdermask.head
+++ b/items/armors/uniques/murdermask/murdermask.head
@@ -43,11 +43,11 @@
     },    
     {
       "stat" : "physicalResistance",
-      "baseMultiplier" : 1.2
+      "amount" : 0.2
     },    
     {
       "stat" : "electricResistance",
-      "baseMultiplier" : 0.8
+      "amount" : -0.2
     }
   ]
 }


### PR DESCRIPTION
Currently the Friendship Mask doesn't affect physical or electric resistance at all.
I think it is save to copy the codes of race bonus in FR, or of some exsisting armors that provides resistance correctly (Geist armor etc.), which looks like

"stat" : "physicalResistance"
"amount": 0.2 

instead of 

"stat" : "physicalResistance"
"baseMultiplier": 1.2