### PR TITLE
cat. not a people person.

### DIFF
--- a/items/active/weapons/melee/meleecombo.lua
+++ b/items/active/weapons/melee/meleecombo.lua
@@ -563,6 +563,7 @@ function MeleeCombo:wait()
 	if stance then
 		self.weapon:setStance(stance)
 	else
+		stance={}
 		stance.duration=0.12
 	end
 	

--- a/items/active/weapons/melee/meleecombo.lua
+++ b/items/active/weapons/melee/meleecombo.lua
@@ -8,25 +8,30 @@ function MeleeCombo:init()
     status.clearPersistentEffects("combobonusdmg")
 	self.comboStep = 1
 
-	--local animationCustom=config.getParameter("animationCustom")
-	local animationData=config.getParameter("animation")
-	if type(animationData)=="string" and animationData:sub(1,1)=="/" then
-		animationData=root.assetJson(animationData)
-	elseif type(animationData)=="string" then
-		local buffer=world.entityHandItem(activeItem.ownerEntityId(),activeItem.hand())
-		buffer=root.itemConfig(buffer).directory..animationData
-		animationData=root.assetJson(buffer)
-	else
-		animationData=nil
-	end
 	self.swooshList={}
-	if animationData then
-		local buffer = animationData.animatedParts and animationData.animatedParts.stateTypes and animationData.animatedParts.stateTypes.swoosh and animationData.animatedParts.stateTypes.swoosh.states
-		for swoosh,_ in pairs(buffer) do
+	local animationCustom=config.getParameter("animationCustom") --first, we check if it has custom animation overrides.
+	if animationCustom and animationCustom.animatedParts and animationCustom.animatedParts.stateTypes and animationCustom.animatedParts.stateTypes.swoosh and animationCustom.animatedParts.stateTypes.swoosh.states then
+		for swoosh,_ in pairs(animationCustom.animatedParts.stateTypes.swoosh.states) do
 			self.swooshList[swoosh]=true
 		end
+	else -- if there are no custom animation overrides we go to the animation file
+		local animationData=config.getParameter("animation")
+		if type(animationData)=="string" and animationData:sub(1,1)=="/" then
+			animationData=root.assetJson(animationData)
+		elseif type(animationData)=="string" then
+			local buffer=world.entityHandItem(activeItem.ownerEntityId(),activeItem.hand())
+			buffer=root.itemConfig(buffer).directory..animationData
+			animationData=root.assetJson(buffer)
+		else
+			animationData=nil
+		end
+		if animationData then
+			local buffer = animationData.animatedParts and animationData.animatedParts.stateTypes and animationData.animatedParts.stateTypes.swoosh and animationData.animatedParts.stateTypes.swoosh.states
+			for swoosh,_ in pairs(buffer) do
+				self.swooshList[swoosh]=true
+			end
+		end
 	end
-
 	self.energyUsage = self.energyUsage or 0
 
 	self:computeDamageAndCooldowns()

--- a/items/active/weapons/melee/meleecombo.lua
+++ b/items/active/weapons/melee/meleecombo.lua
@@ -559,14 +559,14 @@ end
 -- waiting for next combo input
 function MeleeCombo:wait()
 	local stance = self.stances["wait"..(self.comboStep - 1)] or self.stances["wait"] or self.stances["wait".."0"] or self.stances["wait".."1"] or self.stances["wait".."2"] or self.stances["wait".."3"]
-	
+
 	if stance then
 		self.weapon:setStance(stance)
 	else
 		stance={}
 		stance.duration=0.12
 	end
-	
+
 	util.wait(stance.duration, function()
         if self:shouldActivate() then
             self:setState(self.windup)

--- a/items/active/weapons/melee/meleecombo.lua
+++ b/items/active/weapons/melee/meleecombo.lua
@@ -558,10 +558,14 @@ end
 -- State: wait
 -- waiting for next combo input
 function MeleeCombo:wait()
-	local stance = self.stances["wait"..(self.comboStep - 1)]
-
-	self.weapon:setStance(stance)
-
+	local stance = self.stances["wait"..(self.comboStep - 1)] or self.stances["wait"] or self.stances["wait".."0"] or self.stances["wait".."1"] or self.stances["wait".."2"] or self.stances["wait".."3"]
+	
+	if stance then
+		self.weapon:setStance(stance)
+	else
+		stance.duration=0.12
+	end
+	
 	util.wait(stance.duration, function()
         if self:shouldActivate() then
             self:setState(self.windup)

--- a/items/active/weapons/melee/meleeslash.lua
+++ b/items/active/weapons/melee/meleeslash.lua
@@ -79,15 +79,23 @@ end
 
 -- State: windup
 function MeleeSlash:windup()
-	self.energyTotal = (status.stat("maxEnergy") * 0.05)
-		if status.resource("energy") <= 1 then 
-			status.modifyResource("energy",1) 
-			cancelEffects()
-		end 
-		if status.resource("energy") == 1 then 
-			cancelEffects() 
+	self.energyMax = status.resourceMax("energy")
+	self.energyCurrent = status.resource("energy")
+	self.energyTotal = math.min(math.max(1,(self.energyCurrent-1)), (self.energyMax * 0.05))
+	
+	
+	if self.energyCurrent <= 1 then
+		if self.energyMax >= 1 then -- due to weather and other cases it is possible to have a maximum of under 1.
+			status.modifyResource("energy",1)
+			self.energyCurrent = status.resource("energy")
+			self.energyTotal = math.min(math.max(1,(self.energyCurrent-1)), (self.energyMax * 0.05))
 		end
-	if status.consumeResource("energy",math.min((status.resource("energy")-1), self.energyTotal)) then 
+		cancelEffects()
+	end 
+	if status.resource("energy") == 1 then 
+		cancelEffects() 
+	end
+	if (self.energyCurrent > 1) and status.consumeResource("energy",self.energyTotal) then 
 		self.weapon:setStance(self.stances.windup)
 
 		if self.stances.windup.hold then

--- a/items/active/weapons/weapon.lua
+++ b/items/active/weapons/weapon.lua
@@ -146,10 +146,10 @@ function Weapon:updateAim()
   elseif self.stance.aimAngle then
     self.aimAngle = self.stance.aimAngle
   end
-  
+
   --activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation)
   activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation, not self.stance.noAimCompensation)   -- StardustLib edit; added allowRotate parameter
-  
+
   local isPrimary = activeItem.hand() == "primary"
   if isPrimary then
     -- primary hand weapons should set their aim direction whenever they can be flipped,

--- a/items/active/weapons/weapon.lua
+++ b/items/active/weapons/weapon.lua
@@ -253,6 +253,7 @@ function Weapon:damageSource(damageConfig, damageArea, damageTimeout)
 end
 
 function Weapon:setStance(stance)
+  stance=stance or {}
   self.stance = stance
   self.weaponOffset = stance.weaponOffset or {0,0}
   self.relativeWeaponRotation = util.toRadians(stance.weaponRotation or 0)

--- a/items/armors/apex/apex-tier1/apextier1.chest.patch
+++ b/items/armors/apex/apex-tier1/apextier1.chest.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/apex/apex-tier1/apextier1.head.patch
+++ b/items/armors/apex/apex-tier1/apextier1.head.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/apex/apex-tier1/apextier1.legs.patch
+++ b/items/armors/apex/apex-tier1/apextier1.legs.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/avian/avian-tier1/aviantier1.chest.patch
+++ b/items/armors/avian/avian-tier1/aviantier1.chest.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/avian/avian-tier1/aviantier1.head.patch
+++ b/items/armors/avian/avian-tier1/aviantier1.head.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/avian/avian-tier1/aviantier1.legs.patch
+++ b/items/armors/avian/avian-tier1/aviantier1.legs.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/floran/floran-tier1/florantier1.chest.patch
+++ b/items/armors/floran/floran-tier1/florantier1.chest.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/floran/floran-tier1/florantier1.head.patch
+++ b/items/armors/floran/floran-tier1/florantier1.head.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/floran/floran-tier1/florantier1.legs.patch
+++ b/items/armors/floran/floran-tier1/florantier1.legs.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/glitch/glitch-tier1/glitchtier1.chest.patch
+++ b/items/armors/glitch/glitch-tier1/glitchtier1.chest.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/glitch/glitch-tier1/glitchtier1.head.patch
+++ b/items/armors/glitch/glitch-tier1/glitchtier1.head.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/glitch/glitch-tier1/glitchtier1.legs.patch
+++ b/items/armors/glitch/glitch-tier1/glitchtier1.legs.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/human/human-tier1/humantier1.chest.patch
+++ b/items/armors/human/human-tier1/humantier1.chest.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/human/human-tier1/humantier1.head.patch
+++ b/items/armors/human/human-tier1/humantier1.head.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/human/human-tier1/humantier1.legs.patch
+++ b/items/armors/human/human-tier1/humantier1.legs.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/hylotl/hylotl-tier1/hylotltier1.chest.patch
+++ b/items/armors/hylotl/hylotl-tier1/hylotltier1.chest.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/hylotl/hylotl-tier1/hylotltier1.head.patch
+++ b/items/armors/hylotl/hylotl-tier1/hylotltier1.head.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/hylotl/hylotl-tier1/hylotltier1.legs.patch
+++ b/items/armors/hylotl/hylotl-tier1/hylotltier1.legs.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/novakid/nova-tier1/novatier1.chest.patch
+++ b/items/armors/novakid/nova-tier1/novatier1.chest.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/novakid/nova-tier1/novatier1.head.patch
+++ b/items/armors/novakid/nova-tier1/novatier1.head.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/items/armors/novakid/nova-tier1/novatier1.legs.patch
+++ b/items/armors/novakid/nova-tier1/novatier1.legs.patch
@@ -2,7 +2,7 @@
 	[{
 			"op": "test",
 			"path": "/itemTags",
-			"inverse": false
+			"inverse": true
 		},
 		{
 			"op": "add",
@@ -17,8 +17,7 @@
 	],
 	[{
 			"op": "test",
-			"path": "/itemTags",
-			"inverse": true
+			"path": "/itemTags"
 		},
 		{
 			"op": "add",

--- a/scripts/fu_player_init.lua
+++ b/scripts/fu_player_init.lua
@@ -30,6 +30,8 @@ function init(...)
 	message.setHandler("player.enabledTechs", player.enabledTechs)
 	message.setHandler("player.shipUpgrades", player.shipUpgrades)
 	message.setHandler("player.isAdmin", player.isAdmin)
+	message.setHandler("player.isLounging", player.isLounging)
+	message.setHandler("player.loungingIn", player.loungingIn)
 	message.setHandler("player.equippedItem",function (_,_,...) return player.equippedItem(...) end)
 	
 	message.setHandler("fu_specialAnimator.playAudio",function (_,_,...) localAnimator.playAudio(...) end)


### PR DESCRIPTION
corrected vanilla t1 armor patches, which had incorrect test ops and were causing issues for other mods apparently.

meleeslash.lua: corrected error case if max energy is less than 1. because lightning. also implemented 0.75x damage multiplier when energy is less than 1, or recharging.

meleecombo.lua: implemented fix for modded weapons that use meleecombo.lua and not any anim file we cover. they should no longer error. sorry ERM, etc, users. implemented sanity checking  and fallbacks for meleecombo:wait function, as it was attempting to execute nonexistent stances and erroring. Corrected several counts of awkward math which resulted in some penalties being bonuses, and some bonuses being penalties, and some being neither.

weapon.lua: added an additional sanity check in case of being passed a nil stance.

fu_player_init: now allows querying of player lounging state, and player lounging object

cat_primary.lua: addressed issue where cats could drown because of nap position.