### PR TITLE
fix

### DIFF
--- a/interface/scripted/fuweaponupgrade/fuweaponupgradegui.lua
+++ b/interface/scripted/fuweaponupgrade/fuweaponupgradegui.lua
@@ -68,9 +68,15 @@ end
 
 function populateItemList(forceRepop)
 	local upgradeableWeaponItems = player.itemsWithTag("upgradeableWeapon")
+	local buffer = {}
 	for i = 1, #upgradeableWeaponItems do
-		upgradeableWeaponItems[i].count = 1
+		if not checkWorn(upgradeableWeaponItems[i]) then
+			upgradeableWeaponItems[i].count = 1
+			table.insert(buffer,upgradeableWeaponItems[i])
+		end
 	end
+	upgradeableWeaponItems=buffer
+	buffer={}
 	
 	widget.setVisible("emptyLabel", #upgradeableWeaponItems == 0)
 	
@@ -158,11 +164,22 @@ function doUpgrade()
 	end
 end
 
+function checkWorn(item)
+	for _,slot in pairs({"head", "chest", "legs", "back", "headCosmetic", "chestCosmetic", "legsCosmetic", "backCosmetic"}) do
+		local compTo=player.equippedItem(slot)
+		if compare(compTo,item) then return true end
+	end
+	return false
+end
+
 function upgrade(fullUpgrade)
 	local selectedData = widget.getData(string.format("%s.%s", self.itemList, self.selectedItem))
 	local upgradeItem = self.upgradeableWeaponItems[selectedData.index]
 	
 	if upgradeItem then
+		if checkWorn(upgradeItem) then
+			return
+		end
 		local consumedItem = player.consumeItem(upgradeItem, false, true)
 		if consumedItem then
 			local consumedCurrency = player.consumeCurrency("essence", (fullUpgrade and selectedData.priceMax or selectedData.price))

--- a/items/armors/costumes/midnightclothes/midnight.chest
+++ b/items/armors/costumes/midnightclothes/midnight.chest
@@ -7,7 +7,7 @@
   "description" : "Dark as night.",
   "shortdescription" : "Midnight Shirt",
   "category" : "chestarmour",
-  "tooltipKind" : "armornew2",
+  "tooltipKind" : "armor",
 
   "maleFrames" : {
     "body" : "chestm.png",

--- a/items/armors/costumes/midnightclothes/midnight.legs
+++ b/items/armors/costumes/midnightclothes/midnight.legs
@@ -7,7 +7,7 @@
   "description" : "Dark as night.",
   "shortdescription" : "Midnight Pants",
   "category" : "legarmour",
-  "tooltipKind" : "armornew2",
+  "tooltipKind" : "armor",
 
   "maleFrames" : "pants.png",
   "femaleFrames" : "pants.png",

--- a/items/generic/produce/ghostmushroom.consumable
+++ b/items/generic/produce/ghostmushroom.consumable
@@ -6,13 +6,13 @@
 	"price": 20,
 
 	"tooltipKind": "food",
-	"description": "^yellow;^reset;^cyan;Invisibility^reset;: 1m\n^yellow;^reset;^cyan;Invisible to Erchius Horrors^reset;: 5m",
+	"description": "^yellow;^reset;^cyan;Invisible to Erchius Horrors^reset;: 5m",
 	"shortdescription": "Ghost Mushroom",
 
 	"effects": [
 		[{
 				"effect": "camouflage55",
-				"duration": 60
+				"duration": 300
 			},
 			{
 				"effect": "erchiusimmunity",

--- a/stats/effects/fu_effects/glow/fuglow.lua
+++ b/stats/effects/fu_effects/glow/fuglow.lua
@@ -1,7 +1,7 @@
 function init()
   animator.setParticleEmitterOffsetRegion("sparkles", mcontroller.boundBox())
   animator.setParticleEmitterActive("sparkles", true)
-  pd=config.getParameters("parentDirectives","")
+  pd=config.getParameter("parentDirectives","")
   effect.setParentDirectives(pd)
   --color=config.getParameters("color",{255,255,255})
 end

--- a/stats/effects/fu_effects/mage_shield/regeneratingshield_energy-100-10-3.statuseffect
+++ b/stats/effects/fu_effects/mage_shield/regeneratingshield_energy-100-10-3.statuseffect
@@ -1,0 +1,14 @@
+{
+  "name" : "regeneratingshield_energy-100-10-3",
+  "defaultDuration" : 30,
+
+  "scripts" : [
+    "regeneratingshield.lua"
+  ],
+  "effectConfig" : {
+    "shieldcap" : 1.0,
+	"resource":"energy",
+	"shieldBlockTime":3,
+	"shieldRegenRate":0.1
+  }
+}


### PR DESCRIPTION
fixed for fuglow.lua
removed 'invisibility' tooltip data from ghost mushroom. made 'camoflage' last as long as ghost immunity. camo is purely visual anyway.
fixed a duplication exploit with the crucible. you can no longer upgrade items matching anything worn, as a result.
fixed midnight top/bottom tooltips.