### PR TITLE
box of hearts, donkeys that is

### DIFF
--- a/monsters/fulegacyscripts/flying/wanderstate.lua
+++ b/monsters/fulegacyscripts/flying/wanderstate.lua
@@ -4,7 +4,7 @@ wanderState = {}
 function wanderState.enter()
   if hasTarget() then return nil end
 
-  math.randomseed(os.time())
+  math.randomseed( tonumber(tostring(os.time()):reverse():sub(1,6)) )
 
   return {
     wanderDirection = mcontroller.facingDirection(),

--- a/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.lua
+++ b/objects/minibiome/precursor/fu_precursorduplicator/fu_precursorduplicator.lua
@@ -7,7 +7,7 @@ function init()
 	self.craftTime = config.getParameter("craftTime")
 	storage.timer = storage.timer or self.craftTime -- making this, storage.crafting, etc. persistent so that on server terminus, nothing is lost.
 	storage.timer2 = storage.timer2 or 1.0
-	math.randomseed(os.time())
+	math.randomseed( tonumber(tostring(os.time()):reverse():sub(1,6)) )
 end
 
 function update(dt)

--- a/objects/spawner/colonydeed.lua
+++ b/objects/spawner/colonydeed.lua
@@ -432,7 +432,7 @@ function chooseTenants(seed, tags)
   storage.occupier = occupier
 
   if seed then
-    math.randomseed(os.time())
+    math.randomseed( tonumber(tostring(os.time()):reverse():sub(1,6)) )
   end
 end
 

--- a/quests/madness/madnessdata.lua
+++ b/quests/madness/madnessdata.lua
@@ -2,411 +2,337 @@ require "/scripts/util.lua"
 require "/scripts/vec2.lua"
 
 function init()
-  storage.madnessCount = player.currency("fumadnessresource") or 0
-  self.timer = 0
-  self.player = entity.id()
-  self.randEvent = math.random(1,100) --only pick this on init so that effect changes on reloads only
-  self.timerDegrade = math.random(1,12)
-  self.degradeTotal = 0
-  self.bonusTimer = 1
-  
-  status.removeEphemeralEffect("partytime5")--make sure the annoying sounds dont flood
-  status.removeEphemeralEffect("partytime4")
-  status.removeEphemeralEffect("partytime3")
-  status.removeEphemeralEffect("partytime2")
-  
-  self.paintTimer = 0
-  
-  self.playerId = entity.id()
-  self.maxMadnessValue = 15000 
-  self.madnessPercent = storage.madnessCount / self.maxMadnessValue
-  if self.madnessPercent > 1.0 then
-    self.madnessPercent = 1
-  end  
-  self.barName = "madnessBar"
-  self.barColor = {250,0,250,125}
-  self.timerReloadBar = 0  
-  self.timerRemoveAmmoBar = 0
+	self.madnessCount = player.currency("fumadnessresource") or 0
+	self.timer = 10.0 -- was zero, instant event on plopping in. giving players a short grace period. some of us teleport around a LOT.
+	self.player = entity.id()
+	math.randomseed( tonumber(tostring(os.time()):reverse():sub(1,6)) )
+	self.randEvent = math.random(1,100)
+	self.timerDegrade = math.random(1,12)
+	self.degradeTotal = 0
+	self.bonusTimer = 1
+
+	status.removeEphemeralEffect("partytime5")--make sure the annoying sounds dont flood
+	status.removeEphemeralEffect("partytime4")
+	status.removeEphemeralEffect("partytime3")
+	status.removeEphemeralEffect("partytime2")
+
+	self.paintTimer = 0
+
+	self.playerId = entity.id()
+	self.maxMadnessValue = 15000
+	self.madnessPercent = math.min(self.madnessCount / self.maxMadnessValue,1.0)
+
+	self.barName = "madnessBar"
+	self.barColor = {250,0,250,125}
+	self.timerReloadBar = 0
+	self.timerRemoveAmmoBar = 0
+	
+	local elementalTypes=root.assetJson("/damage/elementaltypes.config")
+	local buffer={}
+	
+	for element,data in pairs(elementalTypes) do
+		if data.resistanceStat then
+			buffer[data.resistanceStat]=true
+		end
+	end
+	self.resistList={}
+	for stat,_ in pairs(buffer) do
+		table.insert(self.resistList,stat)
+	end
 end
 
 function randomEvent()
-    storage.currentPrimary = world.entityHandItem(entity.id(), "primary")  --what are we carrying?
-    storage.currentSecondary = world.entityHandItem(entity.id(), "alt")  --what are we carrying?
-    self.isProtectedRand = math.random(1,100)
-    self.isProtectedRandVal = self.isProtectedRand / 100
-    self.currentProtection = status.stat("mentalProtection") or 0
-    --mentalProtection can make it harder to be affected
-    if (status.statPositive("mentalProtection")) and (self.isProtectedRandVal <= status.stat("mentalProtection")) then 
-      self.randEvent = self.randEvent - (self.currentProtection * 10) --math.random(10,70)  --it doesnt *remove* the effect, it just moves it further up the list, and potentially off of it.
-    end
-    
-    -- are we currently carrying any really weird stuff? 
-    isWeirdStuff()
-    
-    --set duration of curse
-    self.curseDuration = storage.madnessCount / 5  --this value will be adjusted based on effect type
-    self.curseDuration_status = self.curseDuration * 2
-    self.curseDuration_annoy = self.curseDuration * 1.2
-    self.curseDuration_resource = self.curseDuration * 2.2	
-    self.curseDuration_stat = self.curseDuration * 2.5
-    self.curseDuration_fast = self.curseDuration *0.25
-    status.addEphemeralEffect("mad",60)
+	if not self.madnessCount then init() end
+	status.setPersistentEffects("madnessEffectsMain",{})--reset persistent effects the next time one pops up.
+	self.randEvent=math.random(1,100)
+	self.currentPrimary = world.entityHandItem(entity.id(), "primary")	--what are we carrying in the right hand?
+	self.currentSecondary = world.entityHandItem(entity.id(), "alt")	--what are we carrying in the left hand?
+	self.isProtectedRand = math.random(1,100)
+	self.isProtectedRandVal = self.isProtectedRand / 100
+	self.currentProtection = status.stat("mentalProtection") or 0
+	
+	--mentalProtection can make it harder to be affected
+	if (status.statPositive("mentalProtection")) and (self.isProtectedRandVal <= status.stat("mentalProtection")) then
+		self.randEvent = self.randEvent - (self.currentProtection * 10) --math.random(10,70)	--it doesnt *remove* the effect, it just moves it further up the list, and potentially off of it.
+	end
 
-    if self.randEvent < 0 then  --failsafe
-      self.randEvent = 0
-    end
-    
-    if storage.madnessCount > 1500 then
-	    if self.randEvent == 44 then 
-		status.addEphemeralEffect("eatself",20) -- You just can't stop eating yourself.
-		status.addEphemeralEffect("healingimmunitydummy",20) -- healing won't work on you
-		if status.isResource("food") then
-			status.addEphemeralEffect("convert_food-health_100_1-10_lethal",20) -- You just can't stop eating yourself.
-			status.addEphemeralEffect("feedpackneg",self.curseDuration_status)-- hunger isn't abating either
-		else
-			status.addEphemeralEffect("heal_neg20",20) -- You just can't stop eating yourself.
+	-- are we currently carrying any really weird stuff?
+	isWeirdStuff()
+
+	--set duration of curse
+	self.curseDuration = math.min(self.timer,self.madnessCount / 5) --this value will be adjusted based on effect type. Clamping this because it's too much otherwise.
+	--at 15k madness, that's 15000/5, or 1000 seconds. 16.6~ mins. ew.
+	--of course, with 0 madness resistance, that means self.timer will be 150. What this results in is a steady growth, followed by a petering off curve as effect frequency increases.
+	--Effects will be more frequent, and more potent overall, as madness increases. This implements a bit of a ceiling on how bad it can get.
+	self.curseDuration_status = self.curseDuration * 2
+	self.curseDuration_annoy = self.curseDuration * 1.2
+	self.curseDuration_resource = self.curseDuration * 2.2
+	self.curseDuration_stat = self.curseDuration * 2.5
+	self.curseDuration_fast = self.curseDuration *0.25
+	status.addEphemeralEffect("mad",self.timer)
+
+	if self.randEvent < 0 then --failsafe
+		self.randEvent = 0
+	end
+
+	if self.madnessCount > 1500 then
+		if self.randEvent == 44 then
+			status.addEphemeralEffect("eatself",20) -- You just can't stop eating yourself.
+			status.addEphemeralEffect("healingimmunitydummy",20) -- healing won't work on you
+			if status.isResource("food") then
+				status.addEphemeralEffect("convert_food-health_100_1-10_lethal",20) -- So hungry...
+				status.addEphemeralEffect("feedpackneg",self.curseDuration_status)-- hunger isn't abating so fast.
+			else
+				status.addEphemeralEffect("heal_neg20",20) -- It gnaws at you.
+			end
+		elseif self.randEvent == 45 then
+			status.addEphemeralEffect("runboost15",self.curseDuration_status) -- run boost!
 		end
-		--status.addEphemeralEffect("bleeding05",20) -- You just can't stop eating yourself.
-	    end  
-	    if self.randEvent == 45 then 
-		status.addEphemeralEffect("runboost15",self.curseDuration_status) -- run boost!
-	    end   
-    elseif storage.madnessCount > 1000 then
-		if self.randEvent == 40 or self.randEvent == 41 or self.randEvent == 42 then
+	end
+	if self.madnessCount > 1000 then
+		if self.randEvent >= 40 and self.randEvent <= 42 then
 			local enabledtechs=player.enabledTechs()
-			if self.randEvent == 40 and contains(enabledtechs,"distortionsphere") then --swap tech
+			if self.randEvent == 40 and contains(enabledtechs,"distortionsphere") then --swap sphere tech
 				player.equipTech("distortionsphere")
-			end      
-			if self.randEvent == 41 and contains(enabledtechs,"doublejump") then --swap tech
+			elseif self.randEvent == 41 and contains(enabledtechs,"doublejump") then --swap jump tech
 				player.equipTech("doublejump")
-			end   
-			if self.randEvent == 42 and contains(enabledtechs,"dash") then --swap tech
+			elseif self.randEvent == 42 and contains(enabledtechs,"dash") then --swap dash tech
 				player.equipTech("dash")
-			end  
+			end
+		elseif self.randEvent == 43 then
+			player.consumeCurrency("fuscienceresource", 1)
+			player.radioMessage("sanitygain")
 		end
- 	    if self.randEvent == 43 then
- 	      player.consumeCurrency("fuscienceresource", 1) 
- 	      player.radioMessage("sanitygain")
-	    end      
-    elseif storage.madnessCount > 750 then
-	    if self.randEvent == 37 and storage.madnessCount > 800 then --if holding a knife, cut yourself
-	      if (storage.currentPrimary and root.itemHasTag(storage.currentPrimary, "dagger")) or (root.itemHasTag(storage.currentSecondary, "dagger") and storage.currentSecondary) then
-			status.addEphemeralEffect("bleeding05",self.curseDuration_status) -- You just can't stop stabbing yourself
-			player.radioMessage("madnessharm")
-	      else
-			self.timerDegradePenalty = 10
-	      end
-	    end   
-	    if self.randEvent == 38 and storage.madnessCount > 800 then 
-		status.addEphemeralEffect("runboost10",self.curseDuration_status) -- run boost!
-		self.timerDegradePenalty = 2
-	    end  
-	    if self.randEvent == 39 and storage.madnessCount > 900 then 
-		status.addEphemeralEffect("rootfu",10) -- unable to move
-		player.radioMessage("madnessroot")
-	    end       
-	    if self.randEvent == 53 then --all res reduction
-	      local penaltyValue = math.random(1,100)/100
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "cosmicResistance", amount = status.stat("cosmicResistance")-penaltyValue },
-			{stat = "radioactiveResistance", amount = status.stat("radioactiveResistance")-penaltyValue },
-			{stat = "shadowResistance", amount = status.stat("shadowResistance")-penaltyValue },
-			{stat = "electricResistance", amount = status.stat("electricResistance")-penaltyValue },
-			{stat = "poisonResistance", amount = status.stat("poisonResistance")-penaltyValue },
-			{stat = "iceResistance", amount = status.stat("iceResistance")-penaltyValue },
-			{stat = "fireResistance", amount = status.stat("fireResistance")-penaltyValue }
-		  })    
-	    end 
-    elseif storage.madnessCount > 500 then
-	    if self.randEvent == 30 then
-	      local penaltyValue = math.random(1,20)
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "protection", amount = status.stat("protection")-penaltyValue }
-		  })    
-	    end 
-	    if self.randEvent == 31 then --increased hunger
-		status.addEphemeralEffect("feedpackneg",self.curseDuration_status) --more hunger
-		player.radioMessage("madnessfood")
-	    end      
-	    if self.randEvent == 32 then 
-		status.addEphemeralEffect("runboostdebuff",self.curseDuration_status) -- run boost!
-		player.radioMessage("madness2")
-	    end      
-	    if self.randEvent == 33 then 
-		status.addEphemeralEffect("swimboost2",self.curseDuration_status) -- Swim boost2!
-	    end 
-
-	    if self.randEvent == 34 then 
-	      if player.isLounging() then
-		status.addEphemeralEffect("burning",self.curseDuration_status)
-		player.radioMessage("combust")
-	      end
-	    end  
-	    if self.randEvent == 35 then 
-		status.addEphemeralEffect("fu_nooxygen",self.curseDuration_status) -- You have forgotten how to breathe
-	    end  
-	     if self.randEvent == 36 then 
-		status.addEphemeralEffect("jumpboost25neg",self.curseDuration_status) -- You suddenly suck at jumping
-		player.radioMessage("madness2")
-	    end         
-	    if self.randEvent == 46 then --fire res reduction
-	      local penaltyValue = math.random(1,100)/100
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "fireResistance", amount = status.stat("fireResistance")-penaltyValue }
-		  })    
-	    end  
-	    if self.randEvent == 47 then --ice res reduction
-	      local penaltyValue = math.random(1,100)/100
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "iceResistance", amount = status.stat("iceResistance")-penaltyValue }
-		  })    
-	    end  
-	    if self.randEvent == 48 then --poison res reduction
-	      local penaltyValue = math.random(1,100)/100
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "poisonResistance", amount = status.stat("poisonResistance")-penaltyValue }
-		  })    
-	    end  
-	    if self.randEvent == 49 then --elec res reduction
-	      local penaltyValue = math.random(1,100)/100
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "electricResistance", amount = status.stat("electricResistance")-penaltyValue }
-		  })    
-	    end
-	    if self.randEvent == 50 then --shadow res reduction
-	      local penaltyValue = math.random(1,100)/100
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "shadowResistance", amount = status.stat("shadowResistance")-penaltyValue }
-		  })    
-	    end 
-	    if self.randEvent == 51 then --rad res reduction
-	      local penaltyValue = math.random(1,100)/100
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "radioactiveResistance", amount = status.stat("radioactiveResistance")-penaltyValue }
-		  })    
-	    end 
-	    if self.randEvent == 52 then --cosmic res reduction
-	      local penaltyValue = math.random(1,100)/100
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "cosmicResistance", amount = status.stat("cosmicResistance")-penaltyValue }
-		  })    
-	    end 	 
-    elseif storage.madnessCount > 200 then
-	    if self.randEvent == 11 then 
-		status.addEphemeralEffect("nude",self.curseDuration_status)
-	    end   
-	    if self.randEvent == 12 then 
-		status.addEphemeralEffect("staffslow2",self.curseDuration_status)
-	    end      
-	    if self.randEvent == 13 then 
-		status.addEphemeralEffect("medicaltoxiccloud",self.curseDuration)
-	    end
-	    if self.randEvent == 14 then 
-		status.addEphemeralEffect("loweredshadow",self.curseDuration_status) --more succeptible to shadow
-	    end
-	    if self.randEvent == 15 then 
-		status.addEphemeralEffect("ffbiomecold0",self.curseDuration_status) --player feels cold
-	    end
-	    if self.randEvent == 16 then 
-		status.addEphemeralEffect("jungleweathernew",self.curseDuration_status) --player feels hot
-	    end
-	    if self.randEvent == 17 then 
-		status.addEphemeralEffect("insanity",self.curseDuration_status) --player feels insane
-	    end
-	    if self.randEvent == 18 then 
-		status.addEphemeralEffect("slow",self.curseDuration_status) --slows the player for a while
-		player.radioMessage("madness2")
-	    end  
-	    if self.randEvent == 19 then 
-		status.addEphemeralEffect("runboost5",curseDuration_fast) -- run boost!
-	    end     
-	    if self.randEvent == 20 then 
-		status.addEphemeralEffect("maxhealthboostneg20",self.curseDuration_status) -- lowered health
-	    end
-	    if self.randEvent == 21 then 
-		status.addEphemeralEffect("maxenergyboostneg20",self.curseDuration_status) -- lowered energy
-	    end
-	    if self.randEvent == 22 then 
-		status.addEphemeralEffect("lowgrav_fallspeedup",curseDuration_fast) -- adjusts gravity
-	    end
-	    if self.randEvent == 23 then 
-		status.addEphemeralEffect("slimeleech",self.curseDuration_status) -- slimeleech. ew.
-	    end  	    
-	    if self.randEvent == 24 then 
-		status.addEphemeralEffect("knockbackWeaknessHidden",self.curseDuration_status) -- Knockbacks affect you more
-	    end 
-	    if self.randEvent == 25 then 
-		status.addEphemeralEffect("swimboost1",self.curseDuration_status) -- Swim boost!
-	    end  	
-	    if self.randEvent == 26 then 
-		status.addEphemeralEffect("vulnerability",self.curseDuration_status) --p
-	    end 	    
-	    if self.randEvent == 27 then 
-	      local penaltyValue = 1.0-(math.random(6,40)/100.0)
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "fuCharisma", baseMultiplier = penaltyValue }
-		  })
-	    end  
-	    if self.randEvent == 28 then --your hunger total is random
-		    if status.isResource("food") then
-		       local randHunger = math.random(1,70)+2
-		       status.setResource("food",randHunger)
-		    end  
-		    player.radioMessage("madnessfood")
-	    end  
-	    if self.randEvent == 29 then --max food reduction
-	      local penaltyValue = math.random(1,8)
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "maxFood", amount = status.stat("maxFood")-penaltyValue }
-		  })    
-	    end  	   
-	    
-    elseif storage.madnessCount > 150 then
-	    if self.randEvent == 6 then 
-		status.addEphemeralEffect("partytime2",self.curseDuration_annoy)
-	    end 
-	    if self.randEvent == 7 then 
-		status.addEphemeralEffect("partytime3",self.curseDuration_annoy)
-	    end 
-	    if self.randEvent == 8 then 
-		status.addEphemeralEffect("partytime4",self.curseDuration_annoy)
-	    end  
-	    if self.randEvent == 9 then 
-		status.addEphemeralEffect("partytime5",self.curseDuration_annoy)
-	    end 
-	    if self.randEvent == 10 then
-	      player.addCurrency("fuscienceresource", 1) 
-	    end    	  
-    elseif storage.madnessCount > 50 then
-	    if self.randEvent == 1 then 
-		status.addEphemeralEffect("booze",self.curseDuration_status) --player feels drunk
-	    end 
-	    if self.randEvent == 2 then 
-		status.addEphemeralEffect("biomeairless",self.curseDuration_status)
-	    end   	    
-	    if self.randEvent == 3 then 
-		status.addEphemeralEffect("sandstorm",self.curseDuration_status)
-	    end  
-	    if self.randEvent == 4 then --temporary protection from madness
-		  status.setPersistentEffects("madnessEffectsMain", {  
-			{stat = "mentalProtection", amount = status.stat("mentalProtection") + 0.5 }
-		  })    
-	    end 	    
-	    if self.randEvent == 5 then 
-		if player.hasCountOfItem("plantfibre")  then -- consume a plant fibre, just to confuse and confound
-			player.consumeItem("plantfibre", true, false)
-			player.radioMessage("madness1")
-		end      
-	    end    
-    end
-    self.randEvent = math.random(1,100)
+	end
+	if self.madnessCount > 750 then
+		if self.randEvent == 37 and self.madnessCount > 800 then
+			if (self.currentPrimary and root.itemHasTag(self.currentPrimary, "dagger")) or (root.itemHasTag(self.currentSecondary, "dagger") and self.currentSecondary) then --if holding a knife, cut yourself
+				status.addEphemeralEffect("bleeding05",self.curseDuration_status) -- You just can't stop stabbing yourself
+				player.radioMessage("madnessharm")
+			else
+				self.timerDegradePenalty = 10
+			end
+		elseif self.randEvent == 38 and self.madnessCount > 800 then
+			status.addEphemeralEffect("runboost10",self.curseDuration_status) -- run boost!
+			self.timerDegradePenalty = 2
+		elseif self.randEvent == 39 and self.madnessCount > 900 then
+			status.addEphemeralEffect("rootfu",10) -- unable to move
+			player.radioMessage("madnessroot")
+		elseif self.randEvent == 53 then
+			--local penaltyValue = math.random(1,100)/100 --while we could make it apply this to all of them, it's better to apply it randomly to all of them!
+			local buffer={}
+			for _,stat in pairs(self.resistList) do
+				table.insert(buffer,{stat=stat,amount=((math.random()>0.75 and 1) or (-1))*(math.random(1,20)/100.0)}) --still, needed to reduce the maximum range to reasonable levels. also added a chance for a bonus
+			end
+			status.setPersistentEffects("madnessEffectsMain", buffer)
+			--same problem as the 'pick random resist' debuff. 
+		end
+	end
+	if self.madnessCount > 500 then
+		if self.randEvent == 30 then
+			status.addEphemeralEffect("percentarmorboostneg"..tostring(math.random(1,5)),self.curseDuration_status)--randomly get a penalty multiplier of 0.9 to 0.5 for defense
+		elseif self.randEvent == 31 then
+			status.addEphemeralEffect("feedpackneg",self.curseDuration_status) --more hunger
+			player.radioMessage("madnessfood")
+		elseif self.randEvent == 32 then
+			status.addEphemeralEffect("runboostdebuff",self.curseDuration_status) -- run boost!
+			player.radioMessage("madness2")
+		elseif self.randEvent == 33 then
+			status.addEphemeralEffect("swimboost2",self.curseDuration_status) -- Swim boost2!
+		elseif self.randEvent == 34 then
+			if player.isLounging() then
+				status.addEphemeralEffect("burning",self.curseDuration_status)--your ass is on fire.
+				player.radioMessage("combust")
+			end
+		elseif self.randEvent == 35 then
+			status.addEphemeralEffect("fu_nooxygen",self.curseDuration_status) -- You have forgotten how to breathe
+		elseif self.randEvent == 36 then
+			status.addEphemeralEffect("jumpboost25neg",self.curseDuration_status) -- You suddenly suck at jumping
+			player.radioMessage("madness2")
+		elseif (self.randEvent >= 46 and self.randEvent <= 52) then
+			status.setPersistentEffects("madnessEffectsMain", {{stat = self.resistList[math.random(1,#self.resistList)], amount = ((math.random()>0.75 and 1) or (-1))*math.random(1,20)/100.0}}) -- pick one from all available resistances, and reduce it by 1-X%. was 100, but that's too much.
+			--old formula. it's whack. with 0 res, it could do nothing or give -100...at 100 it could do nothing or increase it to 200. at 50? double or reduce to nil. at -60? -60 to -160 (leaving you at -120 to -220).
+			--status.setPersistentEffects("madnessEffectsMain", {{stat = resist, amount = status.stat(resist)-penaltyValue}})
+		end
+	end
+	if self.madnessCount > 200 then
+		if self.randEvent == 11 then
+			status.addEphemeralEffect("nude",self.curseDuration_status) --harmless, but silly. YOU ARE NAKEY!
+		elseif self.randEvent == 12 then
+			status.addEphemeralEffect("staffslow2",self.curseDuration_status) -- obnoxious.
+		elseif self.randEvent == 13 then
+			status.addEphemeralEffect("medicaltoxiccloud",self.curseDuration) -- should probably swap for a madness specific variant.
+		elseif self.randEvent == 14 then
+			status.addEphemeralEffect("loweredshadow",self.curseDuration_status) --more susceptible to shadow
+		elseif self.randEvent == 15 then
+			status.addEphemeralEffect("ffbiomecold0",self.curseDuration_status) --player feels cold
+		elseif self.randEvent == 16 then
+			status.addEphemeralEffect("jungleweathernew",self.curseDuration_status) --player feels hot
+		elseif self.randEvent == 17 then
+			status.addEphemeralEffect("insanity",self.curseDuration_status) --player feels insane
+		elseif self.randEvent == 18 then
+			status.addEphemeralEffect("slow",self.curseDuration_status) --slows the player for a while
+			player.radioMessage("madness2")
+		elseif self.randEvent == 19 then
+			status.addEphemeralEffect("runboost5",curseDuration_fast) -- run boost 5!
+		elseif self.randEvent == 20 then
+			status.addEphemeralEffect("maxhealthboostneg20",self.curseDuration_status) -- lowered health
+		elseif self.randEvent == 21 then
+			status.addEphemeralEffect("maxenergyboostneg20",self.curseDuration_status) -- lowered energy
+		elseif self.randEvent == 22 then
+			status.addEphemeralEffect("lowgrav_fallspeedup",curseDuration_fast) -- adjusts gravity
+		elseif self.randEvent == 23 then
+			status.addEphemeralEffect("slimeleech",self.curseDuration_status) -- slimeleech. ew.
+		elseif self.randEvent == 24 then
+			status.addEphemeralEffect("knockbackWeaknessHidden",self.curseDuration_status) -- Knockbacks affect you more
+		elseif self.randEvent == 25 then
+			status.addEphemeralEffect("swimboost1",self.curseDuration_status) -- Swim boost 1!
+		elseif self.randEvent == 26 then
+			status.addEphemeralEffect("vulnerability",self.curseDuration_status/4.0) --vulnerability multiplies all resists and defense by 0.01, biiiig ouch. severely reducing the max duration of this.
+		elseif self.randEvent == 27 then
+			status.setPersistentEffects("madnessEffectsMain", {{stat = "fuCharisma", baseMultiplier = (1.0-(math.random(6,40)/100.0)) }}) --random charisma penalty.
+		elseif self.randEvent == 28 then
+			if status.isResource("food") then
+				status.setResource("food",math.random(1.0,status.stat("maxFood"))) --your current hunger is randomized
+			end
+			player.radioMessage("madnessfood")
+		elseif self.randEvent == 29 then --max food reduction
+			status.setPersistentEffects("madnessEffectsMain", {{stat = "maxFood", amount = -1*math.random(1,8)}})
+		end
+	end
+	if self.madnessCount > 150 then
+		if self.randEvent == 6 then
+			status.addEphemeralEffect("partytime2",self.curseDuration_annoy) -- party
+		elseif self.randEvent == 7 then
+			status.addEphemeralEffect("partytime3",self.curseDuration_annoy) -- party
+		elseif self.randEvent == 8 then
+			status.addEphemeralEffect("partytime4",self.curseDuration_annoy) -- party
+		elseif self.randEvent == 9 then
+			status.addEphemeralEffect("partytime5",self.curseDuration_annoy) -- party
+		elseif self.randEvent == 10 then
+			player.addCurrency("fuscienceresource", 1)
+		end
+	end
+	if self.madnessCount > 50 then
+		if self.randEvent == 1 then
+			status.addEphemeralEffect("booze",self.curseDuration_status) --player feels drunk
+		elseif self.randEvent == 2 then
+			status.addEphemeralEffect("biomeairless",self.curseDuration_status)--annoying harmless warning
+		elseif self.randEvent == 3 then
+			status.addEphemeralEffect("sandstorm",self.curseDuration_status)--you farted sand
+		elseif self.randEvent == 4 then
+			status.setPersistentEffects("madnessEffectsMain", {{stat = "mentalProtection", amount = status.stat("mentalProtection") + 0.5 }}) --temporary protection from madness
+		elseif self.randEvent == 5 then
+			if player.hasCountOfItem("plantfibre") then -- consume a plant fibre, just to confuse and confound
+				player.consumeItem("plantfibre", true, false)
+				player.radioMessage("madness1")
+			end
+		end
+	end
 end
 
 function update(dt)
-   -- we control the ammo bar removal from here for now, since its innocuous enough to work without interfering with update() on the player
-   -- there are better places to put it, bbut this at least keeps it contained
-   if (self.timerRemoveAmmoBar >=6) then
-       world.sendEntityMessage(entity.id(),"removeBar","ammoBar")   --clear ammo bar  
-       self.timerRemoveAmmoBar = 0
-   else
-       self.timerRemoveAmmoBar = self.timerRemoveAmmoBar + dt
-   end   
-  
-   storage.madnessCount = player.currency("fumadnessresource")
-   
-   -- timing refresh for sculptures, painting effects
-   self.paintTimer = self.paintTimer - 1
-   if self.paintTimer == 0 then
-     checkMadnessArt()
-   end
-   
-  -- Core Adjustment Function
-  self.timer = self.timer - 1
-  if self.timer < 1 then 
-      if storage.madnessCount > 50 then
-	 self.degradeTotal = storage.madnessCount / 300 -- max is 50
-	 self.timerDegradePenalty = (storage.madnessCount / 500) 
-	 if self.timerDegradePenalty < 0 then
-	     self.timerDegradePenalty = 0
-	 end
-	 self.timer = (300 - (storage.madnessCount/100) ) + (status.stat("mentalProtection") * 100)
-	 randomEvent() --apply random effect 
-      else
-	 self.timer = 300
-	 self.degradeTotal = 1	  
-      end	  	
-  end
-  self.timerDegrade = self.timerDegrade -1
-  --gradually reduce Madness over time
-  if (self.timerDegrade <= 0) then --no more limit to when it can degrade
-      self.timerDegradePenalty = self.timerDegradePenalty or 0
-      player.consumeCurrency("fumadnessresource", self.degradeTotal)
-      self.timerDegrade= 60 - self.timerDegradePenalty  
-      --displayBar()
-  end 
-  -- apply bonus loss from anti-madness effects even if not above 500 madness
-  self.bonusTimer = self.bonusTimer -1
-  if self.bonusTimer <= 0 then
-      self.protectionBonus = status.stat("mentalProtection")/5 + math.random(1,12) 
-      if (status.statPositive("mentalProtection")) then 
-        player.consumeCurrency("fumadnessresource", self.protectionBonus)   
-      end
-      self.bonusTimer = 40
-      --displayBar() 	    
-  end	
+	-- we control the ammo bar removal from here for now, since its innocuous enough to work without interfering with update() on the player
+	-- there are better places to put it, bbut this at least keeps it contained
+	if (self.timerRemoveAmmoBar >=6) then
+		world.sendEntityMessage(entity.id(),"removeBar","ammoBar")	--clear ammo bar
+		self.timerRemoveAmmoBar = 0
+	else
+		self.timerRemoveAmmoBar = math.min(self.timerRemoveAmmoBar + dt,6.0)
+	end
+
+	self.madnessCount = player.currency("fumadnessresource")
+
+	-- timing refresh for sculptures, painting effects
+	self.paintTimer = math.max(0,self.paintTimer - dt)
+	if self.paintTimer <= 0 then
+		checkMadnessArt()
+	end
+
+	-- Core Adjustment Function
+	self.timer = math.max(self.timer - dt,0.0)
+	if self.timer <= 0.0 then
+		if self.madnessCount > 50 then
+			self.degradeTotal = self.madnessCount / 300 -- max is 50
+			self.timerDegradePenalty = math.max(0.0,self.madnessCount / 500)
+			self.timer = math.max(math.max(10,300.0 - (self.madnessCount/100)) + (status.stat("mentalProtection") * 100),10)--implementing a hard floor on how low the timer can go.
+			randomEvent() --apply random effect
+		else
+			self.timer = 300.0
+			self.degradeTotal = 1
+		end
+	end
+	self.timerDegrade = math.max(self.timerDegrade - dt,0.0)
+	--gradually reduce Madness over time
+	if (self.timerDegrade <= 0) then --no more limit to when it can degrade
+		self.timerDegradePenalty = self.timerDegradePenalty or 0.0
+		player.consumeCurrency("fumadnessresource", self.degradeTotal)
+		self.timerDegrade= 60.0 - self.timerDegradePenalty
+		--displayBar()
+	end
+	-- apply bonus loss from anti-madness effects even if not above 500 madness
+	self.bonusTimer = math.max(self.bonusTimer - dt,0)
+	if self.bonusTimer <= 0.0 then
+		self.protectionBonus = status.stat("mentalProtection")/5.0 + math.random(1,12)
+		if (status.statPositive("mentalProtection")) then
+			player.consumeCurrency("fumadnessresource", self.protectionBonus)
+		end
+		self.bonusTimer = 40.0
+		--displayBar()
+	end
 end
 
 --display madness bar
 function displayBar()
-  if (storage.madnessCount >= 50) then
-    world.sendEntityMessage(self.playerId,"setBar","madnessBar",self.madnessPercent,self.barColor)
-  else
-    world.sendEntityMessage(self.playerId,"removeBar","madnessBar")
-  end
+	if (self.madnessCount >= 50) then
+		world.sendEntityMessage(self.playerId,"setBar","madnessBar",self.madnessPercent,self.barColor)
+	else
+		world.sendEntityMessage(self.playerId,"removeBar","madnessBar")
+	end
 end
 
-function checkMadnessArt()       
-    if player.hasItem("thehuntpainting") or
-    player.hasItem("demiurgepainting") or
-    player.hasItem("elderhugepainting") then
-	player.addCurrency("fumadnessresource", 5) 
-    end  
+function checkMadnessArt()
+	if player.hasItem("thehuntpainting") or
+		player.hasItem("demiurgepainting") or
+		player.hasItem("elderhugepainting") then
+		player.addCurrency("fumadnessresource", 5)
+	end
 
-    if player.hasItem("dreamspainting") or
-    player.hasItem("fleshpainting") or
-    player.hasItem("homepainting") or
-    player.hasItem("hordepainting") or
-    player.hasItem("nightmarepainting") or
-    player.hasItem("theexpansepainting") or
-    player.hasItem("thefishpainting") or
-    player.hasItem("thepalancepainting") or
-    player.hasItem("theroompainting") or
-    player.hasItem("thingsinthedarkpainting") or
-    player.hasItem("elderpainting1") or
-    player.hasItem("elderpainting2") or
-    player.hasItem("elderpainting3") or
-    player.hasItem("elderpainting4") or
-    player.hasItem("elderpainting5") or
-    player.hasItem("elderpainting6") or
-    player.hasItem("elderpainting7") or
-    player.hasItem("elderpainting8") or
-    player.hasItem("elderpainting9") or
-    player.hasItem("elderpainting10") or
-    player.hasItem("elderpainting11") then
-        player.addCurrency("fumadnessresource", 2) 
-    end
-    self.paintTimer = 20 + (status.stat("mentalProtection") * 25)
+	if player.hasItem("dreamspainting") or
+		player.hasItem("fleshpainting") or
+		player.hasItem("homepainting") or
+		player.hasItem("hordepainting") or
+		player.hasItem("nightmarepainting") or
+		player.hasItem("theexpansepainting") or
+		player.hasItem("thefishpainting") or
+		player.hasItem("thepalancepainting") or
+		player.hasItem("theroompainting") or
+		player.hasItem("thingsinthedarkpainting") or
+		player.hasItem("elderpainting1") or
+		player.hasItem("elderpainting2") or
+		player.hasItem("elderpainting3") or
+		player.hasItem("elderpainting4") or
+		player.hasItem("elderpainting5") or
+		player.hasItem("elderpainting6") or
+		player.hasItem("elderpainting7") or
+		player.hasItem("elderpainting8") or
+		player.hasItem("elderpainting9") or
+		player.hasItem("elderpainting10") or
+		player.hasItem("elderpainting11") then
+		player.addCurrency("fumadnessresource", 2)
+	end
+	self.paintTimer = 20.0 + (status.stat("mentalProtection") * 25)
 end
 
 function isWeirdStuff()
-    if player.hasItem("faceskin") or 
-    player.hasItem("greghead") or 
-    player.hasItem("gregnog") or
-    player.hasItem("babyheadonastick") or 
-    player.hasItem("greghead") or 
-    player.hasItem("meatpickle") then
-	player.addCurrency("fumadnessresource", 2) 
-    end
+	if player.hasItem("faceskin") or
+		player.hasItem("greghead") or
+		player.hasItem("gregnog") or
+		player.hasItem("babyheadonastick") or
+		player.hasItem("greghead") or
+		player.hasItem("meatpickle") then
+		player.addCurrency("fumadnessresource", 2)
+	end
 end
 
 function uninit()

--- a/quests/madness/madnessdata.lua
+++ b/quests/madness/madnessdata.lua
@@ -188,7 +188,7 @@ function randomEvent()
 		elseif self.randEvent == 25 then
 			status.addEphemeralEffect("swimboost1",self.curseDuration_status) -- Swim boost 1!
 		elseif self.randEvent == 26 then
-			status.addEphemeralEffect("vulnerability",self.curseDuration_status/4.0) --vulnerability multiplies all resists and defense by 0.01, biiiig ouch. severely reducing the max duration of this.
+			status.addEphemeralEffect("vulnerability",self.curseDuration_fast) --vulnerability multiplies all resists and defense by 0.01, biiiig ouch. severely reducing the max duration of this.
 		elseif self.randEvent == 27 then
 			status.setPersistentEffects("madnessEffectsMain", {{stat = "fuCharisma", baseMultiplier = (1.0-(math.random(6,40)/100.0)) }}) --random charisma penalty.
 		elseif self.randEvent == 28 then

--- a/stats/effects/fu_effects/percentarmorboost/percentarmorboostdebuff.lua
+++ b/stats/effects/fu_effects/percentarmorboost/percentarmorboostdebuff.lua
@@ -1,15 +1,9 @@
 function init()
-  effect.setParentDirectives("fade=FFCC00=0.20")
-  script.setUpdateDelta(5)
-  _x = config.getParameter("defenseModifier", 0)
-  baseValue = config.getParameter("defenseModifier",0)*(status.stat("protection"))
- effect.addStatModifierGroup({{stat = "protection", amount = baseValue }})
+	effect.setParentDirectives("fade=FFCC00=0.20")
+	baseValue = config.getParameter("defenseModifier",0)
+	effect.addStatModifierGroup({{stat = "protection", effectiveMultiplier = baseValue }})
 end
 
-function update(dt)
-  
-end
+function update(dt) end
 
-function uninit()
-  
-end
+function uninit() end

--- a/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg1.statuseffect
+++ b/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg1.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "percentarmorboostneg1",
   "effectConfig" : {
-    "defenseModifier" : -0.10
+    "defenseModifier" : 0.9
   },
   "defaultDuration" : 10,
 
@@ -11,6 +11,6 @@
   
   //"animationConfig" : "percentarmorboostdebuff.animation",
   
-  "label" : "Def -10%",
+  "label" : "Defense x0.9",
   "icon" : "/interface/statuses/defdown.png"
 }

--- a/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg2.statuseffect
+++ b/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg2.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "percentarmorboostneg2",
   "effectConfig" : {
-    "defenseModifier" : -0.20
+    "defenseModifier" : 0.8
   },
   "defaultDuration" : 10,
 
@@ -11,6 +11,6 @@
   
   //"animationConfig" : "percentarmorboostdebuff.animation",
   
-  "label" : "Def -20%",
+  "label" : "Def x0.8",
   "icon" : "/interface/statuses/defdown.png"
 }

--- a/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg3.statuseffect
+++ b/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg3.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "percentarmorboostneg3",
   "effectConfig" : {
-    "defenseModifier" : -0.30
+    "defenseModifier" : 0.7
   },
   "defaultDuration" : 10,
 
@@ -11,6 +11,6 @@
   
   //"animationConfig" : "percentarmorboostdebuff.animation",
   
-  "label" : "Def -30%",
+  "label" : "Def x0.7",
   "icon" : "/interface/statuses/defdown.png"
 }

--- a/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg4.statuseffect
+++ b/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg4.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "percentarmorboostneg4",
   "effectConfig" : {
-    "defenseModifier" : -0.40
+    "defenseModifier" : 0.6
   },
   "defaultDuration" : 10,
 
@@ -11,6 +11,6 @@
   
   //"animationConfig" : "percentarmorboostdebuff.animation",
   
-  "label" : "Def -40%",
+  "label" : "Def x0.6",
   "icon" : "/interface/statuses/defdown.png"
 }

--- a/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg5.statuseffect
+++ b/stats/effects/fu_effects/percentarmorboost/percentarmorboostneg5.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "percentarmorboostneg5",
   "effectConfig" : {
-    "defenseModifier" : -0.50
+    "defenseModifier" : 0.50
   },
   "defaultDuration" : 10,
 
@@ -11,6 +11,6 @@
   
   //"animationConfig" : "percentarmorboostdebuff.animation",
   
-  "label" : "Def -50%",
+  "label" : "Defense x0.5",
   "icon" : "/interface/statuses/defdown.png"
 }

--- a/stats/effects/fu_effects/powerboost/phaseattackstat.lua
+++ b/stats/effects/fu_effects/powerboost/phaseattackstat.lua
@@ -22,7 +22,9 @@ function update(dt)
 	cost=dt*((status.resourceMax("energy")*0.01*cost)+cost)
 	
 	if status.overConsumeResource("energy",cost) then
-		self.damageBonus=self.damageBonus*(1+(0.08*dt))
+		if status.resourcePositive("energyRegenBlock") then
+			self.damageBonus=self.damageBonus*(1+(0.08*dt))
+		end
 	end
 
 	effect.setStatModifierGroup(powerHandler,{{stat = "powerMultiplier", effectiveMultiplier = self.damageBonus}})

--- a/stats/effects/vulnerability/vulnerability.lua
+++ b/stats/effects/vulnerability/vulnerability.lua
@@ -1,21 +1,17 @@
 function init()
-  effect.addStatModifierGroup({
-    {stat = "protection", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "physicalResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "fireResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "iceResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "electricResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "poisonResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "cosmicResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "shadowResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "radioactiveResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "akkimariacidResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)},
-    {stat = "centensianenergyResistance", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)}
-  })
-end
-
-function update(dt)
-end
-
-function uninit()
+	local elementalTypes=root.assetJson("/damage/elementaltypes.config")
+	local statBuffer={{stat = "protection", effectiveMultiplier = config.getParameter("protectionModifier", 0.01)}}
+	local buffer={}
+	
+	for element,data in pairs(elementalTypes) do
+		if data.resistanceStat then
+			buffer[data.resistanceStat]=true
+		end
+	end
+	
+	for stat,_ in pairs(buffer) do
+		table.insert(statBuffer,{stat=stat,effectiveMultiplier=config.getParameter("protectionModifier", 0.01)})
+	end
+	
+	effect.addStatModifierGroup(statBuffer)
 end


### PR DESCRIPTION
updated some randomseed function calls.
upgraded vuln to apply to ALL available resistances.
phase attack damage boost will not increment if your energy regen isn't blocked. no cheese, little rats.
adjusted some armorboostnegative stats to apply effectiveMultiplier

core Madness  script tweaks:
streamlined many conditions by adding elseifs
added maximum value to event base status duration (event interval)
added minimum value to event interval
persistent effects reset each interval
removed some elseifs, resulting in higher madness levels having a wider variety of effects
vuln effect event is now 1/4 event status duration.
resistance effects now can select from ALL available resistances. range reduced to 1-20%. 1/4 chance to be a bonus, instead of a penalty. Resistance values rolled per resist, instead of for the entire set, where applicable.
