### PR TITLE
poof

### DIFF
--- a/items/active/weapons/bow/abilities/rngbows/enhancedbowshot.lua
+++ b/items/active/weapons/bow/abilities/rngbows/enhancedbowshot.lua
@@ -1,5 +1,6 @@
 --Modified bow shot ability that drains energy while drawing and holding, with configurable drain rates. Has an animation state for when arrows have been loosed
 require "/scripts/vec2.lua"
+require "/items/active/weapons/crits.lua"
 
 -- Bow primary ability
 NebBowShot = WeaponAbility:new()

--- a/items/active/weapons/bow/abilities/rngbows/enhancedbowshotelder.lua
+++ b/items/active/weapons/bow/abilities/rngbows/enhancedbowshotelder.lua
@@ -1,5 +1,6 @@
 --Modified bow shot ability that drains energy while drawing and holding, with configurable drain rates. Has an animation state for when arrows have been loosed
 require "/scripts/vec2.lua"
+require "/items/active/weapons/crits.lua"
 
 -- Bow primary ability
 NebBowShotElder = WeaponAbility:new()

--- a/items/active/weapons/bow/abilities/rngbows/rngbowshot.lua
+++ b/items/active/weapons/bow/abilities/rngbows/rngbowshot.lua
@@ -1,5 +1,6 @@
 --Modified bow shot ability that drains energy while drawing and holding, with configurable drain rates. Has an animation state for when arrows have been loosed
 require "/scripts/vec2.lua"
+require "/items/active/weapons/crits.lua"
 
 -- Bow primary ability
 NebRNGBowShot = WeaponAbility:new()

--- a/items/augments/back/damageaugment1.augment.patch
+++ b/items/augments/back/damageaugment1.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants ^green;5^reset;% More Damage"
+ }
+]

--- a/items/augments/back/damageaugment2.augment.patch
+++ b/items/augments/back/damageaugment2.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants ^green;10^reset;% More Damage"
+ }
+]

--- a/items/augments/back/damageaugment3.augment.patch
+++ b/items/augments/back/damageaugment3.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants ^green;15^reset;% More Damage"
+ }
+]

--- a/items/augments/back/electricblockaugment.augment.patch
+++ b/items/augments/back/electricblockaugment.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;25^reset; Electric Resistance and Shock Immunity"
+ }
+]

--- a/items/augments/back/energyaugment1.augment.patch
+++ b/items/augments/back/energyaugment1.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;20^reset; Energy"
+ }
+]

--- a/items/augments/back/energyaugment2.augment.patch
+++ b/items/augments/back/energyaugment2.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;40^reset; Energy"
+ }
+]

--- a/items/augments/back/energyaugment3.augment.patch
+++ b/items/augments/back/energyaugment3.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;60^reset; Energy"
+ }
+]

--- a/items/augments/back/environment/totalImmunity2.augment
+++ b/items/augments/back/environment/totalImmunity2.augment
@@ -4,7 +4,7 @@
   "rarity" : "rare",
   "category" : "eppAugment",
   "inventoryIcon" : "totalaugment1.png",
-  "description" : "Protects against proto, heat, cold and radiation of all sorts. ^cyan;Immune: Gas, Heat, Cold, Rads, Proto, Poison^reset;",
+  "description" : "^cyan;Immune^reset;: Deadly Heat/Cold/Rads, Liq. Nitrogen, Gas, (Proto) Poison",
   "shortdescription" : "Immunity Field",
   "tooltipKind" : "eppaugment",
   "augment" : {
@@ -12,7 +12,7 @@
     "name" : "futotalimmunity2",
     "displayName" : "Immunity Field",
     "displayIcon" : "/items/augments/back/environment/totalaugment1.png",
-    "effects" : [ "liquidnitrogenimmunity", "coldimmunity", "heatimmunity", "radiationimmunity","protoimmunity", "ffextremecoldimmunity", "ffextremeheatimmunity", "ffextremeradiationimmunity", "gasimmunity", "poisonStatusImmunity" ]
+    "effects" : [ "liquidnitrogenimmunity", "coldimmunity", "heatimmunity", "radiationimmunity","protoimmunity", "ffextremecoldimmunity", "ffextremeheatimmunity", "ffextremeradiationimmunity", "gasimmunityhidden", "poisonStatusImmunityHidden" ]
   },
 
   "radioMessagesOnPickup" : [ "pickupaugment" ],

--- a/items/augments/back/fireblockaugment.augment.patch
+++ b/items/augments/back/fireblockaugment.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;25^reset; Fire Resistance and Burn Immunity"
+ }
+]

--- a/items/augments/back/healingaugment1.augment.patch
+++ b/items/augments/back/healingaugment1.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;0.55^reset;% HP/s Regen"
+ }
+]

--- a/items/augments/back/healingaugment2.augment.patch
+++ b/items/augments/back/healingaugment2.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;0.74^reset;% HP/s Regen"
+ }
+]

--- a/items/augments/back/healingaugment3.augment.patch
+++ b/items/augments/back/healingaugment3.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;1.11^reset;% HP/s Regen"
+ }
+]

--- a/items/augments/back/health/regenaugment1.augment
+++ b/items/augments/back/health/regenaugment1.augment
@@ -4,7 +4,7 @@
   "rarity" : "Uncommon",
   "category" : "eppAugment",
   "inventoryIcon" : "regenaugment1.png",
-  "description" : "An EPP module that slowly regenerates living cells, providing a slow regenerative effect.",
+  "description" : "An EPP module that slowly regenerates living cells, providing ^green;0.55^reset;% HP/s.",
   "shortdescription" : "Regeneration I",
   "tooltipKind" : "eppaugment",
   "augment" : {

--- a/items/augments/back/health/regenaugment2.augment
+++ b/items/augments/back/health/regenaugment2.augment
@@ -4,7 +4,7 @@
   "rarity" : "uncommon",
   "category" : "eppAugment",
   "inventoryIcon" : "regenaugment2.png",
-  "description" : "An EPP module that slowly regenerates living cells, providing a slightly faster regenerative effect.",
+  "description" : "An EPP module that slowly regenerates living cells, providing ^green;0.74^reset;% HP/s.",
   "shortdescription" : "Regeneration II",
   "tooltipKind" : "eppaugment",
   "augment" : {

--- a/items/augments/back/health/regenaugment3.augment
+++ b/items/augments/back/health/regenaugment3.augment
@@ -4,7 +4,7 @@
   "rarity" : "legendary",
   "category" : "eppAugment",
   "inventoryIcon" : "regenaugment3.png",
-  "description" : "An EPP module that slowly regenerates living cells, providing an even faster regenerative effect.",
+  "description" : "An EPP module that slowly regenerates living cells, providing ^green;1.11^reset;% HP/s.",
   "shortdescription" : "Regeneration III",
   "tooltipKind" : "eppaugment",
   "augment" : {

--- a/items/augments/back/healthaugment1.augment.patch
+++ b/items/augments/back/healthaugment1.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;20^reset; HP"
+ }
+]

--- a/items/augments/back/healthaugment2.augment.patch
+++ b/items/augments/back/healthaugment2.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;40^reset; HP"
+ }
+]

--- a/items/augments/back/healthaugment3.augment.patch
+++ b/items/augments/back/healthaugment3.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;60^reset; HP"
+ }
+]

--- a/items/augments/back/iceblockaugment.augment.patch
+++ b/items/augments/back/iceblockaugment.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;25^reset; Ice Resistance and Ice Status Immunity"
+ }
+]

--- a/items/augments/back/jumpaugment.augment.patch
+++ b/items/augments/back/jumpaugment.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;20^reset;% Jump"
+ }
+]

--- a/items/augments/back/mobilityaugment.augment.patch
+++ b/items/augments/back/mobilityaugment.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants ^cyan;Run Boost^reset; and ^cyan;Jump Boost^reset; augment effects."
+ }
+]

--- a/items/augments/back/other/berserker.augment
+++ b/items/augments/back/other/berserker.augment
@@ -4,7 +4,7 @@
   "rarity" : "Uncommon",
   "category" : "eppAugment",
   "inventoryIcon" : "berserkaugment.png",
-  "description" : "Trades 20% health for 20% power",
+  "description" : "Gain ^green;30^reset;% More Damage in exchange for ^red;15^reset;% Less HP",
   "shortdescription" : "Berserker Unit",
 
   "augment" : {

--- a/items/augments/back/peacekeeper1.augment.patch
+++ b/items/augments/back/peacekeeper1.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;2^reset; Protection and a soft light."
+ }
+]

--- a/items/augments/back/peacekeeper2.augment.patch
+++ b/items/augments/back/peacekeeper2.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;4^reset; Protection and a soft light."
+ }
+]

--- a/items/augments/back/peacekeeper3.augment.patch
+++ b/items/augments/back/peacekeeper3.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;6^reset; Protection and a soft light."
+ }
+]

--- a/items/augments/back/poisonblockaugment.augment.patch
+++ b/items/augments/back/poisonblockaugment.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;25^reset; Poison Resistance and Poison Immunity"
+ }
+]

--- a/items/augments/back/speedaugment.augment.patch
+++ b/items/augments/back/speedaugment.augment.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/description",
+  "value": "An EPP module that grants +^green;20^reset; Speed"
+ }
+]

--- a/items/augments/extraenergisingaugment.augment
+++ b/items/augments/extraenergisingaugment.augment
@@ -5,8 +5,8 @@
   "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "extraenergisingaugment.png",
-  "description" : "+^#c459c9;25%^reset; Max Energy
-+^cyan;15%^reset; Recharge Time
+  "description" : "^green;25^reset;% More Energy
+^green;15^reset; Less Energy Block Time
 ^yellow;Large energy regen boost^reset;",
   "shortdescription" : "Energising Augment",
 

--- a/items/augments/extraresistanceaugment.augment
+++ b/items/augments/extraresistanceaugment.augment
@@ -5,7 +5,7 @@
   "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "extraresistanceaugment.png",
-  "description" : "An EPP module that prevents knockback, extends invulnerability time and resists physical damage.",
+  "description" : "An EPP module that grants immunity to knockback and stun, sets nvulnerability time to 3s and grants +^green;20^reset;% Phys. Resist.",
   "shortdescription" : "Resistance Augment",
 
   "augment" : {

--- a/items/augments/extraspringaugment.augment
+++ b/items/augments/extraspringaugment.augment
@@ -5,7 +5,7 @@
   "tooltipKind" : "eppaugment",
   "category" : "eppAugment",
   "inventoryIcon" : "extraspringaugment.png",
-  "description" : "An EPP module that increases your jump height and negates fall damage.",
+  "description" : "An EPP module that grants +^green;20^reset;% Jump and negates fall damage.",
   "shortdescription" : "Spring Augment",
 
   "augment" : {

--- a/items/augments/quest/apexartifact.augment
+++ b/items/augments/quest/apexartifact.augment
@@ -5,7 +5,7 @@
   "category" : "eppAugment",
   "inventoryIcon" : "apexartifacticon.png",
   "description" : "^green;+10%^reset; Ice and Poison Resist 
-^green;+15%^reset; Energy
+^green;15%^reset; More Energy
 ^orange;Mobility II^reset;",
   "shortdescription" : "The Genesis Coil",
   "tooltipKind" : "eppaugment",

--- a/items/augments/quest/avianartifact.augment
+++ b/items/augments/quest/avianartifact.augment
@@ -4,9 +4,9 @@
   "rarity" : "legendary",
   "category" : "eppAugment",
   "inventoryIcon" : "avianartifacticon.png",
-  "description" : "^green;+10%^reset; Mid-Air Damage 
-^green;+10%^reset; Run Speed
-^green;+10%^reset; Jump Height",
+  "description" : "^green;10%^reset; More Mid-Air Damage 
++^green;10^reset%; Run Speed
++^green;10^reset%; Jump Height",
   "shortdescription" : "The Wheel of Kluex",
   "tooltipKind" : "eppaugment",
   "augment" : {

--- a/items/augments/quest/erchiusartifact.augment
+++ b/items/augments/quest/erchiusartifact.augment
@@ -4,7 +4,7 @@
   "rarity" : "legendary",
   "category" : "eppAugment",
   "inventoryIcon" : "erchiusartifacticon.png",
-  "description" : "^green;+15%^reset; Energy Regen 
+  "description" : "^green;15^reset;% More Energy Regen 
 ^green;+Glow^reset;",
   "shortdescription" : "Erchius Shard",
   "tooltipKind" : "eppaugment",

--- a/items/augments/quest/eyeofyokar.augment
+++ b/items/augments/quest/eyeofyokar.augment
@@ -4,9 +4,9 @@
   "rarity" : "legendary",
   "category" : "eppAugment",
   "inventoryIcon" : "eyeofyokar.png",
-  "description" : "^green;+20%^reset; Shadow & Cosmic Resist 
-^green;+30%^reset; Mental Resistance
-^cyan;+32%^reset; Max Health",
+  "description" : "+^green;20^reset;% Shadow & Cosmic Resist 
++^green;30^reset;% Mental Resistance
+^green;32^reset;% More HP",
   "shortdescription" : "^green;The Eye of Yokar^reset;",
   "tooltipKind" : "eppaugment",
   "augment" : {

--- a/items/augments/quest/floranartifact.augment
+++ b/items/augments/quest/floranartifact.augment
@@ -4,9 +4,9 @@
   "rarity" : "legendary",
   "category" : "eppAugment",
   "inventoryIcon" : "floranartifacticon.png",
-  "description" : "^green;+15%^reset; Electric Resist
-^green;+10%^reset; Cold Resist 
-^green;+5%^reset; Health, Energy
+  "description" : "+^green;15^reset;% Electric Resist
+^green;+10%^reset; Ice Resist 
++^green;15^reset;% More Health & Energy
 ^orange;Immunity to Electrified^reset;",
   "shortdescription" : "The Bone Trophy",
   "tooltipKind" : "eppaugment",

--- a/items/augments/quest/humanartifact.augment
+++ b/items/augments/quest/humanartifact.augment
@@ -4,9 +4,9 @@
   "rarity" : "essential",
   "category" : "eppAugment",
   "inventoryIcon" : "humanartifacticon.png",
-  "description" : "^green;+10%^reset; Damage
-^green;+20%^reset; Energy
-^green;+20%^reset; Cosmic Resist",
+  "description" : "^green;10^reset;% More Damage
+^green;20^reset; More Energy
++^green;20^reset;% Cosmic Resist",
   "shortdescription" : "^cyan;Broken Master Manipulator^reset;",
   "tooltipKind" : "eppaugment",
   "augment" : {

--- a/items/augments/quest/jellylump.augment
+++ b/items/augments/quest/jellylump.augment
@@ -4,9 +4,9 @@
   "rarity" : "legendary",
   "category" : "eppAugment",
   "inventoryIcon" : "jellylump.png",
-  "description" : "^green;+50%^reset; Fall Damage Resist 
-Gain ^green;Bouncy^reset; Status
-^cyan;+25%^reset; Max Health",
+  "description" : "^green;50^reset;% Less Fall Damage 
+Gain ^cyan;Bouncy^reset; Status
+^green;25^reset;% More HP",
   "shortdescription" : "^cyan;Jelly Lump^reset;",
   "tooltipKind" : "eppaugment",
   "augment" : {

--- a/items/augments/quest/novakidaugment.augment
+++ b/items/augments/quest/novakidaugment.augment
@@ -4,9 +4,9 @@
   "rarity" : "legendary",
   "category" : "eppAugment",
   "inventoryIcon" : "novakidartifacticon.png",
-  "description" : "^green;+5%^reset; Damage 
-^green;+15%^reset; Radiation Resist
-^green;+10%^reset; Fire Resist
+  "description" : "^green;10^reset; More Damage 
++^green;15^reset;% Radiation Resist
++^green;10^reset;% Fire Resist
 ^orange;Glow in the Dark^reset;",
   "shortdescription" : "The Dawn Sigil",
   "tooltipKind" : "eppaugment",

--- a/items/augments/quest/roadkill.augment
+++ b/items/augments/quest/roadkill.augment
@@ -5,7 +5,7 @@
   "category" : "eppAugment",
   "inventoryIcon" : "roadkill.png",
   "description" : "A dead animal. What's wrong with you?
-^green;+10%^reset; Poison Resist",
+^green;+30%^reset; Poison Resist",
   "shortdescription" : "A Dead Animal",
   "tooltipKind" : "eppaugment",
   "augment" : {

--- a/items/augments/quest/strangetome.augment
+++ b/items/augments/quest/strangetome.augment
@@ -4,7 +4,7 @@
   "rarity" : "legendary",
   "category" : "eppAugment",
   "inventoryIcon" : "strangetome.png",
-  "description" : "^green;+60% ^reset; Max Energy
+  "description" : "^green;60^reset;% More Energy
 ^red;-20% ^reset;Cosmic Resistance
 ^red;-20% ^reset;Shadow Resistance
 ^red;-20% ^reset;Mental Protection",

--- a/objects/power/fu_atmosfilter/warpedItemList.json
+++ b/objects/power/fu_atmosfilter/warpedItemList.json
@@ -17,6 +17,24 @@
 			"team": "enemy"
 		}]
 	},
+	"cthulureward": {
+		"effects": [{
+			"status": "percentarmorboostneg5",
+			"team": "enemy"
+		}, {
+			"status": "percentarmorboost30",
+			"team": "friendly"
+		}]
+	},
+	"protheonshard": {
+		"effects": [{
+			"status": "energy_negative_100_hidden",
+			"team": "enemy"
+		}, {
+			"status": "energyregenfu75",
+			"team": "friendly"
+		}]
+	},
 	"madnesstoken3": {
 		"effects": [{
 			"status": "insanity",

--- a/objects/spawner/monsterspawner.lua
+++ b/objects/spawner/monsterspawner.lua
@@ -1,0 +1,71 @@
+require "/scripts/util.lua"
+
+function init()
+  self = config.getParameter("spawner")
+  if not self then
+    sb.logInfo("Monster spawner at %s is missing configuration! Prepare for some serious Lua errors!", object.position())
+    return
+  end
+  if self.trigger == "wire" and object.inputNodeCount() == 0 then
+	local oName=object.name()
+	local eId=entity.id()
+	dbgStr=oName.." ("..eId..") has trigger 'wire' but no input nodes!"
+	sb.logInfo(dbgStr)
+  end
+  object.setInteractive(self.trigger == "interact")
+  self.position = object.toAbsolutePosition(self.position)
+  storage.cooldown = storage.cooldown or util.randomInRange(self.frequency or {0, 0})
+  storage.stock = storage.stock or self.stock
+end
+
+function onInteraction(args)
+  if self.trigger == "interact" then
+    spawn()
+  end
+end
+
+function update(dt)
+  if storage.stock ~= 0 then
+    if storage.cooldown > 0 then storage.cooldown = storage.cooldown - dt end
+
+    if storage.cooldown <= 0 and ((not self.trigger) or (self.trigger == "wire" and ((object.inputNodeCount() > 0) and (object.getInputNodeLevel(0))))) then
+      spawn()
+      storage.cooldown = util.randomInRange(self.frequency or {0, 0})
+    end
+  end
+end
+
+function die()
+  if self.trigger == "break" then
+    for i = 1, storage.stock do
+      spawn()
+    end
+  end
+end
+
+function spawn()
+  local attempts = 10
+  while attempts > 0 do
+    local spawnPosition = {}
+    for i,val in ipairs(self.positionVariance) do
+      if val == 0 then
+        spawnPosition[i] = self.position[i]
+      else
+        spawnPosition[i] = self.position[i] + math.random(val) - (val / 2)
+      end
+    end
+
+    if not self.outOfSight or not world.isVisibleToPlayer({spawnPosition[1] - 3, spawnPosition[2] - 3, spawnPosition[1] + 3, spawnPosition[2] + 3}) then
+      local monsterType = util.randomFromList(self.monsterTypes)
+      self.monsterParams.level = self.monsterLevel and util.randomInRange(self.monsterLevel) or world.threatLevel()
+
+      local monsterId = world.spawnMonster(monsterType, spawnPosition, self.monsterParams or {})
+      if monsterId ~= 0 then
+        storage.stock = storage.stock - 1
+        return
+      end
+    end
+
+    attempts = attempts - 1
+  end
+end

--- a/stats/effects/augments/fuberserker.statuseffect
+++ b/stats/effects/augments/fuberserker.statuseffect
@@ -3,11 +3,11 @@
  	"effectConfig": {
 		"stats": [{
 				"stat": "maxHealth",
-				"baseMultiplier": 0.8
+				"effectiveMultiplier": 0.85
 			},
 			{
 				"stat": "powerMultiplier",
-				"baseMultiplier": 1.2
+				"effectiveMultiplier": 1.3
 			}
 		]
 	},
@@ -16,6 +16,6 @@
 		"/stats/effects/fu_genericStatApplier.lua"
 	],
 
-  "label" : "+20% damage in exchange for -20% health",
+  "label" : "30% More Damage in exchange for 15% Less HP",
   "icon" : "/interface/statuses/rage.png"
 }

--- a/stats/effects/fu_armoreffects/set_bonuses/densiniumsetbonuseffectkhe.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/densiniumsetbonuseffectkhe.lua
@@ -55,7 +55,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"densinium","sniper","chainsword"})
+	local weapons=weaponCheck({"densinium","sniperrifle","chainsword"})
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else

--- a/stats/effects/fu_artifacts/novakidartifact.statuseffect
+++ b/stats/effects/fu_artifacts/novakidartifact.statuseffect
@@ -10,7 +10,7 @@
 			},
 			{
 				"stat": "powerMultiplier",
-				"effectiveMultiplier": 1.05
+				"effectiveMultiplier": 1.1
 			}
 		]
 	},

--- a/stats/effects/fu_artifacts/roadkillaugment.statuseffect
+++ b/stats/effects/fu_artifacts/roadkillaugment.statuseffect
@@ -3,7 +3,7 @@
 	"effectConfig": {
 		"stats": [{
 				"stat": "poisonResistance",
-				"amount": 0.1
+				"amount": 0.3
 			}
 		]
 	},

--- a/stats/effects/fu_artifacts/strangetome.statuseffect
+++ b/stats/effects/fu_artifacts/strangetome.statuseffect
@@ -4,7 +4,7 @@
 		"stats": [
 			{
 				"stat": "maxEnergy",
-				"baseMultiplier": 1.60
+				"effectiveMultiplier": 1.60
 			},
 			{
 				"stat": "cosmicResistance",

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_10.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_10.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_10",
-  "effectConfig" : { "energyrestore" : 0.07 },
+  "effectConfig" : { "energyrestore" : 0.1 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_15.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_15.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_15",
-  "effectConfig" : { "energyrestore" : 0.125 },
+  "effectConfig" : { "energyrestore" : 0.15 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_20.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_20.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_20",
-  "effectConfig" : { "energyrestore" : 0.18 },
+  "effectConfig" : { "energyrestore" : 0.20 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_25.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_25.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_25",
-  "effectConfig" : { "energyrestore" : 0.23 },
+  "effectConfig" : { "energyrestore" : 0.25 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_40.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_40.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_40",
-  "effectConfig" : { "energyrestore" : 0.36 },
+  "effectConfig" : { "energyrestore" : 0.4 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_5.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_5.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_5",
-  "effectConfig" : { "energyrestore" : 0.03 },
+  "effectConfig" : { "energyrestore" : 0.05 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_50.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_50.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_50",
-  "effectConfig" : { "energyrestore" : 0.46 },
+  "effectConfig" : { "energyrestore" : 0.5 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/energyrestorepercentage/energy_75.statuseffect
+++ b/stats/effects/fu_effects/energyrestorepercentage/energy_75.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "energy_75",
-  "effectConfig" : { "energyrestore" : 0.725 },
+  "effectConfig" : { "energyrestore" : 0.75 },
   "defaultDuration" : 1.0,
 
   "scripts" : [

--- a/stats/effects/fu_effects/icefield/icefield.lua
+++ b/stats/effects/fu_effects/icefield/icefield.lua
@@ -7,7 +7,7 @@ end
 function update(dt)
 
 local distanceFromEntity = world.entityQuery(mcontroller.position(),4)
-  if (status.stat("iceResistance")<0.75)
+  if (status.stat("iceResistance")<0.75) then
 	  for key, value in pairs(distanceFromEntity) do
 	   world.sendEntityMessage(value,"applyStatusEffect","slow")
 	  end  

--- a/stats/effects/fu_immunityeffects/poisonimmunityhidden.statuseffect
+++ b/stats/effects/fu_immunityeffects/poisonimmunityhidden.statuseffect
@@ -1,0 +1,20 @@
+{
+	"name": "poisonStatusImmunityHidden",
+	"effectConfig": {
+		"stats": [{
+				"stat": "poisonStatusImmunity",
+				"amount": 1
+			},
+			{
+				"stat": "poisonResistance",
+				"amount": 0.1
+			}
+		]
+	},
+	"defaultDuration": 90,
+	"scripts": [
+		"/stats/effects/fu_genericStatApplier.lua"
+	],
+	"label": "Antidote",
+	"icon": "/interface/statuses/antidote.png"
+}

--- a/stats/effects/liquidimmunity/gasimmunityhidden.statuseffect
+++ b/stats/effects/liquidimmunity/gasimmunityhidden.statuseffect
@@ -1,0 +1,29 @@
+{
+  "name" : "gasimmunityhidden",
+ 	"effectConfig": {
+		"stats": [
+			{
+				"stat": "helium3Immunity",
+				"amount": 1
+			},
+			{
+				"stat": "shadowgasImmunity",
+				"amount": 1
+			},
+			{
+				"stat": "metallichydrogengasImmunity",
+				"amount": 1
+			},
+			{
+				"stat": "poisongasImmunity",
+				"amount": 1
+			}
+		]
+	},
+	"defaultDuration": 60,
+	"scripts": [
+		"/stats/effects/fu_genericStatApplier.lua"
+	],
+  "label" : "X-Gas",
+  "icon" : "/interface/statuses/gas.png"
+}

--- a/stats/effects/regeneration/regenerationminor.lua
+++ b/stats/effects/regeneration/regenerationminor.lua
@@ -4,7 +4,7 @@ function init()
 
   script.setUpdateDelta(5)
 
-  self.healingRate = 1.005 / config.getParameter("healTime", 60)
+  self.healingRate = 1.0 / config.getParameter("healTime", 60)
 end
 
 function update(dt)

--- a/stats/effects/regeneration/regenerationminor2.lua
+++ b/stats/effects/regeneration/regenerationminor2.lua
@@ -4,7 +4,7 @@ function init()
 
   script.setUpdateDelta(5)
 
-  self.healingRate = 1.008 / config.getParameter("healTime", 60)
+  self.healingRate = 1.0 / config.getParameter("healTime", 60)
 end
 
 function update(dt)

--- a/stats/effects/regeneration/regenerationminor2augment.statuseffect
+++ b/stats/effects/regeneration/regenerationminor2augment.statuseffect
@@ -2,7 +2,7 @@
   "name" : "regenerationminor2augment",
     "blockingStat" : "healingStatusImmunity",
   "effectConfig" : {
-    "healTime" : 200
+    "healTime" : 135
   },
   "defaultDuration" : 90,
 
@@ -10,7 +10,5 @@
     "regenerationminor2.lua"
   ],
 
-  "animationConfig" : "regeneration.animation",
-  "label" : "Regen II",
-  "icon" : "/interface/statuses/heal.png"
+  "animationConfig" : "regeneration.animation"
 }

--- a/stats/effects/regeneration/regenerationminor3.lua
+++ b/stats/effects/regeneration/regenerationminor3.lua
@@ -4,7 +4,7 @@ function init()
 
   script.setUpdateDelta(5)
 
-  self.healingRate = 1.01 / config.getParameter("healTime", 60)
+  self.healingRate = 1.0 / config.getParameter("healTime", 60)
 end
 
 function update(dt)

--- a/stats/effects/regeneration/regenerationminor3augment.statuseffect
+++ b/stats/effects/regeneration/regenerationminor3augment.statuseffect
@@ -2,7 +2,7 @@
   "name" : "regenerationminor3augment",
     "blockingStat" : "healingStatusImmunity",
   "effectConfig" : {
-    "healTime" : 180
+    "healTime" : 90
   },
   "defaultDuration" : 90,
 
@@ -10,7 +10,5 @@
     "regenerationminor3.lua"
   ],
 
-  "animationConfig" : "regeneration.animation",
-  "label" : "Regen III",
-  "icon" : "/interface/statuses/heal.png"
+  "animationConfig" : "regeneration.animation"
 }

--- a/stats/effects/regeneration/regenerationminoraugment.statuseffect
+++ b/stats/effects/regeneration/regenerationminoraugment.statuseffect
@@ -2,7 +2,7 @@
   "name" : "regenerationminoraugment",
     "blockingStat" : "healingStatusImmunity",
   "effectConfig" : {
-    "healTime" : 220
+    "healTime" : 180
   },
   "defaultDuration" : 90,
 
@@ -10,7 +10,5 @@
     "regenerationminor.lua"
   ],
 
-  "animationConfig" : "regeneration.animation",
-  "label" : "Augment Regen - Minor",
-  "icon" : "/interface/statuses/heal.png"
+  "animationConfig" : "regeneration.animation"
 }


### PR DESCRIPTION
added crit to requires in rngbowshot luas
fixed densinium EVA not recognizing snipers
fixed icefield.lua
fix toward vanilla monsterspawner screeching errors because the spawner has 'wire' as a trigger but the object has no wire nodes
updated tooltips for several vanilla and FU augments
FU regen augments are now on par with vanilla ones, instead of being severely inferior.
berserker is now 30% More damage at cost of 15% less health, instead of 20% basemult on both
dawn sigil is now 10% More Damage, up from 5
roadkill augment is now 30% poison resistance instead of 10
King in Yellow is now 60% More Energy, instead of 60% Basemult (which equated to +60 in most cases). it is now worthy of the massive penalties, instead of being a worse version of the vanilla energy 3 augment (+60, amount)
