### PR TITLE
No more Poptop Parcels

### DIFF
--- a/treasure/fftreasure.treasurepools
+++ b/treasure/fftreasure.treasurepools
@@ -288,7 +288,36 @@
         {"weight" : 0.04, "pool" : "shield"},
         {"weight" : 0.012, "pool" : "instrument"},
         {"weight" : 0.005, "pool" : "costume"},
-        {"weight" : 0.001, "item" : [ "mysteriousparcel", 1]},
+        {"weight" : 0.003, "item" : "teleportercore"},
+        {"weight" : 0.025, "item" : "torch" }
+      ],
+      "poolRounds" : [
+        [0.23, 1],
+        [0.33, 2],
+        [0.33, 3],
+        [0.33, 4],
+        [0.23, 5]
+      ],
+      "allowDuplication" : true
+    }],
+    [2.9, {
+      "pool" : [
+        {"weight" : 0.03, "pool" : "augments"},
+        {"weight" : 0.03, "pool" : "petcollars2"},
+        {"weight" : 0.8, "pool" : "fuBasicMaterials"},
+        {"weight" : 0.05, "pool" : "fuspecialLoot"},
+        {"weight" : 0.1, "pool" : "fuGenes"},
+        {"weight" : 0.20, "pool" : "money"},
+        {"weight" : 0.3, "item" : "medkit"},
+        {"weight" : 0.15, "pool" : "ore"},
+        {"weight" : 0.1, "pool" : "weapon"},
+        {"weight" : 0.1, "pool" : "food"},
+        {"weight" : 0.05, "pool" : "seed"},
+        {"weight" : 0.04, "pool" : "tool"},
+        {"weight" : 0.04, "pool" : "shield"},
+        {"weight" : 0.012, "pool" : "instrument"},
+        {"weight" : 0.005, "pool" : "costume"},
+        {"weight" : 0.0005, "item" : [ "mysteriousparcel", 1]},
         {"weight" : 0.003, "item" : "teleportercore"},
         {"weight" : 0.025, "item" : "torch" }
       ],

--- a/treasure/fuquesttreasure.treasurepools
+++ b/treasure/fuquesttreasure.treasurepools
@@ -14,7 +14,6 @@
         {"weight" : 1.0, "pool" : "salvageComponent" },
         {"weight" : 1.0, "pool" : "salvageComponent" },
         {"weight" : 1.0, "pool" : "fucodexRandom" },
-        {"weight" : 0.01, "item" : [ "mysteriousparcel", 1]},
         {"weight" : 0.5, "pool" : "challengeChestTreasure" }
       ],
       "allowDuplication" : true


### PR DESCRIPTION
Mysterious Parcels no longer appear in the poptop cavern lootboxes. This prevents early-game farming of elder artifacts.