### PR TITLE
fix for shellguard gun staff upgrade

### DIFF
--- a/interface/scripted/weaponupgrade2/weaponupgrade2gui.lua
+++ b/interface/scripted/weaponupgrade2/weaponupgrade2gui.lua
@@ -192,7 +192,7 @@ function doUpgrade()
 							
 						-- hoe, chainsaw, etc
 						if upgradedItem.parameters.fireTime then
-							if not (itemConfig.config.category == "Gun Staff") or not (itemConfig.config.category == "sggunstaff") then --exclude Shellguard gunblades from this bit to not break their rotation
+							if not (itemConfig.config.category == "Gun Staff") and not (itemConfig.config.category == "sggunstaff") then --exclude Shellguard gunblades from this bit to not break their rotation
 							  upgradedItem.parameters.fireTime = (itemConfig.parameters.fireTime or itemConfig.config.fireTime or 1) * 1.15 
 							end
 						end
@@ -251,7 +251,7 @@ function doUpgrade()
 					end   
 		  
 					if (itemConfig.config.primaryAbility) then	 
-						if not (itemConfig.config.category == "Gun Staff") or not (itemConfig.config.category == "sggunstaff") then --exclude Shellguard gunblades from this bit to not break their rotation
+						if not (itemConfig.config.category == "Gun Staff") and not (itemConfig.config.category == "sggunstaff") then --exclude Shellguard gunblades from this bit to not break their rotation
 							-- bows
 							if (itemConfig.config.category == "bow") then
 							upgradedItem.parameters.primaryAbility = {} 


### PR DESCRIPTION
Hi satyer,

I think it should be "and" instead of "or" here. 
I tested the modified code in single player, and it turns out that gun staffs no longer get fireTime and baseDPS written into their primaryAbility. 
I also tested several weapons in FU to make sure other categories still properly update fireTime and baseDPS as before.