### PR TITLE
converter fixes

### DIFF
--- a/objects/minibiome/precursor/precursorconverter/console.animation
+++ b/objects/minibiome/precursor/precursorconverter/console.animation
@@ -14,50 +14,50 @@
 					}
 				}
 			}
-		}
-	},
+		},
 
-	"parts": {
-		"samplingarrayanim": {
-			"properties": {
-				"centered": false,
-				"zLevel": 1,
-				"fullbright": true
-			},
+		"parts": {
+			"samplingarrayanim": {
+				"properties": {
+					"centered": false,
+					"zLevel": 1,
+					"fullbright": true
+				},
 
-			"partStates": {
-				"samplingarrayanim": {
-					"idle": {
-						"properties": {
-							"image": "<partImage>:default.default"
-						}
-					},
+				"partStates": {
+					"samplingarrayanim": {
+						"idle": {
+							"properties": {
+								"image": "<partImage>:<color>.0"
+							}
+						},
 
-					"working": {
-						"properties": {
-							"image": "<partImage>:default.<frame>"
+						"working": {
+							"properties": {
+								"image": "<partImage>:<color>.<frame>"
+							}
 						}
 					}
 				}
-			}
-		},
-		"samplingarrayanimlit": {
-			"properties": {
-				"centered": false,
-				"zLevel": 2
 			},
+			"samplingarrayanimlit": {
+				"properties": {
+					"centered": false,
+					"zLevel": 2
+				},
 
-			"partStates": {
-				"samplingarrayanim": {
-					"idle": {
-						"properties": {
-							"image": "<partImage>:default.default"
-						}
-					},
+				"partStates": {
+					"samplingarrayanim": {
+						"idle": {
+							"properties": {
+								"image": "<partImage>:<color>.0"
+							}
+						},
 
-					"working": {
-						"properties": {
-							"image": "<partImage>:default.<frame>"
+						"working": {
+							"properties": {
+								"image": "<partImage>:<color>.<frame>"
+							}
 						}
 					}
 				}

--- a/objects/minibiome/precursor/precursorconverter/console.object
+++ b/objects/minibiome/precursor/precursorconverter/console.object
@@ -45,7 +45,8 @@
 
   "animation" : "console.animation",
   "animationParts" : {
-    "samplingarrayanim" : "console.png"
+    "samplingarrayanim" : "console.png",
+	"samplingarrayanimlit" : "consolelit.png"
   },
   "scripts" : [ "/objects/minibiome/precursor/precursorconverter/converter.lua",
                 "/scripts/npcToyObject.lua" ],

--- a/objects/minibiome/precursor/precursorconverter/console2.object
+++ b/objects/minibiome/precursor/precursorconverter/console2.object
@@ -45,7 +45,8 @@
 
   "animation" : "console.animation",
   "animationParts" : {
-    "samplingarrayanim" : "console.png"
+    "samplingarrayanim" : "console.png",
+    "samplingarrayanimlit" : "consolelit.png"
   },
   "scripts" : [ "/objects/minibiome/precursor/precursorconverter/converter.lua",
                 "/scripts/npcToyObject.lua" ],

--- a/objects/minibiome/precursor/precursorconverter/converter.lua
+++ b/objects/minibiome/precursor/precursorconverter/converter.lua
@@ -94,6 +94,7 @@ function update(dt)
 		deltaTime=deltaTime+dt
 	end
     storage.timer = storage.timer - dt
+	
     if storage.timer <= 0 then
         if storage.crafting then
             for k,v in pairs(storage.output) do
@@ -114,13 +115,13 @@ function update(dt)
             storage.output = {}
 			storage.inputs = {}
             storage.timer = self.mintick --reset timer to a safe minimum
-            animator.setAnimationState("samplingarrayanim", "idle")
         end
 
         if not storage.crafting and storage.timer <= 0 then --make sure we didn't just finish crafting
             if not startCrafting(getValidRecipes(getInputContents())) then storage.timer = self.mintick end --set timeout if there were no recipes
         end
     end
+	animator.setAnimationState("samplingarrayanim", storage.crafting and "working" or "idle")
 end
 
 
@@ -141,7 +142,7 @@ function startCrafting(result)
 		storage.crafting = true
 		storage.timer = result.time
 		storage.output = result.outputs
-		animator.setAnimationState("samplingarrayanim", "working")
+		--animator.setAnimationState("samplingarrayanim", "working")
 
 		return true
 	end

--- a/objects/minibiome/precursor/precursorconverter/converter.lua
+++ b/objects/minibiome/precursor/precursorconverter/converter.lua
@@ -112,8 +112,8 @@ function update(dt)
                 end
             end
             storage.crafting = false
-            storage.output = {}
-			storage.inputs = {}
+            storage.output = nil
+			storage.inputs = nil
             storage.timer = self.mintick --reset timer to a safe minimum
         end
 

--- a/quests/bounty/fu_asraNoxSailFix.lua
+++ b/quests/bounty/fu_asraNoxSailFix.lua
@@ -1,4 +1,12 @@
 function init()
 	message.setHandler("swansongFailed",quest.fail)
 	message.setHandler("swansongCompleted",quest.complete)
+	message.setHandler("swansongDead",quest.complete)
+	script.setUpdateDelta(360)
+end
+
+function update(dt)
+	if player.hasCompletedQuest("cultist_mission1") then
+		quest.complete()
+	end
 end

--- a/species/saturn.raceeffect
+++ b/species/saturn.raceeffect
@@ -1,5 +1,6 @@
 {
 	"stats": [
+		{"stat": "maxEnergy","effectiveMultiplier": 1.1},
 		{
 			"stat": "maxHealth",
 			"effectiveMultiplier": 0.75
@@ -33,7 +34,7 @@
 
 	"envEffects": [{
 		"biomes": ["lush","forest","thickjungle","arboreal","arborealdark"],
-		"stats": [{"stat": "maxEnergy","effectiveMultiplier": 1.25}]
+		"stats": [{"stat": "maxEnergy","effectiveMultiplier": 1.15}]
 	}],
 
 	"weaponEffects": [

--- a/species/saturn.species.patch
+++ b/species/saturn.species.patch
@@ -17,7 +17,7 @@
 
 ^orange;Environment^reset;: 
   ^green;Lush, Forest, Primeval and Rainforest^reset; biomes:
-    Energy x^green;1.25^reset;.
+    Energy x^green;1.15^reset;.
 
 ^orange;Weapons^reset;: 
   Wand/Staff: Defense x^green;1.2^reset;

--- a/species/saturn2.raceeffect
+++ b/species/saturn2.raceeffect
@@ -1,5 +1,6 @@
 {
 	"stats": [
+		{"stat": "maxHealth","effectiveMultiplier": 1.1},
 		{
 			"stat": "maxEnergy",
 			"effectiveMultiplier": 0.75
@@ -33,7 +34,7 @@
 
 	"envEffects": [{
 		"biomes": ["lush","forest","thickjungle","arboreal","arborealdark"],
-		"stats": [{"stat": "maxHealth","effectiveMultiplier": 1.25}]
+		"stats": [{"stat": "maxHealth","effectiveMultiplier": 1.15}]
 	}],
 
 	"weaponEffects": [

--- a/species/saturn2.species.patch
+++ b/species/saturn2.species.patch
@@ -17,7 +17,7 @@
 
 ^orange;Environment^reset;: 
   ^green;Lush, Forest, Primeval and Rainforest^reset; biomes:
-    Health x^green;1.25^reset;
+    Health x^green;1.15^reset;
 
 ^orange;Weapons^reset;: 
   Wand/Staff: Defense x^green;1.2^reset;

--- a/species/veluu.species
+++ b/species/veluu.species
@@ -10,7 +10,7 @@
   
 ^orange;Perks^reset;:
   Very nimble. Gain ^green;20^reset;% Jump and ^green;8^reset;% Run Speed^reset;. Fall Damage x^green;0.5^reset;
-  ^green;Resist^reset;: +^green;20^reset;% Cold Resist
+  ^green;Resist^reset;: +^green;20^reset;% Cold
   Night Vision
   Tech: ^green;Razor Claws^reset;
   ^cyan;Immune^reset;: Jungle Dirt and Mud

--- a/stats/effects/fu_effects/feedpack/feedpackcrew1.statuseffect
+++ b/stats/effects/fu_effects/feedpack/feedpackcrew1.statuseffect
@@ -5,7 +5,7 @@
     //"timer" : 5,
 	"shipOnly":true,
 	"groundOnly":false,
-	"statModifiers" : [
+	"stats" : [
       {
         "stat" : "foodDelta",
         "baseMultiplier" : 0.5

--- a/stats/effects/fu_effects/feedpack/feedpackcrew1ground.statuseffect
+++ b/stats/effects/fu_effects/feedpack/feedpackcrew1ground.statuseffect
@@ -5,7 +5,7 @@
     //"timer" : 5,
 	"shipOnly":false,
 	"groundOnly":true,
-	"statModifiers" : [
+	"stats" : [
       {
         "stat" : "foodDelta",
         "baseMultiplier" : 0.833333

--- a/stats/effects/fu_effects/feedpack/feedpackcrew2.statuseffect
+++ b/stats/effects/fu_effects/feedpack/feedpackcrew2.statuseffect
@@ -5,7 +5,7 @@
     //"timer" : 3,
 	"shipOnly":true,
 	"groundOnly":false,
-	"statModifiers" : [
+	"stats" : [
       {
         "stat" : "foodDelta",
         "baseMultiplier" : 0.0

--- a/stats/effects/fu_effects/feedpack/feedpackcrew2ground.statuseffect
+++ b/stats/effects/fu_effects/feedpack/feedpackcrew2ground.statuseffect
@@ -3,7 +3,7 @@
   "effectConfig" : { 
     //"regenAmount" : -0.8,
     //"timer" : 3,
-	"statModifiers" : [
+	"stats" : [
       {
         "stat" : "foodDelta",
         "baseMultiplier" : 0.666666667

--- a/stats/effects/fu_effects/feedpack/feedpackcrew3.statuseffect
+++ b/stats/effects/fu_effects/feedpack/feedpackcrew3.statuseffect
@@ -5,7 +5,7 @@
     //"timer" : 1,
 	"shipOnly":true,
 	"groundOnly":false,
-	"statModifiers" : [
+	"stats" : [
       {
         "stat" : "foodDelta",
         "baseMultiplier" : -0.5

--- a/stats/effects/fu_effects/feedpack/feedpackcrew3ground.statuseffect
+++ b/stats/effects/fu_effects/feedpack/feedpackcrew3ground.statuseffect
@@ -5,7 +5,7 @@
     //"timer" : 1,
 	"shipOnly":false,
 	"groundOnly":true,
-	"statModifiers" : [
+	"stats" : [
       {
         "stat" : "foodDelta",
         "baseMultiplier" : 0.5


### PR DESCRIPTION
previous fixes were done wrong, whoops. this addresses some issues with those. no more flashing when it isnt supposed to, and no more harmless error on breaking a converter
fixed feedpackcrew series. I had a parameter named wrong. oops.
Mech fuel UI fixed up. It will no longer empty the item slot when hitting 'empty fuel', and it will no longer consume fuel when it is full. It will also never consume more than it needs to, fuel more than it can, or waste fuel