### PR TITLE
labels

### DIFF
--- a/interface/bees/industrialcentrifuge/industrialcentrifuge.config
+++ b/interface/bees/industrialcentrifuge/industrialcentrifuge.config
@@ -53,6 +53,14 @@
       "value" : "Items",
       "hAnchor" : "mid",
       "position" : [160, 109]
+    },
+    "clear" : {
+      "type" : "button",
+      "base" : "/interface/button.png",
+      "hover" : "/interface/buttonhover.png",
+      "press" : "/interface/buttonhover.png",
+      "caption" : "Take all",
+      "position" : [56, 8]
     }
   }
 }

--- a/interface/bees/industrialcentrifuge/industrialcentrifuge2.config
+++ b/interface/bees/industrialcentrifuge/industrialcentrifuge2.config
@@ -53,6 +53,14 @@
       "value" : "Items",
       "hAnchor" : "mid",
       "position" : [160, 109]
+    },
+    "clear" : {
+      "type" : "button",
+      "base" : "/interface/button.png",
+      "hover" : "/interface/buttonhover.png",
+      "press" : "/interface/buttonhover.png",
+      "caption" : "Take all",
+      "position" : [56, 8]
     }
   }
 }

--- a/interface/bees/industrialcentrifuge/industrialcentrifuge3.config
+++ b/interface/bees/industrialcentrifuge/industrialcentrifuge3.config
@@ -53,6 +53,14 @@
       "value" : "Items",
       "hAnchor" : "mid",
       "position" : [160, 109]
+    },
+    "clear" : {
+      "type" : "button",
+      "base" : "/interface/button.png",
+      "hover" : "/interface/buttonhover.png",
+      "press" : "/interface/buttonhover.png",
+      "caption" : "Take all",
+      "position" : [56, 8]
     }
   }
 }

--- a/interface/bees/industrialcentrifuge/jarringmachine.config
+++ b/interface/bees/industrialcentrifuge/jarringmachine.config
@@ -53,6 +53,14 @@
       "value" : "Items",
       "hAnchor" : "mid",
       "position" : [160, 109]
+    },
+    "clear" : {
+      "type" : "button",
+      "base" : "/interface/button.png",
+      "hover" : "/interface/buttonhover.png",
+      "press" : "/interface/buttonhover.png",
+      "caption" : "Take all",
+      "position" : [56, 8]
     }
   }
 }

--- a/interface/bees/ironcentrifuge/ironcentrifuge.config
+++ b/interface/bees/ironcentrifuge/ironcentrifuge.config
@@ -53,6 +53,14 @@
       "value" : "Items",
       "hAnchor" : "mid",
       "position" : [160, 109]
+    },
+    "clear" : {
+      "type" : "button",
+      "base" : "/interface/button.png",
+      "hover" : "/interface/buttonhover.png",
+      "press" : "/interface/buttonhover.png",
+      "caption" : "Take all",
+      "position" : [56, 8]
     }
   }
 }

--- a/interface/bees/woodencentrifuge/woodencentrifuge.config
+++ b/interface/bees/woodencentrifuge/woodencentrifuge.config
@@ -53,6 +53,14 @@
       "value" : "Items",
       "hAnchor" : "mid",
       "position" : [160, 109]
+    },
+    "clear" : {
+      "type" : "button",
+      "base" : "/interface/button.png",
+      "hover" : "/interface/buttonhover.png",
+      "press" : "/interface/buttonhover.png",
+      "caption" : "Take all",
+      "position" : [56, 8]
     }
   }
 }

--- a/items/augments/extraenergisingaugment.augment
+++ b/items/augments/extraenergisingaugment.augment
@@ -6,7 +6,7 @@
   "category" : "eppAugment",
   "inventoryIcon" : "extraenergisingaugment.png",
   "description" : "^green;25^reset;% More Energy
-^green;15^reset; Less Energy Block Time
+^green;15^reset;% Less Energy Block Time
 ^yellow;Large energy regen boost^reset;",
   "shortdescription" : "Energising Augment",
 

--- a/items/buildscripts/buildweapon.lua
+++ b/items/buildscripts/buildweapon.lua
@@ -51,7 +51,7 @@ function build(directory, config, parameters, level, seed)
   if builderConfig.elementalConfig then
     util.mergeTable(config, builderConfig.elementalConfig[elementalType])
   end
-  if config.altAbility and config.altAbility.elementalConfig then
+  if config.altAbility and config.altAbility.elementalConfig and config.altAbility.elementalConfig[elementalType] then
     util.mergeTable(config.altAbility, config.altAbility.elementalConfig[elementalType])
   end
 

--- a/items/generic/desserts/plutoniumcookie.consumable
+++ b/items/generic/desserts/plutoniumcookie.consumable
@@ -13,7 +13,7 @@
         "duration": 300
       },
       {
-        "effect": "ffextremeradiationimmunity",
+        "effect": "ffextremeradiationimmunityicon",
         "duration": 300
       }
     ]

--- a/items/generic/drinks/beer/elderbeer.consumable
+++ b/items/generic/drinks/beer/elderbeer.consumable
@@ -4,7 +4,7 @@
   "price": 1200,
   "category": "drink",
   "inventoryIcon": "elderbeer.png",
-  "description": "Honed from the very essence of dreams...and made into booze. Probably not safe.\n^cyan;+^white;17 ^cyan;Defense ^gray;, ^red;Insane^gray;, ^white;35% ^red;Slow ^gray;, ^red;Buzzed ^gray;(^white;2m^gray;)^reset;",
+  "description": "Honed from the very essence of dreams...and made into booze. Probably not safe.\n^cyan;+^white;17 ^cyan;Defense ^gray;, ^red;Insane^gray;, ^white;35% ^red;Slow ^gray;, ^red;Drunk ^gray;(^white;2m^gray;)^reset;",
   "shortdescription": "Sarkomand Ale",
   "handPosition": [0, -4],
   "tooltipKind": "food",
@@ -28,7 +28,6 @@
       },
       {
         "effect": "booze",
-        "amount": 1,
         "duration": 120
       }
     ]

--- a/items/generic/drinks/beer/kilvratjug.consumable
+++ b/items/generic/drinks/beer/kilvratjug.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "corvexputty",
-        "amount": 1.5,
         "duration": 90
       },
       {

--- a/items/generic/drinks/ciders/perrybottle.consumable
+++ b/items/generic/drinks/ciders/perrybottle.consumable
@@ -4,14 +4,13 @@
   "price" : 2150,
   "category" : "drink",
   "inventoryIcon" : "perrybottle.png",
-  "description" : "Jeroboam of sweet perry!\n^cyan;+^white;15 ^cyan;Defense ^gray;(^white;45s^gray;)\n^white;35% ^red;Slow^gray;, ^red;Drunk ^gray;(^white;1m^gray;)^reset;",
+  "description" : "Jeroboam of sweet perry!\n^cyan;+^white;10 ^cyan;Defense ^gray;(^white;45s^gray;)\n^white;35% ^red;Slow^gray;, ^red;Drunk ^gray;(^white;1m^gray;)^reset;",
   "shortdescription" : "Poire",
   "handPosition" : [0, -2],
   "tooltipKind" : "food",
   "effects" : [ [
     {
-      "effect" : "defense2",
-      "amount" : 15,
+      "effect" : "defenseboost10",
       "duration" : 45
     },
 		{

--- a/items/generic/drinks/ciders/premiumcyanider.consumable
+++ b/items/generic/drinks/ciders/premiumcyanider.consumable
@@ -4,14 +4,13 @@
   "price" : 820,
   "category" : "drink",
   "inventoryIcon" : "premiumcyanider.png",
-  "description" : "Cyanider for the knowledgeable!\n^cyan;+^white;15 ^cyan;Defense ^gray;(^white;45s^gray;)\n^white;35% ^red;Slow^gray;, ^red;Drunk ^gray;(^white;1m^gray;)^reset;",
+  "description" : "Cyanider for the knowledgeable!\n^cyan;+^white;10 ^cyan;Defense ^gray;(^white;45s^gray;)\n^white;35% ^red;Slow^gray;, ^red;Drunk ^gray;(^white;1m^gray;)^reset;",
   "shortdescription" : "Premium Cyanider",
   "handPosition" : [0, -2],
   "tooltipKind" : "food",
   "effects" : [ [
     {
-      "effect" : "defense2",
-      "amount" : 15,
+      "effect" : "defenseboost10",
       "duration" : 45
     },
 		{

--- a/items/generic/drinks/fupinacolada.consumable
+++ b/items/generic/drinks/fupinacolada.consumable
@@ -15,7 +15,6 @@
 		},
 		{
       "effect" : "booze",
-      "amount" : 3,
       "duration" : 60
     }
   ] ],

--- a/items/generic/drinks/rums/agedrum.consumable
+++ b/items/generic/drinks/rums/agedrum.consumable
@@ -15,7 +15,6 @@
 		},
 		{
       "effect" : "booze",
-      "amount" : 3,
       "duration" : 60
     }
   ] ]

--- a/items/generic/drinks/rums/amberrum.consumable
+++ b/items/generic/drinks/rums/amberrum.consumable
@@ -15,7 +15,6 @@
 		},
 		{
       "effect" : "booze",
-      "amount" : 3,
       "duration" : 60
     }
   ] ]

--- a/items/generic/drinks/rums/darkrum.consumable
+++ b/items/generic/drinks/rums/darkrum.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/rums/whiterum.consumable
+++ b/items/generic/drinks/rums/whiterum.consumable
@@ -15,7 +15,6 @@
 		},
 		{
       "effect" : "booze",
-      "amount" : 3,
       "duration" : 60
     }
   ] ]

--- a/items/generic/drinks/sodas/apejuice.consumable
+++ b/items/generic/drinks/sodas/apejuice.consumable
@@ -11,7 +11,6 @@
   "effects" : [ [
     {
       "effect" : "rage",
-      "amount" : 0.3,
       "duration" : 30
     }  
   ] ],

--- a/items/generic/drinks/vodka/appleschnapps.consumable
+++ b/items/generic/drinks/vodka/appleschnapps.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/bananaschnapps.consumable
+++ b/items/generic/drinks/vodka/bananaschnapps.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/blisterwhiskey.consumable
+++ b/items/generic/drinks/vodka/blisterwhiskey.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/bloodbrandy.consumable
+++ b/items/generic/drinks/vodka/bloodbrandy.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/cherryschnapps.consumable
+++ b/items/generic/drinks/vodka/cherryschnapps.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/cinnamonschnapps.consumable
+++ b/items/generic/drinks/vodka/cinnamonschnapps.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/deathvodka.consumable
+++ b/items/generic/drinks/vodka/deathvodka.consumable
@@ -15,7 +15,6 @@
 		},
 		{
       "effect" : "booze",
-      "amount" : 3,
       "duration" : 60
     }
   ] ]

--- a/items/generic/drinks/vodka/grapeschnapps.consumable
+++ b/items/generic/drinks/vodka/grapeschnapps.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/iceglobespirit.consumable
+++ b/items/generic/drinks/vodka/iceglobespirit.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/peachschnapps.consumable
+++ b/items/generic/drinks/vodka/peachschnapps.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/shadowspirits.consumable
+++ b/items/generic/drinks/vodka/shadowspirits.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 60
       }
     ]

--- a/items/generic/drinks/vodka/spirits.consumable
+++ b/items/generic/drinks/vodka/spirits.consumable
@@ -16,7 +16,6 @@
       },
       {
         "effect": "booze",
-        "amount": 3,
         "duration": 10
       }
     ]

--- a/items/generic/food/greghead.consumable
+++ b/items/generic/food/greghead.consumable
@@ -21,7 +21,6 @@
 		},
 		{
       "effect" : "booze",
-      "amount" : 3,
       "duration" : 60
     }
   ] ],    

--- a/items/generic/food/orphanpaste.consumable
+++ b/items/generic/food/orphanpaste.consumable
@@ -11,8 +11,7 @@
     [
       {
         "effect": "maxhealthscalingboostfood",
-        "duration": 75,
-        "healthModifier": 1.1
+        "duration": 75
       }
     ],
 	["madnessgain2"] 

--- a/items/generic/loot/myphisinjector.consumable
+++ b/items/generic/loot/myphisinjector.consumable
@@ -10,10 +10,10 @@
   "effects": [
     [
       "madnessgain05",
-      { "effect": "strongcoffee4", "duration": 220, "resistanceAmount": 20 },
-      { "effect": "entropicward", "duration": 220, "resistanceAmount": 20 },
-      { "effect": "booze3", "duration": 220, "resistanceAmount": 20 },
-      { "effect": "stun", "duration": 220, "resistanceAmount": 20 }
+      { "effect": "strongcoffee4", "duration": 220 },
+      { "effect": "entropicward", "duration": 220 },
+      { "effect": "booze3", "duration": 220 },
+      { "effect": "stun", "duration": 220 }
     ]
   ],
   "blockingEffects": ["strongcoffee4"]

--- a/items/generic/other/reactivegel2.consumable
+++ b/items/generic/other/reactivegel2.consumable
@@ -9,8 +9,7 @@
   "learnBlueprintsOnPickup" : ["reactivegel3"],
   "effects" : [ [
     {
-      "effect" : "radienheal2",
-      "healAmount": 75
+      "effect" : "radienheal2"
     }
   ] ],
   "emote" : "",

--- a/items/generic/other/reactivegel3.consumable
+++ b/items/generic/other/reactivegel3.consumable
@@ -9,8 +9,7 @@
   "effects": [
     [
       {
-        "effect": "radienheal3",
-        "healAmount": 100
+        "effect": "radienheal3"
       }
     ]
   ],

--- a/items/generic/produce/avali/kirifruit.consumable
+++ b/items/generic/produce/avali/kirifruit.consumable
@@ -7,7 +7,7 @@
 
 	"tooltipKind": "food",
 	"description": "The fruiting body of a subterranean slime mold\n^yellow;^reset;^cyan;Heal in Darkness 250.25%-252.5% HP^reset;: 5m",
-	"shortdescription": "Kiri Fruit",
+	"shortdescription": "Kiri Fruit [FU]",
 
 	"handPosition": [3, 0],
 	"effects": [

--- a/items/generic/produce/avali/pirufrond.consumable
+++ b/items/generic/produce/avali/pirufrond.consumable
@@ -7,7 +7,7 @@
 
 	"tooltipKind": "food",
 	"description": "^yellow;^reset;^cyan;Swim Boost^reset;, ^cyan;+15% Run^reset;: 2m",
-	"shortdescription": "Piru Frond",
+	"shortdescription": "Piru Frond [FU]",
 
 	"handPosition": [7, 0],
 	"effects": [

--- a/items/generic/produce/blizzberry.consumable
+++ b/items/generic/produce/blizzberry.consumable
@@ -12,7 +12,7 @@
 	"learnBlueprintsOnPickup": ["blizzardcannon"],
 	"effects": [
 		[{
-				"effect": "ffextremecoldimmunity",
+				"effect": "ffextremecoldimmunityicon",
 				"duration": 120
 			},
 			{

--- a/items/generic/produce/guam.consumable
+++ b/items/generic/produce/guam.consumable
@@ -11,7 +11,7 @@
 
 	"effects": [
 		[{
-			"effect": "ffextremeradiationimmunity",
+			"effect": "ffextremeradiationimmunityicon",
 			"duration": 180
 		}]
 	],

--- a/items/generic/produce/ise3/kramilspine.consumable
+++ b/items/generic/produce/ise3/kramilspine.consumable
@@ -22,7 +22,7 @@
 				"duration": 120
 			},
 			{
-				"effect": "ffextremecoldimmunity",
+				"effect": "ffextremecoldimmunityicon",
 				"duration": 120
 			}
 		]

--- a/npcs/crew/crewmemberarctic.npctype
+++ b/npcs/crew/crewmemberarctic.npctype
@@ -25,7 +25,7 @@
           {
             // Ephemeral effects gained upon leaving the ship
             "type" : "EphemeralEffect",
-            "effect" : "ffextremecoldimmunity",
+            "effect" : "ffextremecoldimmunityicon",
             "duration" : 300
           },         
           {

--- a/npcs/crew/crewmemberbiohazard.npctype
+++ b/npcs/crew/crewmemberbiohazard.npctype
@@ -26,7 +26,7 @@
           {
             // Ephemeral effects gained upon leaving the ship
             "type" : "EphemeralEffect",
-            "effect" : "ffextremeradiationimmunity",
+            "effect" : "ffextremeradiationimmunityicon",
             "duration" : 300
           },         
           {

--- a/npcs/crew/crewmemberradien.npctype
+++ b/npcs/crew/crewmemberradien.npctype
@@ -26,7 +26,7 @@
           {
             // Ephemeral effects gained upon leaving the ship
             "type" : "EphemeralEffect",
-            "effect" : "ffextremeradiationimmunity",
+            "effect" : "ffextremeradiationimmunityicon",
             "duration" : 300
           }
         ],

--- a/objects/farmables/a_avali/kirifruitseed.object
+++ b/objects/farmables/a_avali/kirifruitseed.object
@@ -4,7 +4,7 @@
   "rarity" : "Common",
   "category" : "seed",
   "description" : "The fruiting body of a subterranean slime mold. This one has already begun sporing.",
-  "shortdescription" : "Sporing Kiri Fruit",
+  "shortdescription" : "Sporing Kiri Fruit [FU]",
   "objectType" : "farmable",
   "printable" : false,
   "price" : 22,

--- a/objects/farmables/a_avali/piruseed.object
+++ b/objects/farmables/a_avali/piruseed.object
@@ -4,7 +4,7 @@
   "rarity" : "Common",
   "category" : "seed",
   "description" : "Small, barnacle-like colonies which grow long frond-like feeding filaments.",
-  "shortdescription" : "Piru Colony",
+  "shortdescription" : "Piru Colony [FU]",
   "objectType" : "farmable",
   "printable" : false,
   "price" : 22,

--- a/objects/farmables/a_avali/wildkirifruitseed.object
+++ b/objects/farmables/a_avali/wildkirifruitseed.object
@@ -4,7 +4,7 @@
   "rarity" : "Common",
   "category" : "seed",
   "description" : "The fruiting body of a subterranean slime mold. This one has already begun sporing.",
-  "shortdescription" : "Sporing Kiri Fruit",
+  "shortdescription" : "Sporing Kiri Fruit [FU]",
   "objectType" : "farmable",
   "printable" : false,
   "price" : 300,

--- a/objects/farmables/a_avali/wildpiruseed.object
+++ b/objects/farmables/a_avali/wildpiruseed.object
@@ -4,7 +4,7 @@
   "rarity" : "Common",
   "category" : "seed",
   "description" : "Small, barnacle-like colonies which grow long frond-like feeding filaments.",
-  "shortdescription" : "Piru Colony",
+  "shortdescription" : "Piru Colony [FU]",
   "objectType" : "farmable",
   "printable" : false,
   "price" : 300,

--- a/objects/power/fu_blastfurnace/fu_blastfurnace.config
+++ b/objects/power/fu_blastfurnace/fu_blastfurnace.config
@@ -35,7 +35,7 @@
       "hover" : "/interface/buttonhover.png",
       "press" : "/interface/buttonhover.png",
       "caption" : "Take all",
-      "position" : [56, 18]
+      "position" : [56, 12]
     }
   }
 }

--- a/objects/power/isn_arcsmelter/isn_arcsmelter.config
+++ b/objects/power/isn_arcsmelter/isn_arcsmelter.config
@@ -35,7 +35,7 @@
       "hover" : "/interface/buttonhover.png",
       "press" : "/interface/buttonhover.png",
       "caption" : "Take all",
-      "position" : [56, 18]
-    }  
+      "position" : [56, 12]
+    }
   }
 }

--- a/scripts/effectUtil.lua
+++ b/scripts/effectUtil.lua
@@ -78,20 +78,27 @@ function effectUtil.effectTypesInRange(effect,range,types,duration,teamType)
 		return 0
 	end
 	local pos=effectUtil.getPos()
-	local buffer=world.entityQuery(pos,range,{includedTypes=types or {"creature"}})
 	local rVal=0
-	teamType=teamType or "all"
+	if effectUtil.getSelfType()=="player" then
+		local data={}
+		data.messageFunctionArgs={effect,range,types,duration,teamType}
+		data.messenger=effectUtil.getSelf()
+		 world.spawnStagehand(pos,"effectUtilStarryPyHelper",{messageData=data})
+	else
+		local buffer=world.entityQuery(pos,range,{includedTypes=types or {"creature"}})
+		teamType=teamType or "all"
 
-	for _,id in pairs(buffer) do
-		if teamType == "all" then
-			if effectUtil.effectTarget(id,effect,duration) then
-				rVal=rVal+1
-			end
-		else
-			local teamData=world.entityDamageTeam(id)
-			if teamData.type==teamType then
+		for _,id in pairs(buffer) do
+			if teamType == "all" then
 				if effectUtil.effectTarget(id,effect,duration) then
 					rVal=rVal+1
+				end
+			else
+				local teamData=world.entityDamageTeam(id)
+				if teamData.type==teamType then
+					if effectUtil.effectTarget(id,effect,duration) then
+						rVal=rVal+1
+					end
 				end
 			end
 		end

--- a/stagehands/effectUtilStarryPyHelper.lua
+++ b/stagehands/effectUtilStarryPyHelper.lua
@@ -1,0 +1,13 @@
+require "/scripts/effectUtil.lua"
+
+function init()
+	self = config.getParameter("messageData")
+end
+
+function update(dt)
+	if self and self.messageFunctionArgs and self.messenger and world.entityExists(self.messenger) and world.entityType(self.messenger) == "player" then
+		sb.logInfo("EffectUtilHelper: %s applied: %s",world.entityName(self.messenger),self.messageFunctionArgs)
+		effectUtil.effectTypesInRange(table.unpack(self.messageFunctionArgs))	
+	end
+	stagehand.die()
+end

--- a/stagehands/effectUtilStarryPyHelper.stagehand
+++ b/stagehands/effectUtilStarryPyHelper.stagehand
@@ -1,0 +1,9 @@
+{
+    "type" : "effectUtilStarryPyHelper",
+
+    "scripts" : ["/stagehands/effectUtilStarryPyHelper.lua"],
+    "scriptDelta" : 10,
+
+    "object" : 0,
+    "disable" :true
+}

--- a/stats/effects/fu_effects/capturebot/warpedcapture.lua
+++ b/stats/effects/fu_effects/capturebot/warpedcapture.lua
@@ -3,16 +3,20 @@ require "/scripts/companions/util.lua"
 require "/scripts/messageutil.lua"
 
 function init()
-	if world.isMonster(entity.id()) then
+	eType=world.entityType(entity.id())
+	if not eType then return end
+	if eType=="monster" then
 		effect.setParentDirectives(config.getParameter("directives", ""))
 		effect.addStatModifierGroup({{stat = "deathbombDud", amount = 1}})
 		isMonster=true
 	end
 	if not blocker then blocker=config.getParameter("blocker","warpedcapture") end
+	initDone=true
 end
 
 
 function update(dt)
+	if not initDone then init() end
 	if isMonster then
 		hit()
 	end
@@ -38,5 +42,6 @@ end
 
 function spawnFilledPod(pet)
   local pod = createFilledPod(pet)
-  world.spawnItem(pod.name, mcontroller.position(), pod.count, pod.parameters)
+  --world.spawnItem(pod.name, mcontroller.position(), pod.count, pod.parameters)
+  world.spawnItem(pod, mcontroller.position())
 end

--- a/stats/effects/fu_effects/capturebot/warpedcapture.statuseffect
+++ b/stats/effects/fu_effects/capturebot/warpedcapture.statuseffect
@@ -1,6 +1,5 @@
 {
   "name" : "warpedcapture",
-  "blockingStat" : "stunImmunity",
 
   "effectConfig" : {
 	"blocker":"warpedcapture",

--- a/stats/effects/fu_immunityeffects/ffextremecoldimmunityicon.statuseffect
+++ b/stats/effects/fu_immunityeffects/ffextremecoldimmunityicon.statuseffect
@@ -1,8 +1,20 @@
 {
   "name" : "ffextremecoldimmunityicon",
-  "effectConfig" : {},
-
-  "scripts" : [],
+	"effectConfig": {
+		"stats": [{
+				"stat": "ffextremecoldImmunity",
+				"amount": 1
+			},
+			{
+				"stat": "biomecoldImmunity",
+				"amount": 1
+			}
+		]
+	},
+	"defaultDuration": 300,
+	"scripts": [
+		"/stats/effects/fu_genericStatApplier.lua"
+	],
   "label" : "X-Cold Shield",
   "icon" : "/interface/statuses/biomecold.png"
 }

--- a/stats/effects/fu_immunityeffects/ffextremeradiationimmunityicon.statuseffect
+++ b/stats/effects/fu_immunityeffects/ffextremeradiationimmunityicon.statuseffect
@@ -1,5 +1,24 @@
 {
   "name" : "ffextremeradiationimmunityicon",  
   "label" : "X-Rad Shield",
+  "effectConfig": {
+		"stats": [{
+				"stat": "ffextremeradiationImmunity",
+				"amount": 1
+			},
+			{
+				"stat": "biomeradiationImmunity",
+				"amount": 1
+			},
+			{
+				"stat": "radiationburnImmunity",
+				"amount": 1
+			}
+		]
+	},
+	"defaultDuration": 300,
+	"scripts": [
+		"/stats/effects/fu_genericStatApplier.lua"
+	],
   "icon" : "/interface/statuses/biomeradioactive.png"
 }


### PR DESCRIPTION
added '[FU]' tag to avali produce and plants  for easier differentiation
small fix for warpedcapture
adjusted arctic/radiation immunity applying crewmembers: they now apply a version with an icon, for tracking. so do  related foods.
implemented workaround for starrypy server owners using the message blocker plugin, thus resulting in various effects not functioning. workaround includes tracking data, in case someone decides to grief.
corrected energizing augment tooltip not having a % symbol in one line
potential fix for RNG weapons erroring during build sequence, due to missing element data
added 'take all' to centrifuges. adjusted blast furnace and arc smelter 'take all' downward