### PR TITLE
Fixed embalming brains

### DIFF
--- a/objects/minibiome/elder/embalmingtable/embalmingtable.lua
+++ b/objects/minibiome/elder/embalmingtable/embalmingtable.lua
@@ -35,9 +35,9 @@ local recipes =
 {inputs = { fuhair=1 }, outputs = { fuscienceresource = 5 }, time = 6.0},
 
 --brains
-{inputs = { fubrain=1 }, outputs = { inferiorbrain=1,fuscienceresource=5}, time = 6.0},
-{inputs = { fubrain=1,methanol=1 }, outputs = { brain=1,fuscienceresource=10,fumadnessresource=15}, time = 6.0},
 {inputs = { fubrain=1,methanol=1,liquidhealing=5 }, outputs = { brainpeerless=1,fuscienceresource=25,fumadnessresource=45}, time = 6.0},
+{inputs = { fubrain=1,methanol=1 }, outputs = { brain=1,fuscienceresource=10,fumadnessresource=15}, time = 6.0},
+{inputs = { fubrain=1 }, outputs = { inferiorbrain=1,fuscienceresource=5}, time = 6.0},
 
 --cadavers
 {inputs = { cadaver=1 }, outputs = { fuflesh=1, fuhair=1, fubrain=1, fuscienceresource=120, fumadnessresource=30,fleshstrand=4,liquidblood = 40,}, time = 8.0},
@@ -112,8 +112,11 @@ function getInputContents()
 
 function map(l,f)
     local res = {}
-    for k,v in pairs(l) do
-        res[k] = f(v)
+    for k,v in ipairs(l) do
+        local val = f(v)
+        if val ~= nil then
+          table.insert(res, val)
+        end
     end
     return res
 end

--- a/objects/minibiome/elder/embalmingtable/embalmingtable.lua
+++ b/objects/minibiome/elder/embalmingtable/embalmingtable.lua
@@ -1,95 +1,10 @@
-local recipes =
-{
-    -- frackin fishing addons
-{inputs = { FFpoorfish=5 }, outputs = { bone = 1,fuscienceresource=1, rawfish= 2, liquidpus = 1, cellmatter=1 }, time = 1.0},
-{inputs = { FFdecentfish=4 }, outputs = { bone = 1,fuscienceresource=2, rawfish= 2, liquidblood = 2  }, time = 1.0},
-{inputs = { FFgoodfish=3 }, outputs = { bone = 3,fuscienceresource=3, rawfish= 2, liquidblood = 3, inferiorbrain=1  }, time = 1.0},
-{inputs = { FFgreatfish=2 }, outputs = { bone = 3,fuscienceresource=4, rawfish= 3, liquidblood = 4, inferiorbrain=1, gene_fish=1  }, time = 1.0},
-{inputs = { FFpristinefish=1 }, outputs = { bone = 5,fuscienceresource=5, rawfish= 3, liquidblood = 5, inferiorbrain=1, gene_fish=1, gene_aquahomeo=1  }, time = 1.0},
-
---combos
-{inputs = { wrappedbody=1,elderrelic2=1 }, outputs = { inferiorbrain=1,fuscienceresource=520,bone=8,leather=1,alienmeat=4,faceskin=1,rawribmeat=2,liquidelderfluid=120  }, time = 14.0},
-{inputs = { wrappedbody=1,elderrelic10=1 }, outputs = { inferiorbrain=1,fumadnessresource=520,bone=8,leather=1,alienmeat=12,rawribmeat=2,liquidelderfluid=80  }, time = 14.0},
-{inputs = { wrappedbodyputrid=1,elderrelic2=1 }, outputs = { inferiorbrain=1,fuscienceresource=520,bone=8,leather=1,alienmeat=4,faceskin=1,rawribmeat=2,liquidelderfluid=120  }, time = 14.0},
-{inputs = { wrappedbodyputrid=1,elderrelic10=1 }, outputs = { inferiorbrain=1,fumadnessresource=520,bone=8,leather=1,alienmeat=12,rawribmeat=2,liquidelderfluid=80  }, time = 14.0},
-
---trashbag
-{inputs = { mysterioustrashbag=1 }, outputs = { cadaverrotting = 1}, time = 1.0},
-{inputs = { fumysterioustrashbag=1 }, outputs = { cadaverrotting = 1}, time = 1.0},
-
---flesh dissection
-{inputs = { fuflesh=1 }, outputs = { leather=3,faceskin=1,rawribmeat=2,bone=24,alienmeat=4,fufemur=2,futooth=20}, time = 6.0},
-{inputs = { fufleshalien=1 }, outputs = { leather=3,cellmateria=4,rawribmeat=2,bone=24,fufemur=2,futooth=20,gene_void=1}, time = 6.0},
-
---heart dissection
-{inputs = { fuheartalien=1 }, outputs = { liquidalienjuice = 5,gene_muscle=2,fleshstrand=5}, time = 6.0},
-{inputs = { fuheart=1 }, outputs = { liquidalienjuice = 5,gene_muscle=1,fleshstrand=3}, time = 6.0},
-
---tooth
-{inputs = { futooth=20 }, outputs = { bone = 1}, time = 1.0},
-
---femur
-{inputs = { fufemur=1 }, outputs = { bone = 5,gene_skeletal=1}, time = 6.0},
-
---hair
-{inputs = { fuhair=1 }, outputs = { fuscienceresource = 5 }, time = 6.0},
-
---brains
-{inputs = { fubrain=1,methanol=1,liquidhealing=5 }, outputs = { brainpeerless=1,fuscienceresource=25,fumadnessresource=45}, time = 6.0},
-{inputs = { fubrain=1,methanol=1 }, outputs = { brain=1,fuscienceresource=10,fumadnessresource=15}, time = 6.0},
-{inputs = { fubrain=1 }, outputs = { inferiorbrain=1,fuscienceresource=5}, time = 6.0},
-
---cadavers
-{inputs = { cadaver=1 }, outputs = { fuflesh=1, fuhair=1, fubrain=1, fuscienceresource=120, fumadnessresource=30,fleshstrand=4,liquidblood = 40,}, time = 8.0},
-{inputs = { cadaverrotting=1 }, outputs = { fuflesh=1, fuhair=1, fubrain=1,fuscienceresource=70,fleshstrand=1,liquidpoison = 20,}, time = 8.0},
-{inputs = { cadaverbirb=1 }, outputs = { fuflesh=1, fuhair=1, fubrain=1, blooddiamond=1, goldbar=2, fuscienceresource=90,fleshstrand=3 }, time = 8.0},
-{inputs = { cadaveralien=1 }, outputs = { fufleshalien=1,fubrain=1,fuheartalien=1,fuscienceresource=120, fumadnessresource=30,fleshstrand=6,liquidalienjuice = 40, }, time = 8.0},
-{inputs = { apexpod=1 }, outputs = { liquidbioooze=30, cadaver=1, apexpod2=1}, time = 8.0},
-{inputs = { floranpodapex=1 }, outputs = { cadaver=1, agaranichor=5, fuscienceresource=60, fumadnessresource=10}, time = 8.0},
-{inputs = { giantfloranpod=1 }, outputs = {  agaranichor=30, fuscienceresource=90, fumadnessresource=40}, time = 8.0},
-{inputs = { floranpod1=1 }, outputs = {  agaranichor=10, fuscienceresource=20, fumadnessresource=20}, time = 8.0},
-{inputs = { floranpod2=1 }, outputs = {  agaranichor=10, fuscienceresource=20, fumadnessresource=20}, time = 8.0},
-{inputs = { floranpod3=1 }, outputs = {  agaranichor=10, fuscienceresource=20, fumadnessresource=20}, time = 8.0},
-		
---wrapped bodies
-{inputs = { frontiercoffin=1 }, outputs = { cadaver=1,darkwoodmaterial=12,fuscienceresource=40,fumadnessresource=30}, time = 5.0},
-{inputs = { wrappedbody=1 }, outputs = { cadaver=1,bandage=12,fuscienceresource=40,fumadnessresource=30}, time = 5.0},
-{inputs = { wrappedbodyputrid=1 }, outputs = { cadaverrotting = 1,fumadnessresource=60,bandage=12 }, time = 5.0},
-{inputs = { wrappedbodyalien=1 }, outputs = { cadaveralien = 1,fumadnessresource=80,mutaviskbandage=12 }, time = 5.0},
-{inputs = { wrappedbodybirb=1 }, outputs = { cadaverbirb =1,fuscienceresource=50,fuhoneysilkbandage=12}, time = 5.0},
-
-
---miscellaneous
-{inputs = { larva=10 }, outputs = { liquidpus=1,cellmatter=1}, time = 2.0},
-{inputs = { greghead=1 }, outputs = { fumadnessresource=4,inferiorbrain=1,bone=4,slew2=3}, time = 7.0},
-{inputs = { severedheadplatter=1 }, outputs = { fumadnessresource=1,inferiorbrain=1,bone=4,slew2=3}, time = 7.0},
-{inputs = { faceskin=1 }, outputs = { fumadnessresource=1,liquidblood=1, slew2=1}, time = 2.0},
-{inputs = { leather=1 }, outputs = { slew2=1}, time = 2.0},
-{inputs = { hardenedcarapace=1 }, outputs = { slew2=1}, time = 2.0},
-{inputs = { agaranichor=1 }, outputs = { fuscienceresource=5}, time = 2.0},
-{inputs = { biospore=1 }, outputs = { cellmateria=1}, time = 2.0},
-{inputs = { blobbushjelly=1 }, outputs = { fumadnessresource=1,cellmateria=1}, time = 2.0},
-{inputs = { brain=1 }, outputs = { fumadnessresource=2,cellmateria=2}, time = 2.0},
-{inputs = { inferiorbrain=1 }, outputs = { fumadnessresource=1,cellmateria=1}, time = 2.0},
-{inputs = { bone=50 }, outputs = { bonemealmaterial=50}, time = 2.0},
-{inputs = { crunchychick=1 }, outputs = { fumadnessresource=3,bonemealmaterial=10,alienmeat=1}, time = 3.0},
-{inputs = { meatpickle=1 }, outputs = { fumadnessresource=2,alienmeat=1}, time = 2.0},
-{inputs = { milk=1,normaldrone=1 }, outputs = { sourmilkandbees=1}, time = 2.0},
-{inputs = { endomorphicjelly=1 }, outputs = { holidayspirit=50}, time = 2.0},
-{inputs = { monsterhide=1 }, outputs = { leather=1}, time = 1.0},
-{inputs = { avalisample3=1 }, outputs = { inferiorbrain=1}, time = 1.0},
-{inputs = { apexbrainjar=1 }, outputs = { inferiorbrain=1}, time = 1.0},
-{inputs = { apexbrainjar2=1 }, outputs = { brain=1}, time = 1.0},
-{inputs = { apexbrainjar3=1 }, outputs = { artificialbrain=1}, time = 1.0},	
-{inputs = { apexbrainjar4=1 }, outputs = { brainpeerless=1}, time = 1.0}
-}
-
 function init()
     self.timer = 1
     self.mintick = 1
     self.crafting = false
     self.output = {}
     self.setval = 1
+    self.recipeTable = root.assetJson('/objects/minibiome/elder/embalmingtable/embalmingtable_recipes.config')
 end
 
 function getInputContents()
@@ -142,7 +57,7 @@ function getValidRecipes(query)
         return true
     end
 
-return filter(recipes, function(l) return subset(l.inputs, query) end)
+return filter(self.recipeTable, function(l) return subset(l.inputs, query) end)
 
 end
 

--- a/objects/minibiome/elder/embalmingtable/embalmingtable_recipes.config
+++ b/objects/minibiome/elder/embalmingtable/embalmingtable_recipes.config
@@ -1,0 +1,83 @@
+[
+	//frackin fishing addons
+	{"inputs":{"FFpoorfish":5},"outputs":{"bone":1,"fuscienceresource":1,"rawfish":2,"liquidpus":1,"cellmatter":1},"time":1.0},
+	{"inputs":{"FFdecentfish":4},"outputs":{"bone":1,"fuscienceresource":2,"rawfish":2,"liquidblood":2},"time":1.0},
+	{"inputs":{"FFgoodfish":3},"outputs":{"bone":3,"fuscienceresource":3,"rawfish":2,"liquidblood":3,"inferiorbrain":1},"time":1.0},
+	{"inputs":{"FFgreatfish":2},"outputs":{"bone":3,"fuscienceresource":4,"rawfish":3,"liquidblood":4,"inferiorbrain":1,"gene_fish":1},"time":1.0},
+	{"inputs":{"FFpristinefish":1},"outputs":{"bone":5,"fuscienceresource":5,"rawfish":3,"liquidblood":5,"inferiorbrain":1,"gene_fish":1,"gene_aquahomeo":1},"time":1.0},
+
+	//combos
+	{"inputs":{"wrappedbody":1,"elderrelic2":1},"outputs":{"inferiorbrain":1,"fuscienceresource":520,"bone":8,"leather":1,"alienmeat":4,"faceskin":1,"rawribmeat":2,"liquidelderfluid":120},"time":14.0},
+	{"inputs":{"wrappedbody":1,"elderrelic10":1},"outputs":{"inferiorbrain":1,"fumadnessresource":520,"bone":8,"leather":1,"alienmeat":12,"rawribmeat":2,"liquidelderfluid":80},"time":14.0},
+	{"inputs":{"wrappedbodyputrid":1,"elderrelic2":1},"outputs":{"inferiorbrain":1,"fuscienceresource":520,"bone":8,"leather":1,"alienmeat":4,"faceskin":1,"rawribmeat":2,"liquidelderfluid":120},"time":14.0},
+	{"inputs":{"wrappedbodyputrid":1,"elderrelic10":1},"outputs":{"inferiorbrain":1,"fumadnessresource":520,"bone":8,"leather":1,"alienmeat":12,"rawribmeat":2,"liquidelderfluid":80},"time":14.0},
+
+	//trashbag
+	{"inputs":{"mysterioustrashbag":1},"outputs":{"cadaverrotting":1},"time":1.0},
+	{"inputs":{"fumysterioustrashbag":1},"outputs":{"cadaverrotting":1},"time":1.0},
+
+	//flesh dissection
+	{"inputs":{"fuflesh":1},"outputs":{"leather":3,"faceskin":1,"rawribmeat":2,"bone":24,"alienmeat":4,"fufemur":2,"futooth":20},"time":6.0},
+	{"inputs":{"fufleshalien":1},"outputs":{"leather":3,"cellmateria":4,"rawribmeat":2,"bone":24,"fufemur":2,"futooth":20,"gene_void":1},"time":6.0},
+
+	//heart dissection
+	{"inputs":{"fuheartalien":1},"outputs":{"liquidalienjuice":5,"gene_muscle":2,"fleshstrand":5},"time":6.0},
+	{"inputs":{"fuheart":1},"outputs":{"liquidalienjuice":5,"gene_muscle":1,"fleshstrand":3},"time":6.0},
+
+	//tooth
+	{"inputs":{"futooth":20},"outputs":{"bone":1},"time":1.0},
+
+	//femur
+	{"inputs":{"fufemur":1},"outputs":{"bone":5,"gene_skeletal":1},"time":6.0},
+
+	//hair
+	{"inputs":{"fuhair":1},"outputs":{"fuscienceresource":5},"time":6.0},
+
+	//brains
+	{"inputs":{"fubrain":1,"methanol":1,"liquidhealing":5},"outputs":{"brainpeerless":1,"fuscienceresource":25,"fumadnessresource":45},"time":6.0},
+	{"inputs":{"fubrain":1,"methanol":1},"outputs":{"brain":1,"fuscienceresource":10,"fumadnessresource":15},"time":6.0},
+	{"inputs":{"fubrain":1},"outputs":{"inferiorbrain":1,"fuscienceresource":5},"time":6.0},
+
+	//cadavers
+	{"inputs":{"cadaver":1},"outputs":{"fuflesh":1,"fuhair":1,"fubrain":1,"fuscienceresource":120,"fumadnessresource":30,"fleshstrand":4,"liquidblood":40},"time":8.0},
+	{"inputs":{"cadaverrotting":1},"outputs":{"fuflesh":1,"fuhair":1,"fubrain":1,"fuscienceresource":70,"fleshstrand":1,"liquidpoison":20},"time":8.0},
+	{"inputs":{"cadaverbirb":1},"outputs":{"fuflesh":1,"fuhair":1,"fubrain":1,"blooddiamond":1,"goldbar":2,"fuscienceresource":90,"fleshstrand":3},"time":8.0},
+	{"inputs":{"cadaveralien":1},"outputs":{"fufleshalien":1,"fubrain":1,"fuheartalien":1,"fuscienceresource":120,"fumadnessresource":30,"fleshstrand":6,"liquidalienjuice":40},"time":8.0},
+	{"inputs":{"apexpod":1},"outputs":{"liquidbioooze":30,"cadaver":1,"apexpod2":1},"time":8.0},
+	{"inputs":{"floranpodapex":1},"outputs":{"cadaver":1,"agaranichor":5,"fuscienceresource":60,"fumadnessresource":10},"time":8.0},
+	{"inputs":{"giantfloranpod":1},"outputs":{"agaranichor":30,"fuscienceresource":90,"fumadnessresource":40},"time":8.0},
+	{"inputs":{"floranpod1":1},"outputs":{"agaranichor":10,"fuscienceresource":20,"fumadnessresource":20},"time":8.0},
+	{"inputs":{"floranpod2":1},"outputs":{"agaranichor":10,"fuscienceresource":20,"fumadnessresource":20},"time":8.0},
+	{"inputs":{"floranpod3":1},"outputs":{"agaranichor":10,"fuscienceresource":20,"fumadnessresource":20},"time":8.0},
+
+	//wrapped bodies
+	{"inputs":{"frontiercoffin":1},"outputs":{"cadaver":1,"darkwoodmaterial":12,"fuscienceresource":40,"fumadnessresource":30},"time":5.0},
+	{"inputs":{"wrappedbody":1},"outputs":{"cadaver":1,"bandage":12,"fuscienceresource":40,"fumadnessresource":30},"time":5.0},
+	{"inputs":{"wrappedbodyputrid":1},"outputs":{"cadaverrotting":1,"fumadnessresource":60,"bandage":12},"time":5.0},
+	{"inputs":{"wrappedbodyalien":1},"outputs":{"cadaveralien":1,"fumadnessresource":80,"mutaviskbandage":12},"time":5.0},
+	{"inputs":{"wrappedbodybirb":1},"outputs":{"cadaverbirb":1,"fuscienceresource":50,"fuhoneysilkbandage":12},"time":5.0},
+
+	//miscellaneous
+	{"inputs":{"larva":10},"outputs":{"liquidpus":1,"cellmatter":1},"time":2.0},
+	{"inputs":{"greghead":1},"outputs":{"fumadnessresource":4,"inferiorbrain":1,"bone":4,"slew2":3},"time":7.0},
+	{"inputs":{"severedheadplatter":1},"outputs":{"fumadnessresource":1,"inferiorbrain":1,"bone":4,"slew2":3},"time":7.0},
+	{"inputs":{"faceskin":1},"outputs":{"fumadnessresource":1,"liquidblood":1,"slew2":1},"time":2.0},
+	{"inputs":{"leather":1},"outputs":{"slew2":1},"time":2.0},
+	{"inputs":{"hardenedcarapace":1},"outputs":{"slew2":1},"time":2.0},
+	{"inputs":{"agaranichor":1},"outputs":{"fuscienceresource":5},"time":2.0},
+	{"inputs":{"biospore":1},"outputs":{"cellmateria":1},"time":2.0},
+	{"inputs":{"blobbushjelly":1},"outputs":{"fumadnessresource":1,"cellmateria":1},"time":2.0},
+	{"inputs":{"brain":1},"outputs":{"fumadnessresource":2,"cellmateria":2},"time":2.0},
+	{"inputs":{"inferiorbrain":1},"outputs":{"fumadnessresource":1,"cellmateria":1},"time":2.0},
+	{"inputs":{"bone":50},"outputs":{"bonemealmaterial":50},"time":2.0},
+	{"inputs":{"crunchychick":1},"outputs":{"fumadnessresource":3,"bonemealmaterial":10,"alienmeat":1},"time":3.0},
+	{"inputs":{"meatpickle":1},"outputs":{"fumadnessresource":2,"alienmeat":1},"time":2.0},
+	{"inputs":{"milk":1,"normaldrone":1},"outputs":{"sourmilkandbees":1},"time":2.0},
+	{"inputs":{"endomorphicjelly":1},"outputs":{"holidayspirit":50},"time":2.0},
+	{"inputs":{"monsterhide":1},"outputs":{"leather":1},"time":1.0},
+	{"inputs":{"avalisample3":1},"outputs":{"inferiorbrain":1},"time":1.0},
+	{"inputs":{"apexbrainjar":1},"outputs":{"inferiorbrain":1},"time":1.0},
+	{"inputs":{"apexbrainjar2":1},"outputs":{"brain":1},"time":1.0},
+	{"inputs":{"apexbrainjar3":1},"outputs":{"artificialbrain":1},"time":1.0},
+	{"inputs":{"apexbrainjar4":1},"outputs":{"brainpeerless":1},"time":1.0}
+]


### PR DESCRIPTION
With recipes "item a = item x", "Item a + item b = item y" and "item a + item b + item c = item z", having all three items(a, b, c) in machine we can't predict which item(x, y or z), we'll get in result. Pairs() in map function doesn't respect order of elements, and causes mess in table of recipes, and startCrafting() just takes the first one from the top of messed pile. Your mileage may vary, but in my case having all 3 items i was always used only 2 of them.

In embalming table we have a collision of three recipes for brains of different tiers, now recipes will always be proccessed from top to bottom. First one which matches given items - will be performed. That's why they also was reordered, moving more prioritized recipes upper.

I've seen a note in extractor code regarding same issue, and some commented out recipes. It can be reenabled as well by adopting same fix, if needed.