### PR TITLE
Update shadowcrab.monstertype

### DIFF
--- a/monsters/walkers/crabcanoish/shadowcrab/shadowcrab.monstertype
+++ b/monsters/walkers/crabcanoish/shadowcrab/shadowcrab.monstertype
@@ -10,7 +10,7 @@
 
   "dropPools" : [
     {
-    "default" : "ffbasicTreasure",
+    "default" : "icecrabcanoTreasure",
     "bow" : "huntingchitincold",
     "firebow" : "huntingchitincold",
     "icebow" : "huntingchitincold",


### PR DESCRIPTION
shadowcrab had the same treasure pool as chests/crates, allowing for construction of factory farms to loot fuspecial drops.