### PR TITLE
itchy

### DIFF
--- a/items/active/mementomori/fumementomori.lua
+++ b/items/active/mementomori/fumementomori.lua
@@ -22,8 +22,7 @@ function update(dt, fireMode, shiftHeld)
 	else
 		if fireMode=="primary" then
 			local buffer=status.statusProperty(mementomori.deathPositionKey.."."..self.worldId)
-			firing=(not not buffer) and (buffer.worldId==self.worldId) and (world.magnitude(buffer.position,world.entityPosition(activeItem.ownerEntityId())) > 20)
-			--sb.logInfo("fumementomori.lua:update:firingblock:initial:recording use: %s, firing: %s: %s",buffer,firing,{buffer})
+			firing=(not not buffer) and (buffer.position) and (world.magnitude(buffer.position,world.entityPosition(activeItem.ownerEntityId())) > 20)
 			if firing then
 				if not teleportTimer then
 					teleportTimer=0

--- a/items/active/weapons/melee/meleecombo.lua
+++ b/items/active/weapons/melee/meleecombo.lua
@@ -470,7 +470,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/items/active/weapons/ranged/fu_overheating.lua
+++ b/items/active/weapons/ranged/fu_overheating.lua
@@ -55,7 +55,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/items/active/weapons/ranged/gunfire.lua
+++ b/items/active/weapons/ranged/gunfire.lua
@@ -87,7 +87,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/items/active/weapons/ranged/gunfirefixed.lua
+++ b/items/active/weapons/ranged/gunfirefixed.lua
@@ -105,7 +105,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/objects/minibiome/elder/elderswitches/elderlightsensor/elderlightsensor.lua
+++ b/objects/minibiome/elder/elderswitches/elderlightsensor/elderlightsensor.lua
@@ -4,7 +4,7 @@ function init()
 end
 
 function getSample()
-  local sample = world.lightLevel(object.position())
+  local sample = math.min(1.0,world.lightLevel(object.position()))
   return math.floor(sample * 1000) * 0.1
 end
 

--- a/objects/painting/artwork/fu_creepyeyepainting/fu_creepyeyepaintinganimation.lua
+++ b/objects/painting/artwork/fu_creepyeyepainting/fu_creepyeyepaintinganimation.lua
@@ -15,7 +15,7 @@ end
 
 function update()
 	localAnimator.clearDrawables()
-	local lightLevel = world.lightLevel(self.position)
+	local lightLevel = math.min(world.lightLevel(self.position),1.0)
 	if self.state == "turningOn" or self.state == "turningOff" then
 		--Makes it work
 	elseif lightLevel < self.maxLight then

--- a/objects/power/fu_solararray/fu_solararray.object
+++ b/objects/power/fu_solararray/fu_solararray.object
@@ -34,5 +34,5 @@
   
   "isn_powerSupplier" : true,
   "powertype" : "output",
-  "powerLevel" : 2
+  "powerLevel" : 2.5
 }

--- a/objects/power/fu_solararrayadv/fu_solararrayadv.object
+++ b/objects/power/fu_solararrayadv/fu_solararrayadv.object
@@ -4,7 +4,7 @@
     "colonyTags" : [ "science" ],
   "category" : "wire",
   "price" : 600,
-  "description" : "The ultimate in solar generation technology. In ideal conditions this can generate over 15W of power.",
+  "description" : "The ultimate in solar generation technology. In ideal conditions this can generate over 20W of power.",
   "shortdescription" : "^cyan;Solar Tower^white;",
   "race" : "generic",
   "printable" : false,

--- a/objects/power/fu_solararrayadv/fu_solararrayadv.object
+++ b/objects/power/fu_solararrayadv/fu_solararrayadv.object
@@ -33,5 +33,5 @@
   
   "isn_powerSupplier" : true,
   "powertype" : "output",
-  "powerLevel" : 3
+  "powerLevel" : 6.0
 }

--- a/objects/power/isn_nocturnpanel.lua
+++ b/objects/power/isn_nocturnpanel.lua
@@ -60,7 +60,7 @@ function getLight(location)
       world.callScriptedEntity(objects[i],'object.setLightColor',{light[1]/3,light[2]/3,light[3]/3})
     end
   end
-  local light = world.lightLevel(location)
+  local light = math.min(world.lightLevel(location),1.0)
   for key,value in pairs(lights) do
     world.callScriptedEntity(key,'object.setLightColor',value)
   end

--- a/objects/power/isn_solarpanel.lua
+++ b/objects/power/isn_solarpanel.lua
@@ -14,8 +14,7 @@ function update(dt)
 			power.setPower(0)
 		else
 			local location = isn_getTruePosition()
-			local light = world.type() ~= 'playerstation' and getLight(location)
-			local light = math.min(2.0,(world.type() ~= 'playerstation' and getLight(location) or 0.0)) --via 'compressing' liquids like lava it is possible to get exhorbitant values on light level, over 100x the expected range.
+			local light = (world.type() ~= 'playerstation' and getLight(location) or 0.0)
 			local genmult = 1
 			if world.type() == 'playerstation' then
 				genmult = 3.75 -- player space station always counts as high power, but never MAX power.
@@ -61,7 +60,7 @@ function getLight(location)
 			world.callScriptedEntity(objects[i],'object.setLightColor',{light[1]/3,light[2]/3,light[3]/3})
 		end
 	end
-	local light = world.lightLevel(location)
+	local light = math.min(world.lightLevel(location),1.0) --via 'compressing' liquids like lava it is possible to get exhorbitant values on light level, over 100x the expected range.
 	for key,value in pairs(lights) do
 		world.callScriptedEntity(key,'object.setLightColor',value)
 	end

--- a/objects/power/isn_solarpanel.lua
+++ b/objects/power/isn_solarpanel.lua
@@ -14,7 +14,8 @@ function update(dt)
       power.setPower(0)
     else
       local location = isn_getTruePosition()
-      local light = world.type() ~= 'playerstation' and getLight(location) or 0
+      local light = (world.type() ~= 'playerstation' and getLight(location) or 0.0) / 100.0
+	sb.logInfo("l: light %s",light)
       local genmult = 1
       if world.type() == 'playerstation' then
         genmult = 3.75 -- player space station always counts as high power, but never MAX power.
@@ -29,11 +30,13 @@ function update(dt)
       elseif light <= 0 then
         genmult = 0
       end
-
+	sb.logInfo("a: genmult %s",genmult)
       if world.liquidAt(location)then genmult = genmult * 0.05 end -- water significantly reduces the output
+	sb.logInfo("b: genmult %s",genmult)
 
-      local generated = math.min(self.powerLevel * genmult,36) -- max at 36 just in case.
-
+      local generated = self.powerLevel * genmult
+	  
+	sb.logInfo("c: generated %s powerLevel %s",self.powerLevel,generated)
       if genmult >= 4 then
         animator.setAnimationState("meter", "4")
       elseif genmult >= 3 then

--- a/objects/power/isn_solarpanel.lua
+++ b/objects/power/isn_solarpanel.lua
@@ -14,17 +14,8 @@ function update(dt)
 			power.setPower(0)
 		else
 			local location = isn_getTruePosition()
-			local light = (world.type() ~= 'playerstation' and getLight(location) or 0.0)
-			--addressing some special cases that can be made where light will vastly exceed expected values
-			while light  > 10.0 do
-				light=light/10.0
-			end
-			for x=9,2,-1 do
-				if light > x then
-					light=light/x
-				end
-			end
-			--sb.logInfo("l: light %s",light)
+			local light = world.type() ~= 'playerstation' and getLight(location)
+			local light = math.min(2.0,(world.type() ~= 'playerstation' and getLight(location) or 0.0)) --addressing some special cases that can be made where light will vastly exceed expected values	
 			local genmult = 1
 			if world.type() == 'playerstation' then
 				genmult = 3.75 -- player space station always counts as high power, but never MAX power.
@@ -39,13 +30,10 @@ function update(dt)
 			elseif light <= 0 then
 				genmult = 0
 			end
-			--sb.logInfo("a: genmult %s",genmult)
 			if world.liquidAt(location)then genmult = genmult * 0.05 end -- water significantly reduces the output
-			--sb.logInfo("b: genmult %s",genmult)
 
 			local generated = self.powerLevel * genmult
 			
-			--sb.logInfo("c: powerLevel %s generated %s",self.powerLevel,generated)
 			if genmult >= 4 then
 				animator.setAnimationState("meter", "4")
 			elseif genmult >= 3 then
@@ -81,7 +69,6 @@ function getLight(location)
 end
 
 function isn_powerGenerationBlocked()
-	-- Power generation does not occur if...
 	local location = isn_getTruePosition()
 	return world.underground(location) or world.lightLevel(location) < 0.2 or (world.timeOfDay() > 0.55 and world.type() ~= 'playerstation') --or world.type == 'unknown'
 end

--- a/objects/power/isn_solarpanel.lua
+++ b/objects/power/isn_solarpanel.lua
@@ -15,7 +15,7 @@ function update(dt)
 		else
 			local location = isn_getTruePosition()
 			local light = world.type() ~= 'playerstation' and getLight(location)
-			local light = math.min(2.0,(world.type() ~= 'playerstation' and getLight(location) or 0.0)) --addressing some special cases that can be made where light will vastly exceed expected values	
+			local light = math.min(2.0,(world.type() ~= 'playerstation' and getLight(location) or 0.0)) --via 'compressing' liquids like lava it is possible to get exhorbitant values on light level, over 100x the expected range.
 			local genmult = 1
 			if world.type() == 'playerstation' then
 				genmult = 3.75 -- player space station always counts as high power, but never MAX power.

--- a/objects/power/isn_solarpanel.lua
+++ b/objects/power/isn_solarpanel.lua
@@ -1,83 +1,92 @@
 require '/scripts/fupower.lua'
 
 function init()
-  self.powerLevel = config.getParameter("powerLevel",1)
-  power.init()
+	self.powerLevel = config.getParameter("powerLevel",1)
+	power.init()
 end
 
 function update(dt)
-  storage.checkticks = (storage.checkticks or 0) + dt
-  if storage.checkticks >= 10 then
-    storage.checkticks = storage.checkticks - 10
-    if isn_powerGenerationBlocked() then
-      animator.setAnimationState("meter", "0")
-      power.setPower(0)
-    else
-      local location = isn_getTruePosition()
-      local light = (world.type() ~= 'playerstation' and getLight(location) or 0.0) / 100.0
-	--sb.logInfo("l: light %s",light)
-      local genmult = 1
-      if world.type() == 'playerstation' then
-        genmult = 3.75 -- player space station always counts as high power, but never MAX power.
-      elseif light >= 0.85 then
-        genmult = 4 * (1 + light)
-      elseif light >= 0.75 then
-        genmult = 4
-      elseif light >= 0.65 then
-        genmult = 3
-      elseif light >= 0.55 then
-        genmult = 2
-      elseif light <= 0 then
-        genmult = 0
-      end
-	--sb.logInfo("a: genmult %s",genmult)
-      if world.liquidAt(location)then genmult = genmult * 0.05 end -- water significantly reduces the output
-	--sb.logInfo("b: genmult %s",genmult)
+	storage.checkticks = (storage.checkticks or 0) + dt
+	if storage.checkticks >= 10 then
+		storage.checkticks = storage.checkticks - 10
+		if isn_powerGenerationBlocked() then
+			animator.setAnimationState("meter", "0")
+			power.setPower(0)
+		else
+			local location = isn_getTruePosition()
+			local light = (world.type() ~= 'playerstation' and getLight(location) or 0.0)
+			--addressing some special cases that can be made where light will vastly exceed expected values
+			while light  > 10.0 do
+				light=light/10.0
+			end
+			for x=9,2,-1 do
+				if light > x then
+					light=light/x
+				end
+			end
+			--sb.logInfo("l: light %s",light)
+			local genmult = 1
+			if world.type() == 'playerstation' then
+				genmult = 3.75 -- player space station always counts as high power, but never MAX power.
+			elseif light >= 0.85 then
+				genmult = 4 * (1 + light)
+			elseif light >= 0.75 then
+				genmult = 4
+			elseif light >= 0.65 then
+				genmult = 3
+			elseif light >= 0.55 then
+				genmult = 2
+			elseif light <= 0 then
+				genmult = 0
+			end
+			--sb.logInfo("a: genmult %s",genmult)
+			if world.liquidAt(location)then genmult = genmult * 0.05 end -- water significantly reduces the output
+			--sb.logInfo("b: genmult %s",genmult)
 
-      local generated = self.powerLevel * genmult
-	  
-	--sb.logInfo("c: generated %s powerLevel %s",self.powerLevel,generated)
-      if genmult >= 4 then
-        animator.setAnimationState("meter", "4")
-      elseif genmult >= 3 then
-        animator.setAnimationState("meter", "3")
-      elseif genmult >= 2 then
-        animator.setAnimationState("meter", "2")
-      elseif genmult > 0 then
-        animator.setAnimationState("meter", "1")
-      else
-        animator.setAnimationState("meter", "0")
-      end
-      power.setPower(generated)
-    end
-  end
-  power.update(dt)
+			local generated = self.powerLevel * genmult
+			
+			--sb.logInfo("c: powerLevel %s generated %s",self.powerLevel,generated)
+			if genmult >= 4 then
+				animator.setAnimationState("meter", "4")
+			elseif genmult >= 3 then
+				animator.setAnimationState("meter", "3")
+			elseif genmult >= 2 then
+				animator.setAnimationState("meter", "2")
+			elseif genmult > 0 then
+				animator.setAnimationState("meter", "1")
+			else
+				animator.setAnimationState("meter", "0")
+			end
+			power.setPower(generated)
+		end
+	end
+	power.update(dt)
 end
 
 function getLight(location)
-  local objects = world.objectQuery(entity.position(), 20)
-  local lights = {}
-  for i=1,#objects do
-    local light = world.callScriptedEntity(objects[i],'object.getLightColor')
-    if light and (light[1] > 0 or light[2] > 0 or light[3] > 0) then
-      lights[objects[i]] = light
-      world.callScriptedEntity(objects[i],'object.setLightColor',{light[1]/3,light[2]/3,light[3]/3})
-    end
-  end
-  local light = world.lightLevel(location)
-  for key,value in pairs(lights) do
-    world.callScriptedEntity(key,'object.setLightColor',value)
-  end
-  return light
+	local objects = world.objectQuery(entity.position(), 20)
+	local lights = {}
+	for i=1,#objects do
+		local light = world.callScriptedEntity(objects[i],'object.getLightColor')
+		if light and (light[1] > 0 or light[2] > 0 or light[3] > 0) then
+			lights[objects[i]] = light
+			world.callScriptedEntity(objects[i],'object.setLightColor',{light[1]/3,light[2]/3,light[3]/3})
+		end
+	end
+	local light = world.lightLevel(location)
+	for key,value in pairs(lights) do
+		world.callScriptedEntity(key,'object.setLightColor',value)
+	end
+	return light
 end
 
 function isn_powerGenerationBlocked()
-  -- Power generation does not occur if...
-  local location = isn_getTruePosition()
-  return world.underground(location) or world.lightLevel(location) < 0.2 or (world.timeOfDay() > 0.55 and world.type() ~= 'playerstation') --or world.type == 'unknown'
+	-- Power generation does not occur if...
+	local location = isn_getTruePosition()
+	return world.underground(location) or world.lightLevel(location) < 0.2 or (world.timeOfDay() > 0.55 and world.type() ~= 'playerstation') --or world.type == 'unknown'
 end
 
 function isn_getTruePosition()
-  storage.truepos = storage.truepos or {entity.position()[1] + math.random(2,3), entity.position()[2] + 1}
-  return storage.truepos
+	storage.truepos = storage.truepos or {entity.position()[1] + math.random(2,3), entity.position()[2] + 1}
+	return storage.truepos
 end

--- a/objects/power/isn_solarpanel.lua
+++ b/objects/power/isn_solarpanel.lua
@@ -15,7 +15,7 @@ function update(dt)
     else
       local location = isn_getTruePosition()
       local light = (world.type() ~= 'playerstation' and getLight(location) or 0.0) / 100.0
-	sb.logInfo("l: light %s",light)
+	--sb.logInfo("l: light %s",light)
       local genmult = 1
       if world.type() == 'playerstation' then
         genmult = 3.75 -- player space station always counts as high power, but never MAX power.
@@ -30,13 +30,13 @@ function update(dt)
       elseif light <= 0 then
         genmult = 0
       end
-	sb.logInfo("a: genmult %s",genmult)
+	--sb.logInfo("a: genmult %s",genmult)
       if world.liquidAt(location)then genmult = genmult * 0.05 end -- water significantly reduces the output
-	sb.logInfo("b: genmult %s",genmult)
+	--sb.logInfo("b: genmult %s",genmult)
 
       local generated = self.powerLevel * genmult
 	  
-	sb.logInfo("c: generated %s powerLevel %s",self.powerLevel,generated)
+	--sb.logInfo("c: generated %s powerLevel %s",self.powerLevel,generated)
       if genmult >= 4 then
         animator.setAnimationState("meter", "4")
       elseif genmult >= 3 then

--- a/objects/power/isn_solarpanel/isn_solarpanel.object
+++ b/objects/power/isn_solarpanel/isn_solarpanel.object
@@ -40,5 +40,5 @@
   
   "isn_powerSupplier" : true,
   "powertype" : "output",
-  "powerLevel" : 1
+  "powerLevel" : 1.0
 }

--- a/objects/wired/lightsensor/advancedlightsensor.lua
+++ b/objects/wired/lightsensor/advancedlightsensor.lua
@@ -9,7 +9,7 @@ function init()
 end
 
 function getSample()
-  local sample = world.lightLevel(object.position())
+  local sample = math.min(world.lightLevel(object.position()),1.0)
   return math.floor(sample * 1000) * 0.1
 end
 

--- a/scripts/fr_scripts/floranStuff.lua
+++ b/scripts/fr_scripts/floranStuff.lua
@@ -40,7 +40,7 @@ function FRHelper:call(args, main, dt, ...)
 	end
 	
 	local daytime = world.timeOfDay() < 0.5
-	local lightLevel = world.lightLevel(mcontroller.position())
+	local lightLevel = math.min(world.lightLevel(mcontroller.position()),1.0)
 	
 	-- Night penalties
 	if not daytime then

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/starkillersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/starkillersetbonuseffect.lua
@@ -31,7 +31,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/fu_effects/drain/drainnightar.lua
+++ b/stats/effects/fu_effects/drain/drainnightar.lua
@@ -25,7 +25,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/stats/effects/fu_effects/stealthed/stealthed.lua
+++ b/stats/effects/fu_effects/stealthed/stealthed.lua
@@ -44,7 +44,7 @@ function update(dt)
     self.damageListener3:update()
     
         
-    local stealthTransparency = string.format("%X", math.max(math.floor(100 - 50*world.lightLevel(mcontroller.position())), 50))
+    local stealthTransparency = string.format("%X", math.max(math.floor(100 - 50*math.min(1.0,world.lightLevel(mcontroller.position()))), 50))
     if string.len(stealthTransparency) == 1 then stealthTransparency = "0"..stealthTransparency end
     effect.setParentDirectives("multiply=ffffff"..stealthTransparency)
     --sb.logInfo("Light: %s, Speed: %s, Sum: %s", world.lightLevel(mcontroller.position()), vec2.mag(mcontroller.velocity()), stealthCost/args.dt)

--- a/stats/effects/fu_tileeffects/specialty_effects/darkstalker/darkstalker.lua
+++ b/stats/effects/fu_tileeffects/specialty_effects/darkstalker/darkstalker.lua
@@ -39,7 +39,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/stats/effects/fu_weathereffects/new/fuWeatherBase.lua
+++ b/stats/effects/fu_weathereffects/new/fuWeatherBase.lua
@@ -191,7 +191,7 @@ function fuWeatherBase.lightLevel(self)
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/passive/darkhunternightar.lua
+++ b/stats/effects/passive/darkhunternightar.lua
@@ -19,7 +19,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/stats/effects/passive/elduukharflight.lua
+++ b/stats/effects/passive/elduukharflight.lua
@@ -16,7 +16,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/passive/lighthunter.lua
+++ b/stats/effects/passive/lighthunter.lua
@@ -9,7 +9,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/passive/mothflight.lua
+++ b/stats/effects/passive/mothflight.lua
@@ -54,17 +54,17 @@ function update(dt)
     self.foodValue = status.resource("food")
     
     if not daytime and lightLevel <= 60 or underground then --if its dark or underground, a saturnian can regen their food if its dark enough
-    		if (hungerLevel < hungerMax) and ( self.tickTimer <= 0 ) then
-    			self.tickTimer = self.tickTime
-    			adjustedHunger = hungerLevel + (hungerLevel * 0.0075)
-    			status.setResource("food", adjustedHunger)
+		if (hungerLevel < hungerMax) and ( self.tickTimer <= 0 ) then
+			self.tickTimer = self.tickTime
+			adjustedHunger = hungerLevel + (hungerLevel * 0.0075)
+			status.setResource("food", adjustedHunger)
 		end	
     end
     if not daytime and lightLevel >= 60 then --if its night and they are in bright light, a saturnian can regen their food 
-    		if (hungerLevel < hungerMax) and ( self.tickTimer <= 0 ) then
-    			self.tickTimer = self.tickTime
-    			adjustedHunger = hungerLevel + (lightLevel * 0.007)
-    			status.setResource("food", adjustedHunger)
+		if (hungerLevel < hungerMax) and ( self.tickTimer <= 0 ) then
+			self.tickTimer = self.tickTime
+			adjustedHunger = hungerLevel + (lightLevel * 0.007)
+			status.setResource("food", adjustedHunger)
 		end	
     end
 end

--- a/stats/effects/passive/mothflight.lua
+++ b/stats/effects/passive/mothflight.lua
@@ -27,7 +27,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/passive/nightfear.lua
+++ b/stats/effects/passive/nightfear.lua
@@ -9,7 +9,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/stats/effects/passive/saturnflight.lua
+++ b/stats/effects/passive/saturnflight.lua
@@ -54,17 +54,17 @@ function update(dt)
     self.foodValue = status.resource("food")
     
     if daytime and lightLevel then --if its day, a saturnian can regen their food if flying stationary. More light = more regen
-    		if (hungerLevel < hungerMax) and ( self.tickTimer <= 0 ) then
-    			self.tickTimer = self.tickTime
-    			adjustedHunger = hungerLevel + (lightLevel * 0.008)
-    			status.setResource("food", adjustedHunger)
+		if (hungerLevel < hungerMax) and ( self.tickTimer <= 0 ) then
+			self.tickTimer = self.tickTime
+			adjustedHunger = hungerLevel + (lightLevel * 0.008)
+			status.setResource("food", adjustedHunger)
 		end	
     end 
     if not daytime and lightLevel >= 60 then --if its night and they are in bright light, a saturnian can regen their food if flying stationary
-    		if (hungerLevel < hungerMax) and ( self.tickTimer <= 0 ) then
-    			self.tickTimer = self.tickTime
-    			adjustedHunger = hungerLevel + (lightLevel * 0.0075)
-    			status.setResource("food", adjustedHunger)
+		if (hungerLevel < hungerMax) and ( self.tickTimer <= 0 ) then
+			self.tickTimer = self.tickTime
+			adjustedHunger = hungerLevel + (lightLevel * 0.0075)
+			status.setResource("food", adjustedHunger)
 		end	
     end    
 end

--- a/stats/effects/passive/saturnflight.lua
+++ b/stats/effects/passive/saturnflight.lua
@@ -27,7 +27,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/passive/trolllighteffect.lua
+++ b/stats/effects/passive/trolllighteffect.lua
@@ -8,7 +8,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/passive/underworlder.lua
+++ b/stats/effects/passive/underworlder.lua
@@ -44,12 +44,6 @@ function update(dt)
 	  {stat = "energyRegenPercentageRate", amount = self.sunIntensity + 0.24},
 	  {stat = "maxHealth", amount = self.sunIntensity + 1.12}
 	  })
-    elseif lightLevel > 0 then
-	  effect.setStatModifierGroup(underWorlderEffects, {
-	  {stat = "radioactiveResistance", amount = self.sunIntensity + self.radiantWorld + 0.1},
-	  {stat = "energyRegenPercentageRate", amount = self.sunIntensity + 0.23},
-	  {stat = "maxHealth", amount = self.sunIntensity + 1.12}
-	  })
     elseif lightLevel > 95 then
 	  effect.setStatModifierGroup(underWorlderEffects, {
 	  {stat = "radioactiveResistance", amount = self.sunIntensity + self.radiantWorld + 0.001},
@@ -103,6 +97,12 @@ function update(dt)
 	  {stat = "radioactiveResistance", amount = self.sunIntensity + self.radiantWorld + 0.009},
 	  {stat = "energyRegenPercentageRate", amount = self.sunIntensity + 0.22},
 	  {stat = "maxHealth", amount = self.sunIntensity + 1.1}
+	  })
+    elseif lightLevel >= 0 then
+	  effect.setStatModifierGroup(underWorlderEffects, {
+	  {stat = "radioactiveResistance", amount = self.sunIntensity + self.radiantWorld + 0.1},
+	  {stat = "energyRegenPercentageRate", amount = self.sunIntensity + 0.23},
+	  {stat = "maxHealth", amount = self.sunIntensity + 1.12}
 	  })
 	else
 	  effect.setStatModifierGroup(underWorlderEffects,{})

--- a/stats/effects/passive/underworlder.lua
+++ b/stats/effects/passive/underworlder.lua
@@ -13,7 +13,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/regeneration/darkregen.lua
+++ b/stats/effects/regeneration/darkregen.lua
@@ -23,7 +23,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/regeneration/darkregenenergy.lua
+++ b/stats/effects/regeneration/darkregenenergy.lua
@@ -22,7 +22,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/stats/effects/regeneration/darkregenenergy.lua
+++ b/stats/effects/regeneration/darkregenenergy.lua
@@ -40,32 +40,26 @@ function update(dt)
   if nighttime or underground then
 	if lightLevel <= 1 then
 	    self.healingRate = 1.01 / config.getParameter("healTime", 180)
-	    status.modifyResourcePercentage("energy", self.healingRate * dt)
 	elseif lightLevel <= 2 then
 	    self.healingRate = 1.008 / config.getParameter("healTime", 200)
-	    status.modifyResourcePercentage("energy", self.healingRate * dt)
 	elseif lightLevel <= 5 then
 	    self.healingRate = 1.007 / config.getParameter("healTime", 220)
-	    status.modifyResourcePercentage("energy", self.healingRate * dt)
 	elseif lightLevel <= 7 then
 	    self.healingRate = 1.006 / config.getParameter("healTime", 240)
-	    status.modifyResourcePercentage("energy", self.healingRate * dt)
 	elseif lightLevel <= 12 then
 	    self.healingRate = 1.005 / config.getParameter("healTime", 280)
-	    status.modifyResourcePercentage("energy", self.healingRate * dt)
 	elseif lightLevel <= 15 then
 	    self.healingRate = 1.004 / config.getParameter("healTime", 320)
-	    status.modifyResourcePercentage("energy", self.healingRate * dt)
 	elseif lightLevel <= 18 then
 	    self.healingRate = 1.003 / config.getParameter("healTime", 350)
-	    status.modifyResourcePercentage("energy", self.healingRate * dt)
 	elseif lightLevel <= 22 then
 	    self.healingRate = 1.002 / config.getParameter("healTime", 380)
-	    status.modifyResourcePercentage("energy", self.healingRate * dt)
 	elseif lightLevel <= 25 then
 	    self.healingRate = 1.001 / config.getParameter("healTime", 420)
-	    status.modifyResourcePercentage("energy", self.healingRate * dt)
+	else
+		self.healingRate=0
 	end  
+	status.modifyResourcePercentage("energy", self.healingRate * dt)
   end
 		
 end

--- a/stats/effects/regeneration/darkregenfenerox.lua
+++ b/stats/effects/regeneration/darkregenfenerox.lua
@@ -38,7 +38,7 @@ function update(dt)
 		self.foodValue = 70
 	end
 
-	local lightLevel = getLight()
+	--local lightLevel = getLight()--not actually used
 
 	if nighttime or underground and (self.foodValue >= 45) then
 		self.healingRate = 1.007 / config.getParameter("healTime", 220)

--- a/stats/effects/regeneration/darkregenfenerox.lua
+++ b/stats/effects/regeneration/darkregenfenerox.lua
@@ -12,7 +12,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/stats/effects/regeneration/lightregen.lua
+++ b/stats/effects/regeneration/lightregen.lua
@@ -13,7 +13,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/stats/effects/regeneration/lightregenenergy.lua
+++ b/stats/effects/regeneration/lightregenenergy.lua
@@ -13,7 +13,7 @@ function getLight()
   local position = mcontroller.position()
   position[1] = math.floor(position[1])
   position[2] = math.floor(position[2])
-  local lightLevel = world.lightLevel(position)
+  local lightLevel = math.min(world.lightLevel(position),1.0)
   lightLevel = math.floor(lightLevel * 100)
   return lightLevel
 end

--- a/tech/other/huntersclaw.lua
+++ b/tech/other/huntersclaw.lua
@@ -25,7 +25,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/tech/other/minersclaw.lua
+++ b/tech/other/minersclaw.lua
@@ -25,7 +25,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end]]

--- a/tech/other/nightarconshak.lua
+++ b/tech/other/nightarconshak.lua
@@ -57,7 +57,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/tech/other/tenebrhaeburst.lua
+++ b/tech/other/tenebrhaeburst.lua
@@ -24,7 +24,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end

--- a/tech/other/veluuclaw.lua
+++ b/tech/other/veluuclaw.lua
@@ -26,7 +26,7 @@ function getLight()
 	local position = mcontroller.position()
 	position[1] = math.floor(position[1])
 	position[2] = math.floor(position[2])
-	local lightLevel = world.lightLevel(position)
+	local lightLevel = math.min(world.lightLevel(position),1.0)
 	lightLevel = math.floor(lightLevel * 100)
 	return lightLevel
 end


### PR DESCRIPTION
Fixed crystal skull not teleporting due to a missed condition

adjusted solar panels to provide power more in line with their size and creation requirements. in the test environment used (standard lush starter world, midday), the base solar panel produced roughly 4w (8w for 2, 16w for 4), the 2nd tier produced roughly 10w (20w for 2), and the highest tier produced 24w. This helps make the higher tiers more of a reward for their investment, instead of being completely inferior.

moved genmult cap (was 32) to light level (now 1.0), to address a specific exploit using compressed liquids such as lava.

Added ceiling to various light level checks due to the above.
thankfully, except for a few cases this will have been a nonissue. saturnians having infinite food wouldnt have been much issue, but light regen granting effective immortality? Ew.

corrected incorrect elseif order in 'underworlder.lua', resulting in it  always picking the >0 option.