### PR TITLE
box

### DIFF
--- a/interface/mechfuel/mechfuel.lua
+++ b/interface/mechfuel/mechfuel.lua
@@ -84,7 +84,7 @@ function update(dt)
 	end
 
 	if self.maxFuel and self.currentFuel then	
-		widget.setText("lblModuleCount", string.format("%.02f", math.floor(self.currentFuel)) .. " / " .. math.floor(self.maxFuel))
+		widget.setText("lblModuleCount", string.format("%.02f", self.currentFuel) .. " / " .. self.maxFuel)
 	else
 		widget.setText("lblModuleCount", "<Loading>")
 	end
@@ -150,13 +150,13 @@ function fuel()
 	end
 	local id = player.id()
 
-	local fuelMultiplier = 1
+	local fuelMultiplier = 0
 	local fuelBonus = 0
 	local localFuelType = ""
 	
 	local fuelData = self.fuels[item.name]
 	if fuelData then
-		fuelMultiplier = fuelData.fuelMultiplier
+		fuelMultiplier = fuelData.fuelMultiplier or fuelMultiplier
 		localFuelType = fuelData.fuelType 
 	end
 	if fuelMultiplier == 0 then return end
@@ -170,13 +170,16 @@ function fuel()
 	local fuelWillAdd=math.min(fuelCanAdd,math.max(self.maxFuel-self.currentFuel,0))
 	local fuelItemConsume=fuelWillAdd/fuelMultiplier
 	local shimmy = fuelItemConsume%1
-	if shimmy > 0 then
-	shimmy=fuelItemConsume
-	fuelItemConsume=math.floor(fuelItemConsume)
-	shimmy=fuelItemConsume/shimmy
-	fuelWillAdd=shimmy*fuelWillAdd
+
+	if (fuelItemConsume == shimmy) and (fuelCanAdd > 0) then
+		fuelItemConsume=1
+	elseif shimmy > 0 then
+		shimmy=fuelItemConsume
+		fuelItemConsume=math.floor(fuelItemConsume)
+		shimmy=fuelItemConsume/shimmy
+		fuelWillAdd=shimmy*fuelWillAdd
 	end
-	
+
 	if fuelWillAdd > 0 then
 		item.count=item.count-fuelItemConsume
 		if item.count == 0 then
@@ -250,7 +253,7 @@ end
 function fuelCountPreview(item)
 	if not item then
 		if self.currentFuel and self.maxFuel then
-			widget.setText("lblModuleCount", string.format("%.02f", math.floor(self.currentFuel)) .. " / " .. math.floor(self.maxFuel))
+			widget.setText("lblModuleCount", string.format("%.02f",self.currentFuel) .. " / " .. self.maxFuel)
 		end
 		return
 	end
@@ -270,7 +273,7 @@ function fuelCountPreview(item)
 		addFuelCount = self.maxFuel
 	end
 
-	widget.setText("lblModuleCount", "^" .. textColor .. ";" .. string.format("%.02f", addFuelCount) .. "^white; / " .. math.floor(self.maxFuel))
+	widget.setText("lblModuleCount", "^" .. textColor .. ";" .. string.format("%.02f", addFuelCount) .. "^white; / " .. self.maxFuel)
 end
 
 function setFuelTypeText(type)

--- a/monsters/walkers/adultpoptop/megatop.monstertype
+++ b/monsters/walkers/adultpoptop/megatop.monstertype
@@ -345,7 +345,8 @@
 
     "mouthOffset" : [0, 0],
     "feetOffset" : [0, -8],
-    "capturable" : false,
+    "capturable" : true,
+    "captureHealthFraction" : 0.05,
     "nametagColor" : [64, 200, 255]
   }
 }

--- a/monsters/walkers/adultpoptopish/adultpoptopfire/adultpoptopfire3.monstertype
+++ b/monsters/walkers/adultpoptopish/adultpoptopfire/adultpoptopfire3.monstertype
@@ -346,7 +346,7 @@
     "mouthOffset" : [0, 0],
     "feetOffset" : [0, -8],
     "capturable" : false,
-    "captureHealthFraction" : 0.5,
+    "captureHealthFraction" : 0.05,
     "nametagColor" : [64, 200, 255],
     "captureCollectables" : { "fu_monster" : "adultpoptopfire" }
   }

--- a/objects/minibiome/elder/embalmingtable/embalmingtable_recipes.config
+++ b/objects/minibiome/elder/embalmingtable/embalmingtable_recipes.config
@@ -45,7 +45,7 @@
 	{"inputs":{"cadaveralien":1},"outputs":{"fufleshalien":1,"fubrain":1,"fuheartalien":1,"fuscienceresource":120,"fumadnessresource":30,"fleshstrand":6,"liquidalienjuice":40},"time":8.0},
 	{"inputs":{"apexpod":1},"outputs":{"liquidbioooze":30,"cadaver":1,"apexpod2":1},"time":8.0},
 	{"inputs":{"floranpodapex":1},"outputs":{"cadaver":1,"agaranichor":5,"fuscienceresource":60,"fumadnessresource":10},"time":8.0},
-	{"inputs":{"giantfloranpod":1},"outputs":{"agaranichor":30,"fuscienceresource":90,"fumadnessresource":40},"time":8.0},
+	{"inputs":{"giantfloranpod":1},"outputs":{"agaranichor":8,"fuscienceresource":90,"fumadnessresource":40},"time":8.0},
 	{"inputs":{"floranpod1":1},"outputs":{"agaranichor":10,"fuscienceresource":20,"fumadnessresource":20},"time":8.0},
 	{"inputs":{"floranpod2":1},"outputs":{"agaranichor":10,"fuscienceresource":20,"fumadnessresource":20},"time":8.0},
 	{"inputs":{"floranpod3":1},"outputs":{"agaranichor":10,"fuscienceresource":20,"fumadnessresource":20},"time":8.0},

--- a/objects/minibiome/elder/embalmingtable/embalmingtable_recipes.config
+++ b/objects/minibiome/elder/embalmingtable/embalmingtable_recipes.config
@@ -45,7 +45,7 @@
 	{"inputs":{"cadaveralien":1},"outputs":{"fufleshalien":1,"fubrain":1,"fuheartalien":1,"fuscienceresource":120,"fumadnessresource":30,"fleshstrand":6,"liquidalienjuice":40},"time":8.0},
 	{"inputs":{"apexpod":1},"outputs":{"liquidbioooze":30,"cadaver":1,"apexpod2":1},"time":8.0},
 	{"inputs":{"floranpodapex":1},"outputs":{"cadaver":1,"agaranichor":5,"fuscienceresource":60,"fumadnessresource":10},"time":8.0},
-	{"inputs":{"giantfloranpod":1},"outputs":{"agaranichor":8,"fuscienceresource":90,"fumadnessresource":40},"time":8.0},
+	{"inputs":{"giantfloranpod":1},"outputs":{"agaranichor":8,"fuscienceresource":90,"fumadnessresource":40},"time":12.0},
 	{"inputs":{"floranpod1":1},"outputs":{"agaranichor":10,"fuscienceresource":20,"fumadnessresource":20},"time":8.0},
 	{"inputs":{"floranpod2":1},"outputs":{"agaranichor":10,"fuscienceresource":20,"fumadnessresource":20},"time":8.0},
 	{"inputs":{"floranpod3":1},"outputs":{"agaranichor":10,"fuscienceresource":20,"fumadnessresource":20},"time":8.0},

--- a/quests/mechfuel/mechfueldata.lua
+++ b/quests/mechfuel/mechfueldata.lua
@@ -3,131 +3,131 @@ require "/scripts/vec2.lua"
 
 function init()
 
-  --make sure Madness quest is on, this is a safe place to do so
-  if not player.hasQuest("madnessquestdata") then
-  	player.startQuest("madnessquestdata")
-  end
-  
+	--make sure Madness quest is on, this is a safe place to do so
+	if not player.hasQuest("madnessquestdata") then
+		player.startQuest("madnessquestdata")
+	end
 
-  message.setHandler("setQuestFuelCount", function(_, _, value)
-    if storage.fuelCount then
-	    storage.fuelCount = value
-    end
-  end)
 
-  message.setHandler("getQuestFuelCount", function()
-    if storage.fuelCount then
-	    return storage.fuelCount
-    end
-  end)
+	message.setHandler("setQuestFuelCount", function(_, _, value)
+		if storage.fuelCount then
+			storage.fuelCount = value
+		end
+	end)
 
-  message.setHandler("addQuestFuelCount", function(_, _, value)
-    if storage.fuelCount then
-	    storage.fuelCount = storage.fuelCount + value
-	  end
-  end)
+	message.setHandler("getQuestFuelCount", function()
+		if storage.fuelCount then
+			return storage.fuelCount
+		end
+	end)
 
-  message.setHandler("removeQuestFuelCount", function(_, _, value)
-    if storage.fuelCount then
-	    storage.fuelCount = storage.fuelCount - value
-	  end
-  end)
-  
-  message.setHandler("emptyQuestFuelCount", function(_, _, _)
-    if storage.fuelCount then
-	    storage.fuelCount = 0
-	  end
-  end)
+	message.setHandler("addQuestFuelCount", function(_, _, value)
+		if storage.fuelCount then
+			storage.fuelCount = storage.fuelCount + value
+		end
+	end)
 
-  message.setHandler("setFuelSlotItem", function(_, _, value)
-	  storage.itemSlot = value
-  end)
+	message.setHandler("removeQuestFuelCount", function(_, _, value)
+		if storage.fuelCount then
+			storage.fuelCount = storage.fuelCount - value
+		end
+	end)
 
-  message.setHandler("getFuelSlotItem", function()
-	  return storage.itemSlot
-  end)
+	message.setHandler("emptyQuestFuelCount", function(_, _, _)
+		if storage.fuelCount then
+			storage.fuelCount = 0
+		end
+	end)
 
-  message.setHandler("setCurrentMaxFuel", function(_, _, value)
-	  if value then
-	    storage.currentMaxFuel = value
-	  end
-  end)
+	message.setHandler("setFuelSlotItem", function(_, _, value)
+		storage.itemSlot = value
+	end)
 
-  message.setHandler("setFuelType", function(_, _, value)
-	  storage.fuelType = value
-  end)
+	message.setHandler("getFuelSlotItem", function()
+		return storage.itemSlot
+	end)
 
-  message.setHandler("getFuelType", function()
-	  return storage.fuelType
-  end)
+	message.setHandler("setCurrentMaxFuel", function(_, _, value)
+		if value then
+			storage.currentMaxFuel = value
+		end
+	end)
 
-  --refinery code
-  message.setHandler("setRefineryInputItem", function(_, _, value)
-	  storage.rInputItemSlot = value
-  end)
+	message.setHandler("setFuelType", function(_, _, value)
+		storage.fuelType = value
+	end)
 
-  message.setHandler("getRefineryInputItem", function()
-	  return storage.rInputItemSlot
-  end)
+	message.setHandler("getFuelType", function()
+		return storage.fuelType
+	end)
 
-  message.setHandler("setRefineryOutputItem", function(_, _, value)
-	  storage.rOutputItemSlot = value
-  end)
+	--refinery code
+	message.setHandler("setRefineryInputItem", function(_, _, value)
+		storage.rInputItemSlot = value
+	end)
 
-  message.setHandler("getRefineryOutputItem", function()
-	  return storage.rOutputItemSlot
-  end)
+	message.setHandler("getRefineryInputItem", function()
+		return storage.rInputItemSlot
+	end)
 
-  message.setHandler("setCatalystInputItem1", function(_, _, value)
-	  storage.cInputItemSlot1 = value
-  end)
+	message.setHandler("setRefineryOutputItem", function(_, _, value)
+		storage.rOutputItemSlot = value
+	end)
 
-  message.setHandler("setCatalystInputItem2", function(_, _, value)
-	  storage.cInputItemSlot2 = value
-  end)
+	message.setHandler("getRefineryOutputItem", function()
+		return storage.rOutputItemSlot
+	end)
 
-  message.setHandler("getCatalystInputItem1", function()
-	  return storage.cInputItemSlot1
-  end)
+	message.setHandler("setCatalystInputItem1", function(_, _, value)
+		storage.cInputItemSlot1 = value
+	end)
 
-  message.setHandler("getCatalystInputItem2", function()
-    return storage.cInputItemSlot2
-  end)
+	message.setHandler("setCatalystInputItem2", function(_, _, value)
+		storage.cInputItemSlot2 = value
+	end)
 
-  message.setHandler("setCatalystOutputItem", function(_, _, value)
-	  storage.cOutputItemSlot = value
-  end)
+	message.setHandler("getCatalystInputItem1", function()
+		return storage.cInputItemSlot1
+	end)
 
-  message.setHandler("getCatalystOutputItem", function()
-	  return storage.cOutputItemSlot
-  end)
-  --end
+	message.setHandler("getCatalystInputItem2", function()
+		return storage.cInputItemSlot2
+	end)
 
-  if not storage.currentMaxFuel then
-    storage.currentMaxFuel = 0
-  end
+	message.setHandler("setCatalystOutputItem", function(_, _, value)
+		storage.cOutputItemSlot = value
+	end)
 
-  if not storage.fuelCount then
-    storage.fuelCount = 0
-  end
+	message.setHandler("getCatalystOutputItem", function()
+		return storage.cOutputItemSlot
+	end)
+	--end
+
+	if not storage.currentMaxFuel then
+		storage.currentMaxFuel = 0
+	end
+
+	if not storage.fuelCount then
+		storage.fuelCount = 0
+	end
 end
 
 function update(dt)
-  if storage.currentMaxFuel and storage.fuelCount then
-        if storage.fuelCount > storage.currentMaxFuel then
-	    storage.fuelCount = storage.currentMaxFuel
-  	end
-  end
+	--[[if storage.currentMaxFuel and storage.fuelCount then
+		if storage.fuelCount > storage.currentMaxFuel then
+			storage.fuelCount = storage.currentMaxFuel
+		end
+	end]]
 
-  if storage.fuelCount and storage.fuelCount < 0 then
-    storage.fuelCount = 0
-  end
-  
-  if storage.fuelCount > storage.currentMaxFuel then
-    storage.fuelCount = storage.currentMaxFuel
-  end
-  
-  if storage.fuelType and storage.fuelCount and storage.fuelCount <= 0 then
-    storage.fuelType = nil
-  end
+	if storage.fuelCount and storage.fuelCount < 0 then
+		storage.fuelCount = 0
+	end
+
+	--[[if storage.fuelCount > storage.currentMaxFuel then
+		storage.fuelCount = storage.currentMaxFuel
+	end]]
+
+	if storage.fuelType and storage.fuelCount and storage.fuelCount <= 0 then
+		storage.fuelType = nil
+	end
 end


### PR DESCRIPTION
mech fuel UI no longer truncates current fuel values
cat themed fuel is usable again for refueling mech.
mech fuel system now supports going over the maximum by the value of one fuel item. IE: cat fuel at max-1 will become catfuel + max-1. Words are tricky. In short: fuel is never wasted.

reduced embalming table yield of agaranichor from giantfloranpod from 30 to 8. now takes 12s (50% longer) to finish dissecting.

megatop is now capturable at a very very low threshold (5%). may as well, since you basically can only get it by feeding poptops meat