### PR TITLE
yay

### DIFF
--- a/codex/documents/ffguide6.codex
+++ b/codex/documents/ffguide6.codex
@@ -23,7 +23,7 @@ As a small side-note, some terms or symbols are used loosely. If you see a bonus
 ^cyan;Gravity Normalization^reset;: Personal gravity too low? Up it goes. Too high? Down instead. Exception: Zero-gravity.\n
 ^cyan;Vital Power^reset; and ^cyan;Juggernaut^reset;: these effects are set bonus exclusive, and quite powerful; they grant one stat based on a percent of another. Vital power grants power as life, Juggernaut grants life as power.\n
 ^cyan;Undying Resolve^reset;: increases Protection as your life gets lower, up to the stated amount, while Immortal Resolve grants HP Regen instead.\n
-^cyan;Dark Commander^reset;: Increases Damage, Protection, HP and Speed of nearby friendly monsters by the listed percent, increases their jump ability by half of that, and regenerates HP at a sixth of that amount per second.\n
+^cyan;Dark Commander^reset;: Increases Damage, Protection, HP and Speed of pets you summon by the listed percent, increases their jump ability by half of that, and regenerates HP at a sixth of that amount per second.\n
 ^cyan;Charisma^reset;: Your ability to bargain with Traders at space stations. The higher your charisma, the better the deal (and fatter your bank balance!)"
 
 	],

--- a/items/active/unsorted/fu_monsterdetector/fu_monsterdetector.lua
+++ b/items/active/unsorted/fu_monsterdetector/fu_monsterdetector.lua
@@ -1,8 +1,11 @@
+require "/scripts/effectUtil.lua"
+
 function activate(fireMode)
-	local targetlist = world.entityQuery(world.entityPosition(player.id()),50,{includedTypes={"monster"}})
+	effectUtil.effectTypesInRange("minibossglow",50,{"monster"},30)
+	--[[local targetlist = world.entityQuery(world.entityPosition(player.id()),50,{includedTypes={"monster"}})
 	for key, value in pairs(targetlist) do
 		world.sendEntityMessage(value,"applyStatusEffect","minibossglow",30)
-	end
+	end]]
 end
 
 function update()

--- a/items/generic/produce/haleflowerpetal.consumable
+++ b/items/generic/produce/haleflowerpetal.consumable
@@ -6,7 +6,7 @@
   "price": 5,
 
   "tooltipKind": "food",
-  "description": "^cyan;+^white;25% ^cyan;E Regen ^gray;(^white;30s^gray;)^reset;",
+  "description": "^cyan;+^white;60% ^cyan;E Regen ^gray;(^white;30s^gray;)^reset;",
   "shortdescription": "Hale Flower Petal",
 
   "effects": [["energyregenfu60"]]

--- a/metamaterials.config.patch
+++ b/metamaterials.config.patch
@@ -1,0 +1,7 @@
+[
+ {
+  "op": "replace",
+  "path": "/5/collisionKind",
+  "value": "dynamic"
+ }
+]

--- a/recipes/powerstation/convert/electronmicroscope2.recipe
+++ b/recipes/powerstation/convert/electronmicroscope2.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "electronmicroscope", "count" : 1 },
-    { "item" : "network_containerlink2", "count" : 4 }
+    { "item" : "network_containerlink2", "count" : 1 }
   ],
   "output" : {
     "item" : "electronmicroscope2",

--- a/scripts/companions/petspawner.lua
+++ b/scripts/companions/petspawner.lua
@@ -32,6 +32,17 @@ function Pet:init(podUuid, json)
   if self.uniqueId then
     self.statusTimer = config.getParameter("statusTimer", 2)
   end
+  --[[
+	local elementaltypes=root.assetJson("/damage/elementaltypes.config")
+	local buffer={}
+
+
+	for element,data in pairs(elementaltypes) do
+		if data.resistanceStat then
+			buffer[data.resistanceStat]=true
+		end
+	end
+  self.resistanceList=buffer]]
 end
 
 function Pet:store()
@@ -155,65 +166,135 @@ function Pet:getPersistentEffects()
 
   -- The player's armor takes effect if the player is spawning the pet:
   if getPetPersistentEffects then
-    util.appendLists(effects, getPetPersistentEffects())
-    
+	local buffer={}
+
+	--khe: overriding the vanilla function somewhat because it's too limited
+	
+	local armorEffects=status.getPersistentEffects("armor")
+	local filteredEffects={}
+
+	local petPersistentEffects = {
+		--powerMultiplier = true,--removing because we're handling it slightly differently.
+		protection = true,
+		maxHealth = true
+	  }
+	for _,button in pairs(armorEffects) do
+		if type(button)=="table" then
+			if petPersistentEffects[button.stat] then --or self.resistanceList[button.stat] then
+				table.insert(filteredEffects,button)
+			end
+		end
+	end
+	--we're using the player's stats, rather than just armor stats, now.
+	table.insert(filteredEffects,{stat="powerMultiplier",effectiveMultiplier=status.stat("powerMultiplier")})
+    util.appendLists(effects,filteredEffects)
+    --util.appendLists(effects, getPetPersistentEffects())
+	
+
+	local aUSES=status.activeUniqueStatusEffectSummary()
+	for _,pit in pairs(aUSES) do
+		buffer[pit[1]]=true
+		--sb.logInfo("aUSES: %s",aUSES)
+	end
+	aUSES=buffer
+	buffer={}
+	
+	local frackinPetStatEffectsMetatable=status.statusProperty("frackinPetStatEffectsMetatable",{})
+	--sb.logInfo("status.stat(powerMultiplier):%s",status.stat("powerMultiplier"))--works
+	--sb.logInfo("fpsem 1: %s",frackinPetStatEffectsMetatable)
+	local frackinPetStatEffectsMetatableBuffer={}
+	local frackinPetStatEffectsMetatableDirty=false
+	for bonusHandle,effectList in pairs(frackinPetStatEffectsMetatable) do
+		if aUSES[bonusHandle] then
+			if type(effectList)=="table" then
+				for _,statEffect in pairs(effectList) do
+					--try to keep them unique
+					frackinPetStatEffectsMetatableBuffer[statEffect]=true
+				end
+				--debug, to see if this actually works:
+			else
+				sb.logInfo("petspawner.lua pet stat handler: HEY MORON, USE TABLES, NOT OTHER VALUES. frackinPetStatEffectsMetatableBuffer={bonusHandle={\"statuseffect1\",\"statuseffect2\"}} as example. not this crap: %s",effectList)
+			end
+		else
+			frackinPetStatEffectsMetatable[bonusHandle]=nil
+			frackinPetStatEffectsMetatableDirty=true
+		end
+	end
+	if frackinPetStatEffectsMetatableDirty then
+		status.setStatusProperty("frackinPetStatEffectsMetatable",frackinPetStatEffectsMetatable)
+	end
+	--sb.logInfo("fpsemb 1: %s",frackinPetStatEffectsMetatableBuffer)
+	for statEffect,_ in pairs(frackinPetStatEffectsMetatableBuffer) do
+		table.insert(buffer,statEffect)
+	end
+	frackinPetStatEffectsMetatableBuffer=buffer
+	buffer={}
+	--table.insert(frackinPetStatEffectsMetatableBuffer,"fudarkcommander30")
+	--sb.logInfo("fpsemb 2: %s",frackinPetStatEffectsMetatableBuffer)
+	util.appendLists(effects,frackinPetStatEffectsMetatableBuffer)
+	
     -- ~Psi:  Provide a bonus to the pet's base max health, and some minor regen, so it sucks less:
     -- ~Psi:  Total bonus is x4, but we only multiply by 3, since the player's bonusHealth has already been added once
-    local playerHealthBonus = world.entityHealth(player.id())[2]
+    --local playerHealthBonus = world.entityHealth(player.id())[2]--pointless.
+    local playerHealthBonus = status.resourceMax("health")
     playerHealthBonus = playerHealthBonus - 100
     if playerHealthBonus < 10 then playerHealthBonus = 10 end
     local petHealthBonus = playerHealthBonus * 3
-    
-    
-    
+
+
+
     --************* FU special pet stats
-    local playerProtectionBonus = 0
+	--khe: phasing this particular variant out
+    --[[local playerProtectionBonus = 0
     for _, armourEffect in ipairs (effects) do
         if armourEffect.stat == "protection" then
             playerProtectionBonus = playerProtectionBonus + armourEffect.amount
             petHealthBonus = (playerHealthBonus + playerProtectionBonus ) * 1.5 --we add the current Protection of the player x1.5 as bonus health
         end
-    end
-    
+    end]]
+	--khe: we now take into account the actual current value of the player's stats. though slightly delayed.
+	petHealthBonus=(petHealthBonus+status.stat("protection"))*1.5
+
+	--below comment is more or less false. pet stats are periodically refreshed
     --below stats are currently unused, as they need to be linked to update, or they will be permanent after summon, which isnt the intent for them
+	--[[
     if config.getParameter("isNocturnal") then  --is it nocturnal?
       if  world.lightLevel <=0.5 then
           local petHealthBonus = playerHealthBonus * 1.15
-      end       
+      end
     end
     if config.getParameter("isDiurnal") then -- does it prefer the day?
       if world.lightLevel > 0.5 then
           local petHealthBonus = playerHealthBonus * 1.15
-      end    
+      end
     end
     if config.getParameter("isSurface") then -- does it prefer the surface?
       if world.inSurfaceLayer then
           local petHealthBonus = playerHealthBonus * 1.15
-      end    
-    end    
+      end
+    end
     if config.getParameter("isSubterrain") then -- does it prefer being underground?
       if world.underground then
           local petHealthBonus = playerHealthBonus * 1.15
       end
-    end	
+    end
     if config.getParameter("isWindy") then -- does it prefer windy worlds?
       if world.windLevel >=10 then
           local petHealthBonus = playerHealthBonus * 1.15
       end
-    end	    
-    
+    end
+    ]]
     -- New Regen formula
     -- https://www.desmos.com/calculator/mmv4okrc6f
     local petRegenBonus = math.log(playerHealthBonus * 0.05 + 1) / math.log(10) * 5
-    
+
     -- Health Bonus
     util.appendLists(effects, {{stat="maxHealth",amount=petHealthBonus},{stat="healthRegen",amount=petRegenBonus}})
-    
+
     -- ~Psi:  Debugging info
     sb.setLogMap("~[Pet Stats] playerHealthBonus", "%s", tostring(playerHealthBonus))
     sb.setLogMap("~[Pet Stats] petHealthBonus", "%s", tostring(petHealthBonus + playerHealthBonus))
     sb.setLogMap("~[Pet Stats] petRegenBonus", "%s", tostring(petRegenBonus))
-    
   end
 
   -- Collars applied to the capturepod also take effect:
@@ -221,6 +302,8 @@ function Pet:getPersistentEffects()
     util.appendLists(effects, self.collar.effects)
   end
 
+	
+	--sb.logInfo("%s",effects)
   return effects
 end
 

--- a/scripts/companions/petspawner.lua
+++ b/scripts/companions/petspawner.lua
@@ -187,6 +187,8 @@ function Pet:getPersistentEffects()
 	end
 	--we're using the player's stats, rather than just armor stats, now.
 	table.insert(filteredEffects,{stat="powerMultiplier",effectiveMultiplier=status.stat("powerMultiplier")})
+	--doing the same for hp regen with the upcoming changes to it
+	table.insert(filteredEffects,{stat="healthRegen",amount=status.stat("healthRegen")})
     util.appendLists(effects,filteredEffects)
     --util.appendLists(effects, getPetPersistentEffects())
 	

--- a/stats/effects/elitemonster/fudarkcommander.lua
+++ b/stats/effects/elitemonster/fudarkcommander.lua
@@ -1,18 +1,17 @@
 function init()
-	sb.logInfo("Dark Commander init on %s. monster comparator: %s.",entity.id(),world.isMonster(entity.id()))
+	--[[sb.logInfo("Dark Commander init on %s. monster comparator: %s.",entity.id(),world.isMonster(entity.id()))
 	if not world.isMonster(entity.id()) then
 		--removed 'is pod monster' check due to params not being present on servers
 		sb.logInfo("Dark Commander terminated in init.")
 		effect.expire()
 		return
-	end
+	end]]
 	regenHPPerSecond=config.getParameter("regenHPPerSecond",0)
-	sb.logInfo("Dark Commander init passed comparator. Regen value: %s",regenHPPerSecond)
+	--sb.logInfo("Dark Commander init passed comparator. Regen value: %s",regenHPPerSecond)
 end
 
 function update(dt)
 	if not regenHPPerSecond then regenHPPerSecond=config.getParameter("regenHPPerSecond",0) end
-	--donkey
 	healthPercent=status.resourcePercentage("health")
 	if not status.statPositive("healingStatusImmunity") then
 		healthPercent=math.min(healthPercent+(regenHPPerSecond*dt),1.0)

--- a/stats/effects/elitemonster/fudarkcommander.lua
+++ b/stats/effects/elitemonster/fudarkcommander.lua
@@ -1,5 +1,5 @@
 function init()
-	sb.logInfo("Dark Commander init on %s. monster comparator: %s.",entity.id(),world.isMonster(id))
+	sb.logInfo("Dark Commander init on %s. monster comparator: %s.",entity.id(),world.isMonster(entity.id()))
 	if not world.isMonster(entity.id()) then
 		--removed 'is pod monster' check due to params not being present on servers
 		sb.logInfo("Dark Commander terminated in init.")

--- a/stats/effects/elitemonster/fudarkcommander.lua
+++ b/stats/effects/elitemonster/fudarkcommander.lua
@@ -12,7 +12,7 @@ end
 
 function update(dt)
 	if not regenHPPerSecond then regenHPPerSecond=config.getParameter("regenHPPerSecond",0) end
-	
+	--donkey
 	healthPercent=status.resourcePercentage("health")
 	if not status.statPositive("healingStatusImmunity") then
 		healthPercent=math.min(healthPercent+(regenHPPerSecond*dt),1.0)

--- a/stats/effects/elitemonster/fudarkcommander.lua
+++ b/stats/effects/elitemonster/fudarkcommander.lua
@@ -1,11 +1,12 @@
 function init()
 	--[[sb.logInfo("Dark Commander init on %s. monster comparator: %s.",entity.id(),world.isMonster(entity.id()))
 	if not world.isMonster(entity.id()) then
-		--removed 'is pod monster' check due to params not being present on servers
+		--following is incorrect. actual problem is that starrypy has a blocker plugin that is typically run to 'protect' people. load of shit.--removed 'is pod monster' check due to params not being present on servers
 		sb.logInfo("Dark Commander terminated in init.")
 		effect.expire()
 		return
 	end]]
+	--new implementation will be to apply via petspawner override
 	regenHPPerSecond=config.getParameter("regenHPPerSecond",0)
 	--sb.logInfo("Dark Commander init passed comparator. Regen value: %s",regenHPPerSecond)
 end

--- a/stats/effects/elitemonster/fudarkcommander.lua
+++ b/stats/effects/elitemonster/fudarkcommander.lua
@@ -1,10 +1,13 @@
 function init()
+	sb.logInfo("Dark Commander init on %s. monster comparator: %s.",entity.id(),world.isMonster(id))
 	if not world.isMonster(entity.id()) then
 		--removed 'is pod monster' check due to params not being present on servers
+		sb.logInfo("Dark Commander terminated in init.")
 		effect.expire()
 		return
 	end
 	regenHPPerSecond=config.getParameter("regenHPPerSecond",0)
+	sb.logInfo("Dark Commander init passed comparator. Regen value: %s",regenHPPerSecond)
 end
 
 function update(dt)

--- a/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.lua
@@ -29,7 +29,9 @@ function update(dt)
 	else
 		if not self.timer or self.timer >= 1 then
 			for _,id in pairs(world.monsterQuery(entity.position(),50)) do
+				sb.logInfo("Elder Set Bonus update for loop. id: %s. Comparator Pre-negation (isValidTarget): %s.",id,entity.isValidTarget(id))
 				if not entity.isValidTarget(id) then
+					sb.logInfo("for loop comparator passed: %s.",id)
 					world.sendEntityMessage(id, "applyStatusEffect", "fudarkcommander30", (self.timer or 1.0)*2, entity.id())
 				end
 			end

--- a/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.lua
@@ -20,6 +20,7 @@ function init()
 	effectHandlerList.armorBonusHandle=effect.addStatModifierGroup(armorBonus)
 	effectHandlerList.weaponBonusHandle=effect.addStatModifierGroup({})
 	checkWeapons()
+	--sb.logInfo("%s",status.getPersistentEffects("armor"))
 end
 
 function update(dt)
@@ -29,9 +30,9 @@ function update(dt)
 	else
 		if not self.timer or self.timer >= 1 then
 			for _,id in pairs(world.monsterQuery(entity.position(),50)) do
-				sb.logInfo("Elder Set Bonus update for loop. id: %s. Comparator Pre-negation (isValidTarget): %s.",id,entity.isValidTarget(id))
+				--sb.logInfo("Elder Set Bonus update for loop. id: %s. Comparator Pre-negation (isValidTarget): %s.",id,entity.isValidTarget(id))
 				if not entity.isValidTarget(id) then
-					sb.logInfo("for loop comparator passed: %s.",id)
+					--sb.logInfo("for loop comparator passed: %s.",id)
 					world.sendEntityMessage(id, "applyStatusEffect", "fudarkcommander30", (self.timer or 1.0)*2, entity.id())
 				end
 			end

--- a/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.lua
@@ -20,22 +20,30 @@ function init()
 	effectHandlerList.armorBonusHandle=effect.addStatModifierGroup(armorBonus)
 	effectHandlerList.weaponBonusHandle=effect.addStatModifierGroup({})
 	checkWeapons()
-	--sb.logInfo("%s",status.getPersistentEffects("armor"))
+	statusEffectName=config.getParameter("statusEffectName")
 end
 
 function update(dt)
 	if not checkSetWorn(self.setBonusCheck) then
 		status.removeEphemeralEffect("darkregen")
+		if type(statusEffectName)=="string" then
+			local buffer=status.statusProperty("frackinPetStatEffectsMetatable",{})--thisStatusEffectId={"status1","status2"} format
+			if buffer[statusEffectName] then
+				buffer[statusEffectName]=nil
+			end
+			status.setStatusProperty("frackinPetStatEffectsMetatable",buffer)
+		end
 		effect.expire()
 	else
 		if not self.timer or self.timer >= 1 then
-			for _,id in pairs(world.monsterQuery(entity.position(),50)) do
-				--sb.logInfo("Elder Set Bonus update for loop. id: %s. Comparator Pre-negation (isValidTarget): %s.",id,entity.isValidTarget(id))
-				if not entity.isValidTarget(id) then
-					--sb.logInfo("for loop comparator passed: %s.",id)
-					world.sendEntityMessage(id, "applyStatusEffect", "fudarkcommander30", (self.timer or 1.0)*2, entity.id())
+			if type(statusEffectName)=="string" then
+				local buffer=status.statusProperty("frackinPetStatEffectsMetatable",{})--thisStatusEffectId={"status1","status2"} format
+				if not buffer[statusEffectName] then
+					buffer[statusEffectName]={"fudarkcommander30"}
 				end
+				status.setStatusProperty("frackinPetStatEffectsMetatable",buffer)
 			end
+			
 			self.timer = 0
 		else
 			self.timer = self.timer + dt

--- a/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.statuseffect
+++ b/stats/effects/fu_armoreffects/set_bonuses/eldersetbonuseffect.statuseffect
@@ -1,6 +1,7 @@
 {
   "name" : "eldersetbonuseffect",
   "defaultDuration" : 15,
+  "effectConfig":{"statusEffectName":"eldersetbonuseffect"},
 
   "scripts" : [
     "eldersetbonuseffect.lua"

--- a/stats/effects/fu_effects/bizarreglow/bizarreglow.lua
+++ b/stats/effects/fu_effects/bizarreglow/bizarreglow.lua
@@ -1,14 +1,16 @@
+require "/scripts/effectUtil.lua"
+
 function init()
   script.setUpdateDelta(10)
 end
 
 function update(dt)
-
-  local distanceFromEntity = world.entityQuery(mcontroller.position(),12)
+  effectUtil.effectAllInRange("bizarreglow",12)
+  --[[local distanceFromEntity = world.entityQuery(mcontroller.position(),12)
 
   for key, value in pairs(distanceFromEntity) do
    world.sendEntityMessage(value,"applyStatusEffect","bizarreglow")
-  end
+  end]]
 
 end
 

--- a/stats/effects/fu_effects/detectmonster/detectmonster.lua
+++ b/stats/effects/fu_effects/detectmonster/detectmonster.lua
@@ -1,12 +1,15 @@
+require "/scripts/effectUtil.lua"
+
 function init()
   script.setUpdateDelta(10)
 end
 
 function update(dt)
-  local distanceFromEntity = world.entityQuery(mcontroller.position(),60)
+  effectUtil.effectAllInRange("slimebioluminescence",60)
+  --[[local distanceFromEntity = world.entityQuery(mcontroller.position(),60)
   for key, value in pairs(distanceFromEntity) do
    world.sendEntityMessage(value,"applyStatusEffect","slimebioluminescence")
-  end
+  end]]
 end
 
 function uninit()

--- a/stats/effects/fu_effects/draingroup/draingroup.lua
+++ b/stats/effects/fu_effects/draingroup/draingroup.lua
@@ -1,14 +1,17 @@
+require "/scripts/effectUtil.lua"
+
 function init()
   script.setUpdateDelta(10)
 end
 
 function update(dt)
-
+  effectUtil.effectAllInRange("drain",60)
+--[[
 local distanceFromEntity = world.entityQuery(mcontroller.position(),60)
 
   for key, value in pairs(distanceFromEntity) do
    world.sendEntityMessage(value,"applyStatusEffect","drain")
-  end
+  end]]
 end
 
 function uninit()

--- a/stats/effects/fu_effects/healarea/healarea.lua
+++ b/stats/effects/fu_effects/healarea/healarea.lua
@@ -1,13 +1,15 @@
+require "/scripts/effectUtil.lua"
+
 function init()
   script.setUpdateDelta(60)
 end
 
 function update(dt)
-
-  local distanceFromEntity = world.entityQuery(mcontroller.position(),3)
+  effectUtil.effectAllInRange("heal_tier0",3)
+  --[[local distanceFromEntity = world.entityQuery(mcontroller.position(),3)
   for key, value in pairs(distanceFromEntity) do
    world.sendEntityMessage(value,"applyStatusEffect","heal_tier0")
-  end
+  end]]
 end
 
 function uninit()

--- a/stats/effects/fu_effects/icefield/icefield.lua
+++ b/stats/effects/fu_effects/icefield/icefield.lua
@@ -1,3 +1,5 @@
+require "/scripts/effectUtil.lua"
+
 function init()
   animator.setParticleEmitterOffsetRegion("drips", mcontroller.boundBox())
   animator.setParticleEmitterActive("drips", true) 
@@ -5,13 +7,16 @@ function init()
 end
 
 function update(dt)
-
+	if (status.stat("iceResistance")<0.75) then
+		effectUtil.effectAllInRange("slow",4)
+	end
+--[[
 local distanceFromEntity = world.entityQuery(mcontroller.position(),4)
   if (status.stat("iceResistance")<0.75) then
 	  for key, value in pairs(distanceFromEntity) do
 	   world.sendEntityMessage(value,"applyStatusEffect","slow")
 	  end  
-  end
+  end]]
 end
 
 function uninit()

--- a/stats/effects/fu_effects/infection/infection.lua
+++ b/stats/effects/fu_effects/infection/infection.lua
@@ -1,3 +1,5 @@
+require "/scripts/effectUtil.lua"
+
 function init()
   animator.setParticleEmitterOffsetRegion("drips", mcontroller.boundBox())
   animator.setParticleEmitterActive("drips", true)
@@ -6,13 +8,15 @@ function init()
 end
 
 function update(dt)
-
+	effectUtil.effectAllInRange("weakpoison",4)
+	effectUtil.effectAllInRange("darkvision",4)
+--[[
 local distanceCheck = world.entityQuery(mcontroller.position(),4)
 
   for key, value in pairs(distanceCheck) do
    world.sendEntityMessage(value,"applyStatusEffect","weakpoison")
    world.sendEntityMessage(value,"applyStatusEffect","darkvision")
-  end
+  end]]
 end
 
 function uninit()

--- a/stats/effects/fu_effects/madness/madnessgainpainting.lua
+++ b/stats/effects/fu_effects/madness/madnessgainpainting.lua
@@ -1,59 +1,59 @@
 function init()
-  self.applyToTypes = {"player", "npc"}
-  self.baseValue = config.getParameter("baseValue")
-  self.valBonus = config.getParameter("valBonus") - ((config.getParameter("mentalProtection") or 0) * 10)
-  self.timer = 10
-  self.afk = 0
-  self.myspeed = 0
-  animator.setParticleEmitterOffsetRegion("insane", mcontroller.boundBox())
-  animator.setParticleEmitterEmissionRate("insane", config.getParameter("emissionRate", 3))
-  animator.setParticleEmitterActive("insane", true)
-  activateVisualEffects()
-  
-  effect.addStatModifierGroup({{stat = "madnessModifier", amount = (status.stat("madnessModifier") or 0) * 1.25}})  
-  
-  script.setUpdateDelta(3)
+	self.applyToTypes = {"player", "npc"}
+	self.baseValue = config.getParameter("baseValue")
+	self.valBonus = config.getParameter("valBonus") - ((config.getParameter("mentalProtection") or 0) * 10)
+	self.timer = 10
+	self.afk = 0
+	self.myspeed = 0
+	animator.setParticleEmitterOffsetRegion("insane", mcontroller.boundBox())
+	animator.setParticleEmitterEmissionRate("insane", config.getParameter("emissionRate", 3))
+	animator.setParticleEmitterActive("insane", true)
+	activateVisualEffects()
+
+	effect.addStatModifierGroup({{stat = "madnessModifier", amount = (status.stat("madnessModifier") or 0) * 1.25}})  
+
+	script.setUpdateDelta(3)
 end
 
 function allowedType()
-  local entityType = entity.entityType()
-  for _,applyType in ipairs(self.applyToTypes) do
-    if entityType == applyType then
-      return true
-    end
-  end
+	local entityType = entity.entityType()
+	for _,applyType in ipairs(self.applyToTypes) do
+		if entityType == applyType then
+			return true
+		end
+	end
 end
 
 function update(dt)
-  	self.timer = self.timer - dt
+	self.timer = self.timer - dt
 	if (status.stat("maxEnergy")) then
 		if (self.timer <= 0) then
-			self.healthDamage = ((math.max(1.0 - status.stat("mentalProtection"),0))*10) + status.stat("madnessModifier")
-			self.timer = 30
-			self.totalValue = self.baseValue + self.valBonus + math.random(1,6)
-      self.myspeed = mcontroller.xVelocity() --check speed, dont drop madness if we are afking
-  		if  entity.entityType() =="player" then
-        if self.myspeed < 5 then
-          if self.afk > 2000 then -- do not go higher than this value
-            self.afk = 2000 
-          end
-          self.afk = self.afk + 1
-          world.spawnItem("fumadnessresource",entity.position(),self.totalValue)
-          animator.playSound("madness")
-          activateVisualEffects()
-          status.applySelfDamageRequest({
-            damageType = "IgnoresDef",
-            damage = self.healthDamage,
-            damageSourceKind = "shadow",
-            sourceEntityId = entity.id()
-          })          
-        else
-          self.afk = self.afk -50  --movement decrements the penalty
-          if self.afk < 1 then
-            self.afk = 0
-          end
-        end       
-  		end
+		self.healthDamage = ((math.max(1.0 - status.stat("mentalProtection"),0))*10) + status.stat("madnessModifier")
+		self.timer = 30
+		self.totalValue = self.baseValue + self.valBonus + math.random(1,6)
+		self.myspeed = mcontroller.xVelocity() --check speed, dont drop madness if we are afking
+			if  entity.entityType() =="player" then
+				if self.myspeed < 5 then
+					if self.afk > 2000 then -- do not go higher than this value
+						self.afk = 2000 
+					end
+					self.afk = self.afk + 1
+					world.spawnItem("fumadnessresource",entity.position(),self.totalValue)
+					animator.playSound("madness")
+					activateVisualEffects()
+					status.applySelfDamageRequest({
+						damageType = "IgnoresDef",
+						damage = self.healthDamage,
+						damageSourceKind = "shadow",
+						sourceEntityId = entity.id()
+					})          
+				else
+					self.afk = self.afk -50  --movement decrements the penalty
+					if self.afk < 1 then
+						self.afk = 0
+					end
+				end       
+			end
 		end
 	else
 		effect.expire()
@@ -62,12 +62,12 @@ end
 
 
 function activateVisualEffects()
-  effect.setParentDirectives("fade=765e72=0.4")
-  if entity.entityType()=="player" then
-  local statusTextRegion = { 0, 1, 0, 1 }
-  animator.setParticleEmitterOffsetRegion("statustext", statusTextRegion)
-  animator.burstParticleEmitter("statustext")
-  end
+	effect.setParentDirectives("fade=765e72=0.4")
+	if entity.entityType()=="player" then
+		local statusTextRegion = { 0, 1, 0, 1 }
+		animator.setParticleEmitterOffsetRegion("statustext", statusTextRegion)
+		animator.burstParticleEmitter("statustext")
+	end
 end
 
 

--- a/stats/effects/fu_effects/madness/madnessgainpainting.lua
+++ b/stats/effects/fu_effects/madness/madnessgainpainting.lua
@@ -28,7 +28,7 @@ function update(dt)
   	self.timer = self.timer - dt
 	if (status.stat("maxEnergy")) then
 		if (self.timer <= 0) then
-			self.healthDamage = ((status.stat("mentalProtection") or 0)*10) + status.stat("madnessModifier")
+			self.healthDamage = ((math.max(1.0 - status.stat("mentalProtection"),0))*10) + status.stat("madnessModifier")
 			self.timer = 30
 			self.totalValue = self.baseValue + self.valBonus + math.random(1,6)
       self.myspeed = mcontroller.xVelocity() --check speed, dont drop madness if we are afking

--- a/stats/effects/fu_effects/madness/madnessloss.statuseffect
+++ b/stats/effects/fu_effects/madness/madnessloss.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "madnessloss",
   "effectConfig" : {
-    "mentalProtect" : 20
+    "mentalProtect" : 0.2
   },
   "defaultDuration" : 120,
 

--- a/stats/effects/fu_effects/madness/madnessloss2.statuseffect
+++ b/stats/effects/fu_effects/madness/madnessloss2.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "madnessloss2",
   "effectConfig" : {
-    "mentalProtect" : 40
+    "mentalProtect" : 0.4
   },
   "defaultDuration" : 120,
 

--- a/stats/effects/fu_effects/madness/madnessloss3.statuseffect
+++ b/stats/effects/fu_effects/madness/madnessloss3.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "madnessloss3",
   "effectConfig" : {
-    "mentalProtect" : 65
+    "mentalProtect" : 0.65
   },
   "defaultDuration" : 120,
 

--- a/stats/effects/fu_effects/madness/madnessloss4.statuseffect
+++ b/stats/effects/fu_effects/madness/madnessloss4.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "madnessloss4",
   "effectConfig" : {
-    "mentalProtect" : 80
+    "mentalProtect" : 0.8
   },
   "defaultDuration" : 120,
 

--- a/stats/effects/fu_tileeffects/poison_effects/pus/puseffect.lua
+++ b/stats/effects/fu_tileeffects/poison_effects/pus/puseffect.lua
@@ -1,3 +1,5 @@
+require "/scripts/effectUtil.lua"
+
 function init()
   script.setUpdateDelta(5)
   self.tickTime = 3.0
@@ -24,15 +26,17 @@ function activateVisualEffects()
   animator.setParticleEmitterOffsetRegion("drips", mcontroller.boundBox())
   animator.setParticleEmitterActive("drips", true)
   if entity.entityType()=="player" then
-  local statusTextRegion = { 0, 1, 0, 1 }
-  animator.setParticleEmitterOffsetRegion("statustext", statusTextRegion)
-  animator.burstParticleEmitter("statustext")
+	  local statusTextRegion = { 0, 1, 0, 1 }
+	  animator.setParticleEmitterOffsetRegion("statustext", statusTextRegion)
+	  animator.burstParticleEmitter("statustext")
   end
   
-  local distanceFromEntity = world.entityQuery(mcontroller.position(),60)
+  --because really, applying it to every creature in 60 tiles is just wasteful and stupid
+  effectUtil.effectSelf("slimebioluminescence")
+  --[[local distanceFromEntity = world.entityQuery(mcontroller.position(),60)
   for key, value in pairs(distanceFromEntity) do
    world.sendEntityMessage(value,"applyStatusEffect","slimebioluminescence")
-  end
+  end]]
   
 end
 


### PR DESCRIPTION
elder set bonus now properly affects only the pets the player summons, due to the following change
changed FU's petspawner.lua implementation to allow application of persistent status effects.
changed petspawner.lua so that pets inherit 'protection' bonuses based on the player's current stats, rather than just armor added ones. (still functions the same as before, adding bonus health instead of more protection). pets now get their powermultiplier directly from the player, rather than from the player's armor. this allows for pets to be more useful by scaling more with player buffs, but is balanced by it working in both directions (such as Glass Cannon)

shifted several status effects to use effectUtil implementation, in preparation for some special handling for starrypy blocking entity messages of 'applyStatusEffect'  from the player

fixed vanilla lockdoor metamaterial collision kind, thus making them properly block light again

fixed haleflowerpetal  tooltip listing wrong value

fixed damage scaling on paintings
fixed counsellor series crewmate buffs being 100x strong as intended