### PR TITLE
wok

### DIFF
--- a/interface/scripted/fu_multiupgrade/fu_multiupgrade.lua
+++ b/interface/scripted/fu_multiupgrade/fu_multiupgrade.lua
@@ -34,13 +34,17 @@ function populateItemList(forceRepop)
 	local upgradableItems={}
 	
 	for i = 1, #upgradeableWeaponItems do
-		upgradeableWeaponItems[i].count = 1
-		table.insert(upgradableItems,{itemData=upgradeableWeaponItems[i],itemType="weapon"})
+		if not (upgradeableWeaponItems[i].parameters and upgradeableWeaponItems[i].parameters.currentAugment) then
+			upgradeableWeaponItems[i].count = 1
+			table.insert(upgradableItems,{itemData=upgradeableWeaponItems[i],itemType="weapon"})
+		end
 	end
 	
 	for i = 1, #upgradeableToolItems do
-		upgradeableToolItems[i].count = 1
-		table.insert(upgradableItems,{itemData=upgradeableToolItems[i],itemType="tool"})
+		if not (upgradeableToolItems[i].parameters and upgradeableToolItems[i].parameters.currentAugment) then
+			upgradeableToolItems[i].count = 1
+			table.insert(upgradableItems,{itemData=upgradeableToolItems[i],itemType="tool"})
+		end
 	end
 	
 	

--- a/interface/scripted/fuweaponupgrade/fuweaponupgradegui.lua
+++ b/interface/scripted/fuweaponupgrade/fuweaponupgradegui.lua
@@ -69,12 +69,14 @@ end
 function populateItemList(forceRepop)
 	local upgradeableWeaponItems = player.itemsWithTag("upgradeableWeapon")
 	local buffer = {}
+	
 	for i = 1, #upgradeableWeaponItems do
-		if not checkWorn(upgradeableWeaponItems[i]) then
+		if (not (upgradeableWeaponItems[i].parameters and upgradeableWeaponItems[i].parameters.currentAugment)) and (not checkWorn(upgradeableWeaponItems[i])) then
 			upgradeableWeaponItems[i].count = 1
 			table.insert(buffer,upgradeableWeaponItems[i])
 		end
 	end
+	
 	upgradeableWeaponItems=buffer
 	buffer={}
 

--- a/items/active/crewcontracts/crewcontract_arctic.activeitem
+++ b/items/active/crewcontracts/crewcontract_arctic.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "Hires an arctic explorer that provides ^cyan;Deadly Cold Immunity^reset; and increase ship fuel efficiency by 8%.",
+  "description" : "Hires an arctic explorer that provides ^cyan;Deadly Cold Immunity^reset; and reduces ship fuel costs by 8%.",
   "shortdescription" : "Arctic Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_chef.activeitem
+++ b/items/active/crewcontracts/crewcontract_chef.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires an apprentice chef to keep you slightly fed and reduce fuel cost by 2%.",
+  "description" : "Hires an apprentice chef to keep you slightly fed and reduce fuel costs by 2%.",
   "shortdescription" : "Chef Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_chef.activeitem
+++ b/items/active/crewcontracts/crewcontract_chef.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires an apprentice chef to keep you slightly fed and improve fuel efficiency by 4%.",
+  "description" : "Hires an apprentice chef to keep you slightly fed and reduce fuel cost by 2%.",
   "shortdescription" : "Chef Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_chef2.activeitem
+++ b/items/active/crewcontracts/crewcontract_chef2.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires a Line Chef to keep you fed and improve fuel efficiency by 6%.",
+  "description" : "Hires a Line Chef to keep you fed and reduce fuel cost by 4%.",
   "shortdescription" : "Line Chef Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_chef2.activeitem
+++ b/items/active/crewcontracts/crewcontract_chef2.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires a Line Chef to keep you fed and reduce fuel cost by 4%.",
+  "description" : "Hires a Line Chef to keep you fed and reduce fuel costs by 4%.",
   "shortdescription" : "Line Chef Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_chef3.activeitem
+++ b/items/active/crewcontracts/crewcontract_chef3.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires a Sous Chef to keep you stuffed and reduce fuel cost by 6%.",
+  "description" : "Hires a Sous Chef to keep you stuffed and reduce fuel costs by 6%.",
   "shortdescription" : "Sous Chef Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_chef3.activeitem
+++ b/items/active/crewcontracts/crewcontract_chef3.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires a Sous Chef to keep you stuffed and improve fuel efficiency by 8%.",
+  "description" : "Hires a Sous Chef to keep you stuffed and reduce fuel cost by 6%.",
   "shortdescription" : "Sous Chef Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_collector.activeitem
+++ b/items/active/crewcontracts/crewcontract_collector.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "Loves to hurl his balls at things until they crawl inside. Also provides 6% fuel efficiency and a useful ^green;Thorns effect.^reset;",
+  "description" : "Loves to hurl his balls at things until they crawl inside. Also provides a 2% fuel cost reduction and a useful ^green;Thorns effect.^reset;",
   "shortdescription" : "Collector Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_counsellor.activeitem
+++ b/items/active/crewcontracts/crewcontract_counsellor.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "Counsellor are quite useful - they can keep madness at bay! They also provide 4% fuel efficiency.",
+  "description" : "Counsellor are quite useful - they can keep madness at bay! They also provide 2% reduced fuel cost.",
   "shortdescription" : "Counsellor Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_counsellor2.activeitem
+++ b/items/active/crewcontracts/crewcontract_counsellor2.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Mental health expert. Reduces madness effects up to 40%. Reduces fuel cost by 2%.",
+  "description" : "Mental health expert. Reduces madness effects up to 40%. Reduces fuel costs by 2%.",
   "shortdescription" : "Ship Psychologist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_counsellor2.activeitem
+++ b/items/active/crewcontracts/crewcontract_counsellor2.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Mental health expert. Reduces madness effects up to 40%. Increases fuel efficiency by 4%.",
+  "description" : "Mental health expert. Reduces madness effects up to 40%. Reduces fuel cost by 2%.",
   "shortdescription" : "Ship Psychologist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_counsellor3.activeitem
+++ b/items/active/crewcontracts/crewcontract_counsellor3.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "legendary",
   "category" : "mysteriousReward",
-  "description" : "Master brain-healer-guy. Reduces madness effects up to 65%. Increases fuel efficiency by 4%.",
+  "description" : "Master brain-healer-guy. Reduces madness effects up to 65%. Reduces fuel costs by 2%.",
   "shortdescription" : "Ship Psychiatrist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_engineer.activeitem
+++ b/items/active/crewcontracts/crewcontract_engineer.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires an engineer to increase ship speed by 3.75 and fuel efficiency by 20%.",
+  "description" : "Hires an engineer to increase ship speed by 3.75 and reduce fuel costs by 10%.",
   "shortdescription" : "Engineer Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_engineer2.activeitem
+++ b/items/active/crewcontracts/crewcontract_engineer2.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Provides 40% increased fuel efficiency and 3.75 ship speed.",
+  "description" : "Provides 20% reduced fuel costs, and +3.75 ship speed.",
   "shortdescription" : "Engineer II Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_magicalgirl.activeitem
+++ b/items/active/crewcontracts/crewcontract_magicalgirl.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "A magic girl with a staff. Provides ^indigo;Shadow and Shadow Gas Immunity^reset;, and 25% fuel efficiency.",
+  "description" : "A magic girl with a staff. Provides ^indigo;Shadow and Shadow Gas Immunity^reset;, and 5% reduced fuel cost.",
   "shortdescription" : "Magical Girl Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_magicalgirl.activeitem
+++ b/items/active/crewcontracts/crewcontract_magicalgirl.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "A magic girl with a staff. Provides ^indigo;Shadow and Shadow Gas Immunity^reset;, and 5% reduced fuel cost.",
+  "description" : "A magic girl with a staff. Provides ^indigo;Shadow and Shadow Gas Immunity^reset;, and 5% reduced fuel costs.",
   "shortdescription" : "Magical Girl Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_mechanic.activeitem
+++ b/items/active/crewcontracts/crewcontract_mechanic.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Hires a mechanic to increase fuel efficiency by 10% and reduce ship mass by 20%.",
+  "description" : "Hires a mechanic to reduce ship mass by 20% and fuel costs by 10%.",
   "shortdescription" : "Mechanic Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_mechanic2.activeitem
+++ b/items/active/crewcontracts/crewcontract_mechanic2.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Increases fuel efficiency by 25% and decreases ship mass by 20%.",
+  "description" : "Reduces fuel cost by 20% and decreases ship mass by 20%.",
   "shortdescription" : "Mechanic II Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_mechanic2.activeitem
+++ b/items/active/crewcontracts/crewcontract_mechanic2.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "mysteriousReward",
-  "description" : "Reduces fuel cost by 20% and decreases ship mass by 20%.",
+  "description" : "Reduces fuel costs by 20% and decreases ship mass by 20%.",
   "shortdescription" : "Mechanic II Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_metalhead.activeitem
+++ b/items/active/crewcontracts/crewcontract_metalhead.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "common",
   "category" : "mysteriousReward",
-  "description" : "Dude. 4% fuel efficiency. Rock on.",
+  "description" : "Dude. 4% reduced fuel costs. Rock on.",
   "shortdescription" : "80s Metalhead Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_plur.activeitem
+++ b/items/active/crewcontracts/crewcontract_plur.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "The danciest companion in the universe, with booze and 4% fuel efficiency.",
+  "description" : "The danciest companion in the universe, with booze and 4% reduced fuel cost.",
   "shortdescription" : "PLUR Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_plur.activeitem
+++ b/items/active/crewcontracts/crewcontract_plur.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "The danciest companion in the universe, with booze and 4% reduced fuel cost.",
+  "description" : "The danciest companion in the universe, with booze and 4% reduced fuel costs.",
   "shortdescription" : "PLUR Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_radien.activeitem
+++ b/items/active/crewcontracts/crewcontract_radien.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "Legendary",
   "category" : "mysteriousReward",
-  "description" : "Hires a unique, powerful crew member that provides a 75% boost to fuel efficiency and ^yellow;Deadly Radiation Immunity^reset;",
+  "description" : "Hires a unique, powerful crew member that provides a 20% reduction to fuel costs and ^yellow;Deadly Radiation Immunity^reset;",
   "shortdescription" : "Radien Explorer Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_sciencedrug.activeitem
+++ b/items/active/crewcontracts/crewcontract_sciencedrug.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "Hires a drug specialist to increase jump height and speed, and your ship's fuel efficiency by 5%.",
+  "description" : "Hires a drug specialist to increase jump height and speed, and reduces your ship's fuel costs by 5%.",
   "shortdescription" : "Drug Specialist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_sciencedrug.activeitem
+++ b/items/active/crewcontracts/crewcontract_sciencedrug.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "Hires a drug specialist to increase jump height and speed, and your ship's fuel efficiency by 25%.",
+  "description" : "Hires a drug specialist to increase jump height and speed, and your ship's fuel efficiency by 5%.",
   "shortdescription" : "Drug Specialist Contract",
   "twoHanded" : true,
 

--- a/items/active/crewcontracts/crewcontract_sciencegas.activeitem
+++ b/items/active/crewcontracts/crewcontract_sciencegas.activeitem
@@ -8,7 +8,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "category" : "mysteriousReward",
-  "description" : "Hires a toxin specialist to provide ^pink;Gas Immunity^reset;, and increase your ship's fuel efficiency by 10%.",
+  "description" : "Hires a toxin specialist to provide ^pink;Gas Immunity^reset;, and reduce your ship's fuel costs by 5%.",
   "shortdescription" : "Toxin Specialist Contract",
   "twoHanded" : true,
 
@@ -21,6 +21,6 @@
   "fireOffset" : [1.0, 0.0],
 
   "crewtype" : {
-    "crewname" : "crewmemberhobo"
+    "crewname" : "crewmembersciencegas"
   }
 }

--- a/npcs/crew/catcrewmemberengineer.npctype
+++ b/npcs/crew/catcrewmemberengineer.npctype
@@ -16,10 +16,9 @@
 
         "benefits" : [
           {
-            "type" : "PeriodicMultiplier",
+            "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 1.1,
-            "period" : 1000
+            "value" : 0.10
           }
         ]
       }
@@ -30,14 +29,14 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "Meow! I'll get to work on impurroving mewr fuel efficiency!"
+              "Meow! Purrfect! Fuel costs reduced by 10%!"
             ]
           }
         },
         "shipImprovementApplied" : {
           "default" : {
             "default" : [
-              "Meow! Purrfect! Fuel efficiency is up another 10%! I'll keep working on it!"
+              "Meow! Purrfect! Fuel costs reduced by 10%!"
             ]
           }
         }

--- a/npcs/crew/crewmemberarctic.npctype
+++ b/npcs/crew/crewmemberarctic.npctype
@@ -45,7 +45,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll give you a 8% fuel efficiency boost whenever we're on the ship!"
+              "I'll give you an 8% fuel cost reduction whenever we're on the ship!"
             ]
           },
           "floran" : {
@@ -55,7 +55,7 @@
           },
           "glitch" : {
             "default" : [
-              "Friendly. I'll give you a 8% fuel efficiency boost whenever we're on the ship!"
+              "Friendly. I'll give you an 8% fuel cost reduction whenever we're on the ship!"
             ]
           }
         },

--- a/npcs/crew/crewmemberchef.npctype
+++ b/npcs/crew/crewmemberchef.npctype
@@ -19,7 +19,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.04
+            "value" : 0.02
           },        
           {
             "type" : "EphemeralEffect",
@@ -43,7 +43,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll give you a 4% fuel efficiency boost whenever we're on the ship! I cook *that* well!"
+              "I'll give you a 2% fuel cost reduction whenever we're on the ship! I cook *that* well!"
             ]
           }
         },

--- a/npcs/crew/crewmemberchef2.npctype
+++ b/npcs/crew/crewmemberchef2.npctype
@@ -19,7 +19,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.06
+            "value" : 0.04
           },        
          {
             "type" : "EphemeralEffect",
@@ -43,7 +43,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll give you a 6% fuel efficiency boost whenever we're on the ship! I cook *that* well!"
+              "I'll give you a 4% fuel cost reduction whenever we're on the ship! I cook *that* well!"
             ]
           }
         },

--- a/npcs/crew/crewmemberchef3.npctype
+++ b/npcs/crew/crewmemberchef3.npctype
@@ -19,7 +19,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.08
+            "value" : 0.06
           },        
          {
             "type" : "EphemeralEffect",
@@ -43,7 +43,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll give you a 8% fuel efficiency boost whenever we're on the ship! I cook *that* well!"
+              "I'll give you a 6% fuel cost reduction whenever we're on the ship! I cook *that* well!"
             ]
           }
         },

--- a/npcs/crew/crewmembercollector.npctype
+++ b/npcs/crew/crewmembercollector.npctype
@@ -19,7 +19,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.06
+            "value" : 0.02
           },
           {
             "type" : "EphemeralEffect",
@@ -43,7 +43,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll give you a 6% fuel efficiency boost whenever we're on the ship!"
+              "I'll give you a 2% fuel cost reduction whenever we're on the ship!"
             ]
           }
         },

--- a/npcs/crew/crewmembercounsellor.npctype
+++ b/npcs/crew/crewmembercounsellor.npctype
@@ -18,7 +18,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.04
+            "value" : 0.02
           },        
           {
             "type" : "EphemeralEffect",

--- a/npcs/crew/crewmembercounsellor2.npctype
+++ b/npcs/crew/crewmembercounsellor2.npctype
@@ -18,7 +18,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.04
+            "value" : 0.02
           },        
           {
             "type" : "EphemeralEffect",

--- a/npcs/crew/crewmembercounsellor3.npctype
+++ b/npcs/crew/crewmembercounsellor3.npctype
@@ -18,7 +18,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.04
+            "value" : 0.02
           },        
           {
             "type" : "EphemeralEffect",

--- a/npcs/crew/crewmemberengineer.npctype.patch
+++ b/npcs/crew/crewmemberengineer.npctype.patch
@@ -1,11 +1,16 @@
 [
-  {
-    "op": "add",
-    "path": "/scriptConfig/crew/role/benefits/0",
-    "value": {
-      "type": "ShipUpgradeBenefit",
-      "property": "fuelEfficiency",
-      "value": 0.2
-    }
-  }
+	[{
+		"op": "add",
+		"path": "/scriptConfig/crew/role/benefits/0",
+		"value": {
+			"type": "ShipUpgradeBenefit",
+			"property": "fuelEfficiency",
+			"value": 0.1
+		}
+	}],
+	[{
+		"op": "replace",
+		"path": "/scriptConfig/dialog/crewmember/roleDescription/default/default/0",
+		"value": "I'll keep your engines in good shape. Thrust velocity is up by 25%, fuel costs reduced by 10%!"
+	}]
 ]

--- a/npcs/crew/crewmemberengineer2.npctype
+++ b/npcs/crew/crewmemberengineer2.npctype
@@ -23,7 +23,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.4
+            "value" : 0.2
           }          
         ]
       }
@@ -34,7 +34,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll keep your engines in good shape. Thrust velocity is up by 25% and Fuel efficiency is up 40%."
+              "I'll keep your engines in good shape. Thrust velocity is up by 25% and fuel costs are down by 20%."
             ]
           }
         }

--- a/npcs/crew/crewmemberguardian.npctype
+++ b/npcs/crew/crewmemberguardian.npctype
@@ -44,7 +44,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll give you a 5% fuel efficiency boost whenever we're on the ship!"
+              "I'll give you a 5% fuel cost reduction whenever we're on the ship!"
             ]
           },
           "floran" : {
@@ -54,7 +54,7 @@
           },
           "glitch" : {
             "default" : [
-              "Friendly. I'll give you a 5% fuel efficiency boost whenever we're on the ship!"
+              "Friendly. I'll give you a 5% fuel cost reduction whenever we're on the ship!"
             ]
           }
         },

--- a/npcs/crew/crewmembermagicalgirl.npctype
+++ b/npcs/crew/crewmembermagicalgirl.npctype
@@ -55,7 +55,7 @@
 	        {
             "type": "ShipUpgradeBenefit",
             "property": "fuelEfficiency",
-            "value": 0.25
+            "value": 0.05
           }
         ],
         "type" : "soldier",

--- a/npcs/crew/crewmembermechanic.npctype.patch
+++ b/npcs/crew/crewmembermechanic.npctype.patch
@@ -1,11 +1,16 @@
 [
-  {
-    "op": "add",
-    "path": "/scriptConfig/crew/role/benefits/0",
-    "value": {
-      "type": "PersistentEffect",
-      "property": "shipMass",
-      "value": 0.8
-    }
-  }
+	[{
+		"op": "add",
+		"path": "/scriptConfig/crew/role/benefits/0",
+		"value": {
+			"type": "PersistentEffect",
+			"property": "shipMass",
+			"value": 0.8
+		}
+	}],
+	[{
+		"op": "replace",
+		"path": "/scriptConfig/dialog/crewmember/roleDescription/default/default/0",
+		"value": "I'll keep clearing out the carborator while I'm here. Fuel costs reduced by 10%!"
+	}]
 ]

--- a/npcs/crew/crewmembermechanic2.npctype
+++ b/npcs/crew/crewmembermechanic2.npctype
@@ -28,7 +28,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.25
+            "value" : 0.2
           }
         ]
       }
@@ -39,7 +39,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll keep clearing out the carborator while I'm here. Fuel efficiency is up 25% and Ship mass has decreased by 20%."
+              "I'll keep clearing out the carborator while I'm here. Fuel costs are down by 20% and Ship Mass has decreased by 20%."
             ]
           }
         }

--- a/npcs/crew/crewmemberradien.npctype
+++ b/npcs/crew/crewmemberradien.npctype
@@ -21,7 +21,7 @@
           {
             "type" : "ShipUpgradeBenefit",
             "property" : "fuelEfficiency",
-            "value" : 0.75
+            "value" : 0.2
           },        
           {
             // Ephemeral effects gained upon leaving the ship
@@ -42,7 +42,7 @@
         "roleDescription" : {
           "default" : {
             "default" : [
-              "I'll give you a massive fuel efficiency boost whenever we're on the ship!"
+              "I'll give you a massive 20% fuel cost reduction whenever we're on the ship!"
             ]
           }
         },

--- a/npcs/crew/crewmembersciencedrug.npctype
+++ b/npcs/crew/crewmembersciencedrug.npctype
@@ -31,7 +31,7 @@
 	  {
             "type": "ShipUpgradeBenefit",
             "property": "fuelEfficiency",
-            "value": 0.25
+            "value": 0.05
           } 
         ]
       }

--- a/npcs/crew/crewmembersciencegas.npctype
+++ b/npcs/crew/crewmembersciencegas.npctype
@@ -25,7 +25,7 @@
 	  {
             "type": "ShipUpgradeBenefit",
             "property": "fuelEfficiency",
-            "value": 0.1
+            "value": 0.05
           }  
         ]
       }

--- a/objects/power/fu_furnace_common.lua
+++ b/objects/power/fu_furnace_common.lua
@@ -3,65 +3,65 @@ require "/scripts/kheAA/transferUtil.lua"
 require '/scripts/fupower.lua'
 
 function init()
-  power.init()
-  transferUtil.init()
-  object.setInteractive(true)
+	power.init()
+	transferUtil.init()
+	object.setInteractive(true)
 	
-  storage.currentinput = nil
-  storage.currentoutput = nil
-  storage.bonusoutputtable = nil
-  storage.activeConsumption = false
+	storage.currentinput = nil
+	storage.currentoutput = nil
+	storage.bonusoutputtable = nil
+	storage.activeConsumption = false
 
-  self.timerInitial = config.getParameter ("fu_timer", 1)
-  self.extraConsumptionChance = config.getParameter ("fu_extraConsumptionChance", 0)
-  self.itemList=config.getParameter("inputsToOutputs")
-  self.bonusItemList=config.getParameter("bonusOutputs")
-  self.timer = self.timerInitial
+	self.timerInitial = config.getParameter ("fu_timer", 1)
+	self.extraConsumptionChance = config.getParameter ("fu_extraConsumptionChance", 0)
+	self.itemList=config.getParameter("inputsToOutputs")
+	self.bonusItemList=config.getParameter("bonusOutputs")
+	self.timer = self.timerInitial
 end
 
 function update(dt)
-  if deltaTime and deltaTime > 1 then
-	deltaTime=0
-	transferUtil.loadSelfContainer()
-  else
-	deltaTime=(deltaTime or 0)+dt
-  end
-  self.timer = self.timer - dt
-  if self.timer <= 0 then
-	local checkNormal,checkBonus=oreCheck()
-	local cSC=(checkNormal and clearSlotCheck(storage.currentoutput)) or false
-	--sb.logInfo("checkNormal=%s,cSC=%s,checkBonus=%s",checkNormal,cSC,checkBonus)
-    if (checkNormal and cSC) or (checkBonus) then
-	  if power.getTotalEnergy() >= config.getParameter("isn_requiredPower", 1) and world.containerConsume(entity.id(), {name = storage.currentinput, count = 2, data={}}) and power.consume(config.getParameter("isn_requiredPower", 1)*self.timerInitial) then
-	    animator.setAnimationState("furnaceState", "active")
-	    storage.activeConsumption = true
-	    if math.random() <= self.extraConsumptionChance then
-		  world.containerConsume(entity.id(), {name = storage.currentinput, count = 2, data={}})
-	    end
-	    if checkBonus then
-		  for key, value in pairs(storage.bonusoutputtable) do
-		    if clearSlotCheck(key) and math.random(0,100) <= value then 
-			  fu_sendOrStoreItems(0, {name = key, count = 1, data = {}}, {0}, true)
-		    end
-		  end
-	    end
-		if type(storage.currentoutput)=="string" then
-			fu_sendOrStoreItems(0, {name = storage.currentoutput, count = math.random(1,2), data = {}}, {0}, true)
-		elseif type(storage.currentoutput)=="table" then
-			for _,item in pairs(storage.currentoutput) do
-				fu_sendOrStoreItems(0, {name = item, count = math.random(1,2), data = {}}, {0}, true)
-			end
-		end
-	    self.timer = self.timerInitial
-	  else
-	    storage.activeConsumption = false
-	    animator.setAnimationState("furnaceState", "idle")
-	  end
-    else
-      animator.setAnimationState("furnaceState", "idle")
+	if deltaTime and deltaTime > 1 then
+		deltaTime=0
+		transferUtil.loadSelfContainer()
+	else
+		deltaTime=(deltaTime or 0)+dt
 	end
-  end
-  power.update(dt)
+	self.timer = self.timer - dt
+	if self.timer <= 0 then
+		local checkNormal,checkBonus=oreCheck()
+		local cSC=(checkNormal and clearSlotCheck(storage.currentoutput)) or false
+		--sb.logInfo("checkNormal=%s,cSC=%s,checkBonus=%s",checkNormal,cSC,checkBonus)
+		if (checkNormal and cSC) or (checkBonus) then
+			if power.getTotalEnergy() >= config.getParameter("isn_requiredPower", 1) and world.containerConsume(entity.id(), {name = storage.currentinput, count = 2, data={}}) and power.consume(config.getParameter("isn_requiredPower", 1)*self.timerInitial) then
+				animator.setAnimationState("furnaceState", "active")
+				storage.activeConsumption = true
+				if math.random() <= self.extraConsumptionChance then
+					world.containerConsume(entity.id(), {name = storage.currentinput, count = 2, data={}})
+				end
+				if checkBonus then
+				for key, value in pairs(storage.bonusoutputtable) do
+					if clearSlotCheck(key) and math.random(0,100) <= value then 
+					fu_sendOrStoreItems(0, {name = key, count = 1, data = {}}, {0}, true)
+					end
+				end
+			end
+			if type(storage.currentoutput)=="string" then
+				fu_sendOrStoreItems(0, {name = storage.currentoutput, count = math.random(1,2), data = {}}, {0}, true)
+			elseif type(storage.currentoutput)=="table" then
+				for _,item in pairs(storage.currentoutput) do
+					fu_sendOrStoreItems(0, {name = item, count = math.random(1,2), data = {}}, {0}, true)
+				end
+			end
+				self.timer = self.timerInitial
+			else
+				storage.activeConsumption = false
+				animator.setAnimationState("furnaceState", "idle")
+			end
+		else
+			animator.setAnimationState("furnaceState", "idle")
+		end
+	end
+	power.update(dt)
 end
 
 
@@ -94,9 +94,11 @@ function hasNormalOutputs(content)
 			storage.currentoutput = self.itemList[content.name]
 			return true
 		else
+			storage.currentoutput = {}
 			return false
 		end
 	else
+		storage.currentoutput = {}
 		return false
 	end
 end
@@ -107,9 +109,11 @@ function hasBonusOutputs(content)
 			storage.bonusoutputtable = self.bonusItemList[content.name]
 			return true
 		else
+			storage.bonusoutputtable = {}
 			return false
 		end
 	else
+		storage.bonusoutputtable = {}
 		return false
 	end
 end

--- a/objects/ship/fu_fuelpurifier/fu_fuelpurifier.object
+++ b/objects/ship/fu_fuelpurifier/fu_fuelpurifier.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "science", "machines" ],
   "printable" : false,
   "rarity" : "common",
-  "description" : "Purifies fuel before it reaches your ships FTL drive. Increases fuel efficiency by ^green;5^reset;%",
+  "description" : "Purifies fuel before it reaches your ships FTL drive. Reduces fuel cost by ^green;5^reset;%",
   "shortdescription" : "^cyan;Fuel Purifier^reset;",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_fuelpurifier/fu_fuelpurifiert2.object
+++ b/objects/ship/fu_fuelpurifier/fu_fuelpurifiert2.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "science", "machines" ],
   "printable" : false,
   "rarity" : "uncommon",
-  "description" : "Purifies fuel before it reaches your ships FTL drive. Increases fuel efficiency by ^green;10^reset;%",
+  "description" : "Purifies fuel before it reaches your ships FTL drive. Reduces fuel cost by ^green;10^reset;%",
   "shortdescription" : "^cyan;Advanced Fuel Purifier^reset;",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_fuelpurifier/fu_fuelpurifiert3.object
+++ b/objects/ship/fu_fuelpurifier/fu_fuelpurifiert3.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "science", "machines" ],
   "printable" : false,
   "rarity" : "rare",
-  "description" : "Purifies fuel before it reaches your ships FTL drive. Increases fuel efficiency by ^green;15^reset;%",
+  "description" : "Purifies fuel before it reaches your ships FTL drive. Reduces fuel cost by ^green;15^reset;%",
   "shortdescription" : "^cyan;Dense Fuel Purifier^reset;",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_fuelpurifier/fu_fuelpurifiert4.object
+++ b/objects/ship/fu_fuelpurifier/fu_fuelpurifiert4.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "science", "machines" ],
   "printable" : false,
   "rarity" : "legendary",
-  "description" : "Purifies fuel before it reaches your ships FTL drive. Increases fuel efficiency by ^green;20^reset;%",
+  "description" : "Purifies fuel before it reaches your ships FTL drive. Reduces fuel cost by ^green;20^reset;%",
   "shortdescription" : "^cyan;Densinium Fuel Purifier^reset;",
   "race" : "generic",
   "category" : "furniture",

--- a/objects/ship/fu_fuelpurifier/fu_fuelpurifiert5.object
+++ b/objects/ship/fu_fuelpurifier/fu_fuelpurifiert5.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "science", "machines","precursor" ],
   "printable" : false,
   "rarity" : "legendary",
-  "description" : "Exceptionally effective. Increases fuel efficiency by ^green;40^reset;%",
+  "description" : "Exceptionally effective. Reduces fuel cost by ^green;40^reset;%",
   "shortdescription" : "^cyan;Precursor Fuel Purifier^reset;",
   "race" : "generic",
   "category" : "furniture",


### PR DESCRIPTION
tentative fix for people using augment slots for armor or worse, that with combinable augments, resulting in an instruction limit error: they should no longer show in upgrade tables at all if the armor  has augments installed.

furnace/smelter output glitch fixed.

crew/object wording change: fuel efficiency -> fuel cost reduction
crew: fuel cost reductions rebalanced. highest is now 20%, most are 10 or under.