### PR TITLE
Precursor spawned enemies no longer drop brains

### DIFF
--- a/objects/minibiome/precursor/fu_precursorspawner/fu_precursorspawner.lua
+++ b/objects/minibiome/precursor/fu_precursorspawner/fu_precursorspawner.lua
@@ -84,6 +84,10 @@ function update(dt)
 					params.statusSettings = baseParams.statusSettings or {}
 					params.statusSettings.stats = baseParams.statusSettings.stats or {}
 					params.statusSettings.stats.boozeImmunity = {baseValue = 1.0}
+					params.statusSettings.statusProperties = params.statusSettings.stats.statusProperties or {}
+					params.statusSettings.statusProperties.fu_precursorSpawned = true
+					
+					params.anchorName = object.name() --to make ship pets spawned by it not despawn
 					
 					params.behaviorConfig = util.mergeTable(baseParams.behaviorConfig or {}, params.behaviorConfig or {})
 					
@@ -116,7 +120,8 @@ function update(dt)
 					end
 					
 					if monsterType and params.seed then
-						world.spawnMonster(monsterType, spawnPosition, params);
+						local monsterId = world.spawnMonster(monsterType, spawnPosition, params);
+						world.callScriptedEntity(monsterId, "setAnchor", entity.id())	--to allow ship pets to be spawned
 					end
 				end
 				storage.crafting = false

--- a/stats/effects/deathbomb/deathbombbrainharvest.statuseffect
+++ b/stats/effects/deathbomb/deathbombbrainharvest.statuseffect
@@ -17,13 +17,15 @@
 			},
 			"monster": {
 				"default": "madnessBrainHarvesting",
-				"robotic": "madnessBrainHarvestingRobot"
+				"robotic": "madnessBrainHarvestingRobot",
+				"beer": "madnessBrainHarvestingBeer"
 			}
 		}
 	},
 	"defaultDuration": 10,
 
 	"scripts": [
-		"deathbombcomplextreasurepool.lua"
+		"deathbombcomplextreasurepool.lua", 
+		"fu_precursorspawnerbrainharvest.lua"
 	]
 }

--- a/stats/effects/deathbomb/fu_precursorspawnerbrainharvest.lua
+++ b/stats/effects/deathbomb/fu_precursorspawnerbrainharvest.lua
@@ -1,0 +1,8 @@
+local origInit = init or function() end
+
+function init()
+	origInit()
+	if self.didInit and entType == "monster" and status.statusProperty("fu_precursorSpawned") then
+		subType = "beer"
+	end
+end

--- a/treasure/madness.treasurepools
+++ b/treasure/madness.treasurepools
@@ -37,7 +37,7 @@
   "madnessBrainHarvestingBeer" : [
     [0, {
       "pool" : [
-       {"weight" : 1, "item" : "beer"}
+       {"weight" : 1, "item" : {"name" : "beer", "count" : 1, "parameters" : {"price" : 0}}}
       ]
     }]
   ],

--- a/treasure/madness.treasurepools
+++ b/treasure/madness.treasurepools
@@ -34,7 +34,13 @@
       ]
     }]
   ],
-  
+  "madnessBrainHarvestingBeer" : [
+    [0, {
+      "pool" : [
+       {"weight" : 1, "item" : "beer"}
+      ]
+    }]
+  ],
 
   "fuMadnessVoxelMicro" : [
     [0, {


### PR DESCRIPTION
- Precursor spawners can now spawn ship pets if they are in a capture pod (break it to get rid of them)
- Enemies spawned from precursor spawners no longer drop brains