### PR TITLE
Rework Advanced Liquid Sensor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ Desktop.ini
 *.sublime-project
 *.sublime-workspace
 
+# VS Code settings
+.vscode
+
 # Recycle Bin used on file shares
 $RECYCLE.BIN/`
 

--- a/interface/swtjc_wp_advancedliquidsensor/swtjc_wp_advancedliquidsensor.config
+++ b/interface/swtjc_wp_advancedliquidsensor/swtjc_wp_advancedliquidsensor.config
@@ -1,0 +1,24 @@
+{
+	"gui" : {
+		"background" : {
+			"type" : "background",
+			"fileHeader" : "/interface/smartbox/header.png",
+			"fileBody" : "/interface/smartbox/singular.png"
+		},
+		"close" : {
+			"type" : "button",
+			"base" : "/interface/x.png",
+			"hover" : "/interface/xhover.png",
+			"press" : "/interface/xpress.png",
+			//dx: 18, dy: 24
+			"position" : [111, 56]
+		},
+		"itemGrid" : {
+			"type" : "itemgrid",
+			"backingImage" : "/interface/inventory/empty.png",
+			"position" : [54, 17],
+			"dimensions" : [1, 1],
+			"spacing" : [20, 20]
+		}
+	}
+}

--- a/objects/wired/liquidsensor/swtjc_wp_advancedliquidsensor.lua
+++ b/objects/wired/liquidsensor/swtjc_wp_advancedliquidsensor.lua
@@ -10,32 +10,25 @@ function init()
   self.defaultOffAnimation = config.getParameter("defaultOffAnimation","off")
 end
 
-function sampleLiquid()
-  return world.liquidAt(object.position())
-end
-
 -- Compares the stored object's 'liquid' field against the sampled liquid's name.
 function isOn()
   local predicateId = predicateLiquidId()
   local sampleId = sampleLiquidId()
-  local result = sampleId and predicateId == sampleId
-  return result
+  local on = sampleId and predicateId == sampleId
+  return on
 end
 
 function sampleLiquidId()
-  local sample = sampleLiquid()
+  local sample = world.liquidAt(object.position())
   if (sample == nil) then
-    sb.logInfo("sample nil")
     return nil 
   end
   return sample[1]
 end
 
 function predicateLiquidId()
-  local id = entity.id()
-  local predicate = world.containerItemAt(id, 0)
+  local predicate = world.containerItemAt(entity.id(), 0)
   if (predicate == nil) then 
-    sb.logInfo("predicate nil")
     return nil 
   end
   return liquidLib.itemToLiquidId(predicate)
@@ -48,7 +41,6 @@ function update(dt)
     transferUtil.loadSelfContainer()
   end
 
-
   local on = isOn()
 
   if on then 
@@ -58,5 +50,4 @@ function update(dt)
     object.setOutputNodeLevel(0, false)
     animator.setAnimationState("sensorState", self.defaultOffAnimation)
   end
-
 end

--- a/objects/wired/liquidsensor/swtjc_wp_advancedliquidsensor.object
+++ b/objects/wired/liquidsensor/swtjc_wp_advancedliquidsensor.object
@@ -2,15 +2,16 @@
   "objectName" : "swtjc_wp_advancedliquidsensor",
   "colonyTags" : ["wired"],
   "printable" : false,
+  "objectType" : "container",
   "rarity" : "Common",
-  "description" : "This can detect and discriminate between the presence of various liquids.",
+  "description" : "This can detect the presence of a specific liquid.",
   "shortdescription" : "Advanced Liquid Sensor",
   "race" : "generic",
   "category" : "wire",
   "price" : 10,
 
-  "floranDescription" : "Thisss can detect and dissscriminate between the presssence of variousss liquidsss.",
-  "glitchDescription" : "Impressed. This can detect and discriminate between the presence of various liquids.",
+  "floranDescription" : "Thiss detectss the pressence of a sspecific liquid.",
+  "glitchDescription" : "Impressed. This can detect the presence of a specific liquid.",
 
   "inventoryIcon" : "liquidsensoricon.png",
 
@@ -57,6 +58,16 @@
     }
   ],
 
+  "inputSlot" : 1,
+  "acceptsItems" : true,
+  "itemAgeMultiplier" : 0.0,
+  
+  "openSounds" : [ "/sfx/objects/locker_open.ogg" ],
+	"slotCount" : 1,
+  "uiConfig" : "/interface/swtjc_wp_advancedliquidsensor/swtjc_wp_advancedliquidsensor.config",
+  "frameCooldown" : 67,
+	"autoCloseCooldown" : 3600,
+
   "scripts" : [ "swtjc_wp_advancedliquidsensor.lua" ],
   "scriptDelta" : 2,
 
@@ -66,13 +77,5 @@
   },
   "animationPosition" : [0, 0],
 
-  "outputNodes" : [ [0, 0], [-1, 1], [0, 1], [1, 1], [-1, 0], [1, 0], [-1, -1], [0, -1], [1, -1] ], //1st node in this array is reserved for miscellaneous liquids that are not defined below.
-
-//  "defaultOnAnimation" : "other",
-//  "defaultOffAnimation" : "off",
-  "liquidCount" : 9, //Total number of liquids to discriminate between. All others will be treated as "miscellaneous", and will be handled by the "default" node.
-
-  "liquidArrayIDs" : [1, 6, 12, 2, 8, 3, 11, 5, 13], //These are the IDs of liquids to specifically discriminate. For example, 1=water, 2=lava, 3=poison, etc.
-  "liquidArrayNodes" : [1, 2, 3, 4, 4, 5, 6, 7, 8], //Each discriminated liquid will be associated with one or more output nodes.
-  "liquidArrayAnimations" : ["water", "water", "water", "lava", "lava", "poison", "other", "other", "other"] //Determines which animation frame to use when the sensor detects a particular liquid.
+  "outputNodes" : [ [0, 0] ]
 }


### PR DESCRIPTION
This PR reworks the Advanced Liquid Sensor. With these changes, the sensor has a smaller wiring footprint, and more powerful detection.

- The sensor now has a single container slot.
- The sensor now has only one wire output (was 9 outputs).
- The sensor's script now compares the liquid at its position to the item placed in its container slot.

Some issues:
- This will break existing setups using the Advanced Liquid Sensor. Any existing setups will not output any signal.
- I'm not certain how existing setups would respond to the sensor having fewer outputs than before. Would this cause a crash? Would the wires be removed silently?

If backward compatibility is a substantial issue, we could move the new implementation to a new item. The prior implementation is very limited in usefulness, so I doubt many setups exist at this point anyway.