### PR TITLE
Removed references to transfer rates in battery branch

### DIFF
--- a/zb/researchTree/fu_power.config
+++ b/zb/researchTree/fu_power.config
@@ -332,11 +332,11 @@
 			
 			"battery1" : ["Silicon Batteries","^orange;Tier 2^reset;\n\nUsing silicon, you've learned to create simple solid-state batteries at your ^orange;Electronics Center^reset;- a big step up from junky old lead-acid ones."],	
 			
-			"battery2" : ["Improved Batteries","^orange;Tier 3^reset;\n\nYou've improved your skills building batteries with silicon, and can now create batteries that discharge faster and hold much more charge than before."],	
+			"battery2" : ["Improved Batteries","^orange;Tier 3^reset;\n\nYou've improved your skills building batteries with silicon, and can now create batteries that hold much more charge than before."],	
 			
 			"battery3" : ["Protocite Batteries","^orange;Tier 4^reset;\n\nUsing Protocite's amazing ability to store and channel energy, you've designed a new kind of battery that is better than silicon in every way."],		
 			
-			"battery4" : ["Advanced Batteries","^orange;Tier 5^reset;\n\nCombining AI technology and Quietus metals, you have developed a bizarre sort of battery that stores energy almost like a living creature. This comes with even better storage and discharge rates."],	
+			"battery4" : ["Advanced Batteries","^orange;Tier 5^reset;\n\nCombining AI technology and Quietus metals, you have developed a bizarre sort of battery that stores energy almost like a living creature. This comes with even better storage capacity."],	
 			
 			"battery5a" : ["Hydrogen Batteries","^orange;Tier 6^reset;\n\nLiquid Metallic Hydrogen is such a potent energy medium that it blows any solid-state battery out of the water. With it, you've designed what may well be the best battery in the galaxy."],	
 			


### PR DESCRIPTION
The Improved Batteries and Advanced Batteries nodes referenced discharge rates, which have now been made obsolete by the recent battery changes. Lunari Batteries was left unchanged as the node is not currently available.