### PR TITLE
uh...ouch

### DIFF
--- a/items/active/weapons/protectorate/brokenprotectoratebroadsword.activeitem.patch
+++ b/items/active/weapons/protectorate/brokenprotectoratebroadsword.activeitem.patch
@@ -22,5 +22,10 @@
     "op": "add",
     "path": "/itemTags/-",
     "value": "upgradeableWeapon"
+  },
+  {
+    "op": "add",
+    "path": "/itemTags/-",
+    "value": "protectorate"
   }
 ]

--- a/items/armors/tier4/x10/xeno.chest
+++ b/items/armors/tier4/x10/xeno.chest
@@ -6,7 +6,7 @@
   "rarity" : "uncommon",
    "description" : "^orange;Set Bonuses^reset;: 
 ^yellow;^reset; Fall Damage x^green;0.7^reset;
-^yellow;^reset; Assault/Energy Rifle: Damage x^green;1.25^reset; and +^green;2^reset;% Crit Chance
+^yellow;^reset; Assault/Energy Rifle: Damage x^green;1.2^reset; and +^green;2^reset;% Crit Chance
 ^yellow;^reset; ^cyan;Immune^reset;: Oxygen, Gas, Liq. Nitrogen, Cold",  
   "shortdescription" : "X10 Power Armor",
   "category" : "chestarmour",

--- a/items/armors/tier4/x10/xeno.head
+++ b/items/armors/tier4/x10/xeno.head
@@ -7,7 +7,7 @@
    "description" : "^cyan;Headlamp^reset;
 ^orange;Set Bonuses^reset;: 
 ^yellow;^reset; Fall Damage x^green;0.7^reset;
-^yellow;^reset; Assault/Energy Rifle: Damage x^green;1.25^reset; and +^green;2^reset;% Crit Chance
+^yellow;^reset; Assault/Energy Rifle: Damage x^green;1.2^reset; and +^green;2^reset;% Crit Chance
 ^yellow;^reset; ^cyan;Immune^reset;: Oxygen, Gas, Liq. Nitrogen, Cold", 
   "shortdescription" : "X10 Power Helm",
   "category" : "headarmour",

--- a/items/armors/tier4/x10/xeno.legs
+++ b/items/armors/tier4/x10/xeno.legs
@@ -6,7 +6,7 @@
   "rarity" : "uncommon",
    "description" : "^orange;Set Bonuses^reset;: 
 ^yellow;^reset; Fall Damage x^green;0.7^reset;
-^yellow;^reset; Assault/Energy Rifle: Damage x^green;1.25^reset; and +^green;2^reset;% Crit Chance
+^yellow;^reset; Assault/Energy Rifle: Damage x^green;1.2^reset; and +^green;2^reset;% Crit Chance
 ^yellow;^reset; ^cyan;Immune^reset;: Oxygen, Gas, Liq. Nitrogen, Cold", 
   "shortdescription" : "X10 Power Legs",
   "category" : "legarmour",

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/x10setbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/x10setbonuseffect.lua
@@ -14,7 +14,7 @@ armorEffect={
 	{stat = "gasImmunity", amount = 1.0},
 	{stat = "liquidnitrogenImmunity", amount = 1.0},
 	{stat = "biomecoldImmunity", amount = 1.0},
-	{stat = "fallDamageMultiplier", amount = 0.70}
+	{stat = "fallDamageMultiplier", effectiveMultiplier = 0.70}
 }
 
 require "/stats/effects/fu_armoreffects/setbonuses_common.lua"

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/xenosetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/xenosetbonuseffect.lua
@@ -10,7 +10,7 @@ armorEffect={
 	{stat = "gasImmunity", amount = 1.0},
 	{stat = "liquidnitrogenImmunity", amount = 1.0},
 	{stat = "biomecoldImmunity", amount = 1.0},
-	{stat = "fallDamageMultiplier", amount = 0.70}
+	{stat = "fallDamageMultiplier", effectiveMultiplier = 0.70}
 }
 
 require "/stats/effects/fu_armoreffects/setbonuses_common.lua"


### PR DESCRIPTION
added protectorate tag to broken broadsword
corrected x10 tooltip
corrected a 3 year old bug with the x10 and xeno sets: they were increasing fall damage multiplier by 0.7...not multiplying it.