### PR TITLE
Cultist Lair microdungeon to macrodungeon

### DIFF
--- a/biomes/surface/arborealdark.biome
+++ b/biomes/surface/arborealdark.biome
@@ -550,7 +550,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fulabs", "fuencounters", "newhumanmicro", "newavianmicro", "minigreenruins", "fuencountercultist", "fuhives", "furedhives", "furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter","cultistlair" ]
+          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fulabs", "fuencounters", "newhumanmicro", "newavianmicro", "minigreenruins", "fuencountercultist", "fuhives", "furedhives", "furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter" ]
         },
         {
           "mode" : "floor",

--- a/biomes/surface/arcticdark.biome
+++ b/biomes/surface/arcticdark.biome
@@ -374,7 +374,7 @@
         "distribution" : "/biomes/distributions.config:overgroundChests",
 
         "type" : "microdungeon",
-        "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fuencounters",  "fulabs", "fubandits", "newhumanmicro", "newavianmicro", "furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter","cultistlair" ]
+        "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fuencounters",  "fulabs", "fubandits", "newhumanmicro", "newavianmicro", "furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter" ]
       },      
       
       {

--- a/biomes/surface/atropusdark.biome
+++ b/biomes/surface/atropusdark.biome
@@ -571,7 +571,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "fuencountercultist", "fuapexencounter", "furandomencounter","cultistlair" ]
+          "microdungeons" : [ "fuencountercultist", "fuapexencounter", "furandomencounter" ]
         },           
         {
           "mode" : "floor",

--- a/biomes/surface/chromatic.biome
+++ b/biomes/surface/chromatic.biome
@@ -287,7 +287,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fuencounters", "fulabs", "fuhives", "furedhives", "newhumanmicro", "newavianmicro", "minigreenruins", "furandomencounter", "fuglitchencounter", "fuhumanencounter","cultistlair" ]
+          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fuencounters", "fulabs", "fuhives", "furedhives", "newhumanmicro", "newavianmicro", "minigreenruins", "furandomencounter", "fuglitchencounter", "fuhumanencounter" ]
         },       
       {
         "mode" : "floor",

--- a/biomes/surface/desertwastes.biome
+++ b/biomes/surface/desertwastes.biome
@@ -322,7 +322,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fuencounters",  "fulabs", "fuelders", "fuhives", "furedhives", "newhumanmicro", "newavianmicro", "minigreenruins", "furandomencounter", "fuglitchencounter", "fuavianencounter","cultistlair" ]
+          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fuencounters",  "fulabs", "fuelders", "fuhives", "furedhives", "newhumanmicro", "newavianmicro", "minigreenruins", "furandomencounter", "fuglitchencounter", "fuavianencounter" ]
         },
       {
         "mode" : "floor",

--- a/biomes/surface/desertwastesdark.biome
+++ b/biomes/surface/desertwastesdark.biome
@@ -395,7 +395,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fuencounters",  "fulabs", "fuelders", "fuhives", "furedhives", "newhumanmicro", "newavianmicro", "minigreenruins", "furandomencounter", "fuglitchencounter", "fuavianencounter","cultistlair" ]
+          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fuencounters",  "fulabs", "fuelders", "fuhives", "furedhives", "newhumanmicro", "newavianmicro", "minigreenruins", "furandomencounter", "fuglitchencounter", "fuavianencounter" ]
         },
       {
         "mode" : "floor",

--- a/biomes/surface/icewastedark.biome
+++ b/biomes/surface/icewastedark.biome
@@ -266,7 +266,7 @@
           "distribution" : "/biomes/distributions.config:scatteredSmall",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "ice", "fuelders", "icewastemini","cultistlair" ]
+          "microdungeons" : [ "ice", "fuelders", "icewastemini" ]
         },
         {
           "mode" : "floor",

--- a/biomes/surface/infernusdark.biome
+++ b/biomes/surface/infernusdark.biome
@@ -276,7 +276,7 @@
           "distribution" : "/biomes/distributions.config:tiyDistTerrainfeatures",
 
           "type" : "microdungeon",
-          "microdungeons" : [  "randomencounterfire", "shroomencounterfire", "eyeencounterfire", "colourfulencounterfire", "boneencounterfire", "humanencounterfire", "glitchencounterfire", "apexencounterfire", "avianencounterfire", "floranencounterfire", "frozenvolcanicmini", "canyonmini", "terrainfeatures", "rockclimb","rocktunnel",  "toxicmicrodungeons", "sandstone", "blockpile", "loops", "flats","cultistlair" ]
+          "microdungeons" : [  "randomencounterfire", "shroomencounterfire", "eyeencounterfire", "colourfulencounterfire", "boneencounterfire", "humanencounterfire", "glitchencounterfire", "apexencounterfire", "avianencounterfire", "floranencounterfire", "frozenvolcanicmini", "canyonmini", "terrainfeatures", "rockclimb","rocktunnel",  "toxicmicrodungeons", "sandstone", "blockpile", "loops", "flats" ]
         },
         {
           "mode" : "floor",

--- a/biomes/surface/magmadark.biome
+++ b/biomes/surface/magmadark.biome
@@ -351,7 +351,7 @@
   "distribution" : "/biomes/distributions.config:mainBiomeEncounterDungeon",
 
   "type" : "microdungeon",
-  "microdungeons" : [ "randomencounterfire", "shroomencounterfire", "eyeencounterfire", "colourfulencounterfire", "boneencounterfire", "humanencounterfire", "glitchencounterfire", "apexencounterfire", "avianencounterfire", "floranencounterfire", "fulabs", "fubandits", "newhumanmicro", "newavianmicro","furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter","cultistlair" ]
+  "microdungeons" : [ "randomencounterfire", "shroomencounterfire", "eyeencounterfire", "colourfulencounterfire", "boneencounterfire", "humanencounterfire", "glitchencounterfire", "apexencounterfire", "avianencounterfire", "floranencounterfire", "fulabs", "fubandits", "newhumanmicro", "newavianmicro","furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter" ]
   },    
       {
         "mode" : "floor",

--- a/biomes/surface/penumbra.biome
+++ b/biomes/surface/penumbra.biome
@@ -348,7 +348,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fuelders", "fubandits", "fuencounters", "furandomencounter", "fuhumanencounter", "fuapexencounter", "alienmicrodungeons", "furedhives","cultistlair" ]
+          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fuelders", "fubandits", "fuencounters", "furandomencounter", "fuhumanencounter", "fuapexencounter", "alienmicrodungeons", "furedhives" ]
         },        
         {
           "mode" : "floor",

--- a/biomes/surface/protoworld.biome
+++ b/biomes/surface/protoworld.biome
@@ -468,7 +468,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "randomencounter", "alienmicrodungeons", "wastelandbuildings", "rarebuildings", "furedhives", "fuencounters", "fulabs", "fuhives", "fuelders", "fuavali", "fubandits","cultistlair" ]
+          "microdungeons" : [ "randomencounter", "alienmicrodungeons", "wastelandbuildings", "rarebuildings", "furedhives", "fuencounters", "fulabs", "fuhives", "fuelders", "fuavali", "fubandits" ]
         }
       ]
     },

--- a/biomes/surface/tarball.biome
+++ b/biomes/surface/tarball.biome
@@ -378,7 +378,7 @@
 	  "distribution" : "/biomes/distributions.config:mainBiomeEncounterDungeon",
 
 	  "type" : "microdungeon",
-	  "microdungeons" : [ "randomencounterfire", "shroomencounterfire", "eyeencounterfire", "colourfulencounterfire", "boneencounterfire", "humanencounterfire", "glitchencounterfire", "apexencounterfire", "avianencounterfire", "floranencounterfire", "fulabs", "fubandits", "newhumanmicro", "newavianmicro","furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter","cultistlair" ]
+	  "microdungeons" : [ "randomencounterfire", "shroomencounterfire", "eyeencounterfire", "colourfulencounterfire", "boneencounterfire", "humanencounterfire", "glitchencounterfire", "apexencounterfire", "avianencounterfire", "floranencounterfire", "fulabs", "fubandits", "newhumanmicro", "newavianmicro","furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter" ]
 	},
        
         {

--- a/biomes/surface/thickjungle.biome
+++ b/biomes/surface/thickjungle.biome
@@ -509,7 +509,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "furainforest", "fuencounters", "randomencounter", "minigreenruins", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fuavali", "fulabs", "newhumanmicro", "newavianmicro", "fuhives", "furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter","cultistlair" ] 
+          "microdungeons" : [ "furainforest", "fuencounters", "randomencounter", "minigreenruins", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fubandits", "fuavali", "fulabs", "newhumanmicro", "newavianmicro", "fuhives", "furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter" ] 
         },
         {
           "mode" : "floor",

--- a/biomes/surface/tundradark.biome
+++ b/biomes/surface/tundradark.biome
@@ -313,7 +313,7 @@
 	  "distribution" : "/biomes/distributions.config:mainBiomeEncounterDungeon",
 
 	  "type" : "microdungeon",
-	  "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fuencounters", "fulabs", "fubandits", "newhumanmicro", "newavianmicro", "fuhives", "furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter","cultistlair" ]
+	  "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fuencounters", "fulabs", "fubandits", "newhumanmicro", "newavianmicro", "fuhives", "furandomencounter", "fuapexencounter", "fuglitchencounter", "fuavianencounter", "fuhumanencounter" ]
       },    
       {
         "mode" : "floor",

--- a/biomes/surface/urbanwasteland.biome
+++ b/biomes/surface/urbanwasteland.biome
@@ -224,7 +224,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "fuencounters", "fubandits", "randomencounter", "junkmini", "fulabs", "fuwastelanddungeons", "furandomencounter", "fuhumanencounter", "fuapexencounter","cultistlair" ] 
+          "microdungeons" : [ "fuencounters", "fubandits", "randomencounter", "junkmini", "fulabs", "fuwastelanddungeons", "furandomencounter", "fuhumanencounter", "fuapexencounter" ] 
         },
         {
           "mode" : "floor",

--- a/biomes/surface/urbanwasteland2.biome
+++ b/biomes/surface/urbanwasteland2.biome
@@ -224,7 +224,7 @@
           "distribution" : "/biomes/distributions.config:randomEncounter",
 
           "type" : "microdungeon",
-          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fuencounters", "fubandits", "randomencounter", "junkmini", "fulabs", "fuwastelanddungeons", "furandomencounter", "fuhumanencounter", "fuapexencounter","cultistlair" ] 
+          "microdungeons" : [ "randomencounter", "shroomencounter", "eyeencounter", "colourfulencounter", "boneencounter", "humanencounter", "glitchencounter", "floranencounter", "apexencounter", "avianencounter", "fuencounters", "fubandits", "randomencounter", "junkmini", "fulabs", "fuwastelanddungeons", "furandomencounter", "fuhumanencounter", "fuapexencounter" ] 
         },
         {
           "mode" : "floor",

--- a/terrestrial_worlds.config.patch
+++ b/terrestrial_worlds.config.patch
@@ -1328,7 +1328,8 @@
 	  [ 1.0, "fungalden" ],
 	  [1.0, "weaponsfactory"],
 	  [1.0, "greentower"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -1455,7 +1456,8 @@
 	  [ 1.0, "fungalden" ],
 	  [1.0, "weaponsfactory"],
 	  [1.0, "greentower"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -1533,7 +1535,8 @@
 	  [ 1.0, "fungalden" ],
 	  [1.0, "weaponsfactory"],
 	  [1.0, "greentower"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -1849,7 +1852,8 @@
 	  [1.0, "weaponsfactory"],
 	  [1.0, "greentower"],
 	  [1.0, "alienjungleruins"],
-          [1.0, "futreehouse"]
+          [1.0, "futreehouse"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -1934,7 +1938,8 @@
           [1.0, "ship1"],
           [0.5, "fuwreck"],
           [1.0, "dungeoncrawler"],
-          [1.0, "humanprison"]
+          [1.0, "humanprison"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -2301,7 +2306,8 @@
 	  [1.0, "fungalden"],
 	  [1.0, "weaponsfactory"],
 	  [1.0, "greentower"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -2377,7 +2383,8 @@
 	  [1.0, "novakidoutlawcamp"],
 	  [3.0, "weaponsfactory"],
 	  [1.0, "greentower"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -2449,7 +2456,8 @@
 	  [1.0, "novakidoutlawcamp"],
 	  [3.0, "weaponsfactory"],
 	  [1.0, "greentower"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -2664,7 +2672,8 @@
 	  [1.0, "novakidoutlawcamp"],
 	  [1.0, "oceanfrontcity"],
 	  [3.0, "weaponsfactory"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -2892,7 +2901,8 @@
           [1.0, "apextowerblock"],
           [1.0, "humanbunker"],
 	  [3.0, "weaponsfactory"],
-          [1.0, "fuscifidungeon"]
+          [1.0, "fuscifidungeon"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -3040,7 +3050,8 @@
           [1.0, "humanbunker"],
           [1.0, "fuscifidungeon"],
 	  [1.0, "aviandeeppyramid"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
            ]
          },
         "subsurface" : {
@@ -3470,7 +3481,8 @@
 	  [1.0, "novakidoutlawcamp"],
 	  [1.0, "fungalden"],
 	  [1.0, "weaponsfactory"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -3559,7 +3571,8 @@
 	  [1.0, "fungalden"],
 	  [1.0, "weaponsfactory"],
 	  [1.0, "greentower"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -3909,7 +3922,8 @@
           [1.0, "fuscifidungeon"],
 	  [1.0, "aviandeeppyramid"],
 	  [1.0, "weaponsfactory"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
            ]
          },
         "subsurface" : {
@@ -4036,7 +4050,8 @@
 	  [1.0, "fungalden"],
 	  [1.0, "weaponsfactory"],
 	  [1.0, "greentower"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -4121,7 +4136,8 @@
 	  [1.0, "humanapartments"],
 	  [1.0, "novakidoutlawcamp"],
 	  [3.0, "weaponsfactory"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {
@@ -4208,7 +4224,8 @@
 	  [1.0, "humanapartments"],
 	  [1.0, "novakidoutlawcamp"],
 	  [3.0, "weaponsfactory"],
-	  [1.0, "alienjungleruins"]
+	  [1.0, "alienjungleruins"],
+	  [1.0, "cultistlair"]
           ]
         },
         "subsurface" : {


### PR DESCRIPTION
After very thorough testing, I have found that the Cultist Lair will not spawn as a microdungeon (too big), so it has to be moved to a macrodungeon for it to spawn naturally.