### PR TITLE
Fix Atmospheric Condenser

### DIFF
--- a/interface/cockpit/cockpit.lua
+++ b/interface/cockpit/cockpit.lua
@@ -1281,7 +1281,7 @@ function planetScreenState(planet)
             orbiting = shipLocation[2]
           end
           if orbiting and compare(coordinatePlanet(orbiting), coordinatePlanet(self.travel.target[2])) then
-            celestial.flyShip(self.travel.system, self.travel.target)
+            flyShip(self.travel.system, self.travel.target)
             self.travel = {}
           end
         end


### PR DESCRIPTION
Atmospheric Condenser relies on "ship.celestial_type" property to track current planet when installed on ship. "flyShip" it's wrapper to "celestial.flyShip" function which set that property. For some reason it was broken in 089a848cc5a69122cc4092573d65ea20662a0e84.