### PR TITLE
In which I provide the changes I made in #gamestart-revision.

### DIFF
--- a/objects/crafting/armory/armory.object
+++ b/objects/crafting/armory/armory.object
@@ -219,7 +219,8 @@
           "riflequietusfu",
           "rifleferoziumfu",
           "rifleaegisaltfu",
-          "rifleferoziumfu"                      
+	  "riflevioliumfu",
+          "riflepyreitefu"                      
         ]
       },
 

--- a/objects/outpost/shipyardwelding/shipyardwelding.object.patch
+++ b/objects/outpost/shipyardwelding/shipyardwelding.object.patch
@@ -72,7 +72,10 @@
         },
         {
           "item": "autochip"
-        }
+        },
+	{
+	  "item": "warpmanifold", "price" : 10000 
+	}
     }
   }
 ]

--- a/objects/outpost/shipyardwelding/shipyardwelding.object.patch
+++ b/objects/outpost/shipyardwelding/shipyardwelding.object.patch
@@ -32,45 +32,47 @@
         }
       },
       "buyFactor": 1,
-      "sellFactor": 0.15,
+      "sellFactor": 0.25,
       "items": [
         {
-          "item": "salvagetier4"
+          "item": "slopedrustypanel", "price" : 10 
         },  
         {
-          "item": "salvagearm"
+          "item": "slopedscrappanel", "price" : 10 
         },    
         {
-          "item": "salvagebody"
+          "item": "rustymetal", "price" : 5 
         },  
         {
-          "item": "salvagebooster"
+          "item": "wreckplatform", "price" : 5 
         },   
         {
-          "item": "salvagelegs"
+          "item": "wreckbed"
         },                   
         {
-          "item": "ff_silicon"
+          "item": "wreckdoor"
         },        
         {
-          "item": "fu_hydrogen"
+          "item": "wrecklocker"
         },      
         {
-          "item": "fu_nitrogen"
+          "item": "wreckchair"
         },      
         {
-          "item": "fu_oxygen"
+          "item": "wrecktable"
         },
         {
-          "item": "crystal"
+          "item": "wrecksmalltable"
         },
         {
-          "item": "warpmanifold"
+          "item": "redlight"
+        },
+	    	{
+          "item": "scorchedcitycrate"
         },
         {
           "item": "autochip"
         }
-      ]
     }
   }
 ]

--- a/objects/outpost/shipyardwelding/shipyardwelding.object.patch
+++ b/objects/outpost/shipyardwelding/shipyardwelding.object.patch
@@ -67,7 +67,7 @@
         {
           "item": "redlight"
         },
-	    	{
+	{
           "item": "scorchedcitycrate"
         },
         {

--- a/objects/outpost/shipyardwelding/shipyardwelding.object.patch
+++ b/objects/outpost/shipyardwelding/shipyardwelding.object.patch
@@ -76,6 +76,7 @@
 	{
 	  "item": "warpmanifold", "price" : 10000 
 	}
+	]
     }
   }
 ]

--- a/quests/fu_questlines/byos/fu_byosftldrive.questtemplate
+++ b/quests/fu_questlines/byos/fu_byosftldrive.questtemplate
@@ -6,7 +6,7 @@
   "text" : "To travel through space I need to build a ^orange;Small FTL Drive^reset; on a ^orange;Machining Table^reset;. Maybe I can find an erchius crystal mine and get some ^green;erchius crystals^reset; from there.",
   "completionText" : "All I need to do is place the ^orange;FTL Drive^reset; and I can travel through space.",
   "moneyRange" : [0, 0],
-  "rewards" : [ [ [ "salvagebody", 10 ],[ "salvagelegs", 6 ],[ "slopedhullpanel", 200 ] ] ],
+  "rewards" : [ [ [ "apexshipdetails", 50 ],[ "apexshipsupport", 50 ],[ "apexshipwall", 200 ],[ "slopedhullpanel", 200 ] ] ],
   "speaker" : "player",
   
   "updateDelta" : 10,

--- a/ships/fu_byos/blockKey.config
+++ b/ships/fu_byos/blockKey.config
@@ -16,7 +16,7 @@
       "value" : [128, 128, 128, 255],
       "foregroundBlock" : true,
       "backgroundBlock" : false,
-	  "foregroundMat" : "slopedhullpanel"
+	  "foregroundMat" : "slopedrustypanel"
     },
     
 	{
@@ -30,7 +30,7 @@
       "value" : [64, 64, 64, 255],
       "foregroundBlock" : true,
       "backgroundBlock" : true,
-	  "foregroundMat" : "slopedhullpanel",
+	  "foregroundMat" : "slopedrustypanel",
 	  "backgroundMat" : "glass"
     },
 	
@@ -38,24 +38,24 @@
       "value" : [127, 58, 127, 255],
       "foregroundBlock" : true,
       "backgroundBlock" : true,
-	  "foregroundMat" : "slopedhullpanel",
-	  "backgroundMat" : "apexshipsupport"
+	  "foregroundMat" : "slopedrustypanel",
+	  "backgroundMat" : "slopedscrappanel"
     },
 	
 	{
       "value" : [255, 255, 200, 255],
       "foregroundBlock" : true,
       "backgroundBlock" : true,
-	  "foregroundMat" : "slopedhullpanel",
-	  "backgroundMat" : "apexshipwall"
+	  "foregroundMat" : "slopedrustypanel",
+	  "backgroundMat" : "rustymetal"
     },
 	
 	{
       "value" : [255, 140, 144, 255],
       "foregroundBlock" : true,
       "backgroundBlock" : true,
-	  "foregroundMat" : "slopedhullpanel",
-	  "backgroundMat" : "apexshipdetails"
+	  "foregroundMat" : "slopedrustypanel",
+	  "backgroundMat" : "rustymetal"
     },
 
     {
@@ -68,7 +68,7 @@
       "value" : [192, 192, 192, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipsupport",
+      "backgroundMat" : "slopedscrappanel",
       "object" : "fu_bootuptemp",
       "objectParameters" : {
         "unbreakable" : true
@@ -79,7 +79,7 @@
       "value" : [0, 255, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipwall",
+      "backgroundMat" : "rustymetal",
       "flags" : [ "shipLockerPosition" ],
       "object" : "fu_byosshiplocker",
       "objectParameters" : {
@@ -92,7 +92,7 @@
       "value" : [0, 128, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipwall",
+      "backgroundMat" : "rustymetal",
       "object" : "fu_byosshiplockerTier0",
 	  "objectParameters" : {
         "unbreakable" : true
@@ -103,7 +103,7 @@
       "value" : [99, 128, 99, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipwall",
+      "backgroundMat" : "slopedscrappanel",
       "object" : "fu_ftldrivedecosmallbroken",
 	  "objectParameters" : {
         "unbreakable" : false
@@ -113,7 +113,7 @@
       "value" : [142, 255, 142, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipwall",
+      "backgroundMat" : "rustymetal",
       "object" : "fu_byostechstationTier0",
       "objectParameters" : {
         "unbreakable" : true
@@ -124,7 +124,7 @@
       "value" : [255, 87, 81, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-	  "backgroundMat" : "apexshipwall",
+	  "backgroundMat" : "rustymetal",
       "object" : "fu_byosbrokenfuelhatch",
 	  "objectParameters" : {
         "unbreakable" : true
@@ -135,7 +135,7 @@
       "value" : [255, 90, 90, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-	  "backgroundMat" : "apexshipwall",
+	  "backgroundMat" : "rustymetal",
       "object" : "fu_byosfuelhatch"
     },
 
@@ -143,7 +143,7 @@
       "value" : [255, 255, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipdetails",
+      "backgroundMat" : "slopedscrappanel",
       "object" : "apexshiplight"
     },
     
@@ -151,7 +151,7 @@
       "value" : [191, 191, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipdetails",
+      "backgroundMat" : "slopedscrappanel",
       "object" : "apexshiplightBroken",
       "objectParameters" : {
         "unbreakable" : true
@@ -162,7 +162,7 @@
       "value" : [95, 95, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipwall",
+      "backgroundMat" : "rustymetal",
       "object" : "apexshiplightBroken",
       "objectParameters" : {
         "unbreakable" : true
@@ -173,19 +173,19 @@
       "value" : [128, 128, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipdetails",
+      "backgroundMat" : "slopedrustypanel",
       "object" : "apexshiplight",
       "objectParameters" : {
         "defaultLightState" : false,
 		"unbreakable" : true
-      }
+      } 
     },
 	
 	{
       "value" : [64, 64, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipwall",
+      "backgroundMat" : "rustymetal",
       "object" : "apexshiplight",
       "objectParameters" : {
         "defaultLightState" : false,
@@ -197,7 +197,7 @@
       "value" : [255, 102, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipdetails",
+      "backgroundMat" : "slopedscrappanel",
       "object" : "fu_byosshipdoor"
     },
     
@@ -205,7 +205,7 @@
       "value" : [128, 51, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipdetails",
+      "backgroundMat" : "slopedscrappanel",
       "object" : "fu_byosshipdoorBroken",
 	  "objectParameters" : {
         "unbreakable" : true
@@ -216,7 +216,7 @@
       "value" : [192, 76, 0, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipwall",
+      "backgroundMat" : "rustymetal",
       "object" : "fu_byosshiphatchBroken",
 	  "objectParameters" : {
         "unbreakable" : true
@@ -235,7 +235,7 @@
       "anchor" : true,
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipdetails",
+      "backgroundMat" : "slopedscrappanel",
       "object" : "fu_byosteleporter",
       "flags" : [ "playerSpawn" ]
     },
@@ -245,7 +245,7 @@
       "anchor" : true,
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipdetails",
+      "backgroundMat" : "slopedscrappanel",
       "object" : "fu_byosteleporterTier0",
       "flags" : [ "playerSpawn" ],
       "objectParameters" : {
@@ -313,7 +313,7 @@
       "value" : [0, 255, 255, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-	  "backgroundMat" : "apexshipdetails",
+	  "backgroundMat" : "slopedscrappanel",
       "object" : "fu_byoscaptainschair",
       "objectDirection" : "right"
     },
@@ -336,21 +336,21 @@
       "value" : [255, 255, 144],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipwall"
+      "backgroundMat" : "rustymetal"
     },
 
     {
       "value" : [255, 117, 144],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipdetails"
+      "backgroundMat" : "slopedscrappanel"
     },
 
     {
       "value" : [255, 117, 255],
       "foregroundBlock" : false,
       "backgroundBlock" : true,
-      "backgroundMat" : "apexshipsupport"
+      "backgroundMat" : "slopedscrappanel"
     },
 
     {
@@ -365,7 +365,7 @@
       "foregroundBlock" : true,
       "backgroundBlock" : true,
       "foregroundMat" : "hazard",
-      "backgroundMat" : "apexshipdetails"
+      "backgroundMat" : "slopedscrappanel"
     }
   ]
 }


### PR DESCRIPTION
In summary:
- Vork the Penguin's shop lets you sequence break progression a little too hard. Instead of selling useful things like gasses, mech parts, crystals and silicon, he now sells junk ship parts which you can use to cheaply create a larger BYOS ship earlier in the game than you would otherwise.
- The starting BYOS ship is now made of junk (rusty sloped panels replace the ship's hull, while the inside is replaced with rusty metal latticed by scrap panels. 
- Completing the "build a Small FTL Drive" quest now gives you clean sloped hull panels, wall panels, ship supports and metal railings (thus giving you the blueprints) so that you can build a clean, shiny BYOS ship if you put the effort in.