### PR TITLE
Default unlock checker

### DIFF
--- a/items/active/unsorted/fu_defaultunlockdiagnoser/fu_defaultunlockdiagnoser.activeitem
+++ b/items/active/unsorted/fu_defaultunlockdiagnoser/fu_defaultunlockdiagnoser.activeitem
@@ -1,11 +1,11 @@
 {
     "itemName" : "fu_defaultunlockdiagnoser",
-    "price" : 800,
+    "price" : 0,
     "inventoryIcon" : "fu_defaultunlockdiagnoser.png",
     "maxStack" : 1,
-    "rarity" : "Uncommon",
-    "description" : "Shows missing unlocks and ones that are where the vanilla ones should be in a pop-up, also prints it to your log.",
-    "shortdescription" : "Default Unlock Diagnoser",
+    "rarity" : "Essential",
+    "description" : "Use to check if you have any missing default unlocks. Prints items that could be causing the issue to the log.",
+    "shortdescription" : "^cyan;Default Unlock Checker",
     "category" : "Tool",
 
     "twoHanded" : true,
@@ -13,6 +13,12 @@
 	"animation" : "fu_defaultunlockdiagnoser.animation",
 
     "scripts" : ["fu_defaultunlockdiagnoser.lua"],
+	
+	"strings" : {
+		"numMissingUnlocks" : "There are <numMissing> default unlocks missing.",
+		"missingUnlocksPresent" : "Check your log for a list of default unlocks that are likely causing the issue.",
+		"logString" : "Default unlocks that are likely causing issues: "
+	},
 	
 	"defaultUnlocks" : [
 		"campfire",

--- a/items/active/unsorted/fu_defaultunlockdiagnoser/fu_defaultunlockdiagnoser.lua
+++ b/items/active/unsorted/fu_defaultunlockdiagnoser/fu_defaultunlockdiagnoser.lua
@@ -1,10 +1,10 @@
 require "/scripts/vec2.lua"
 
 function init()
-	-- This code could probs be optimised quite a bit, but don't really feel like it atm
 	local playerCfg = root.assetJson("/player.config")
 	local defaultUnlocks = playerCfg.defaultBlueprints.tier1
 	local unlocks = {}
+	local strings = config.getParameter("strings", {})
 	for _, item in ipairs(defaultUnlocks) do
 		local itemName = item.item or item.name
 		if itemName then
@@ -12,30 +12,34 @@ function init()
 		end
 	end
 	local requiredUnlocks = config.getParameter("defaultUnlocks", {})
+	local requiredUnlocksTable = {}
 	local missingUnlocks = {}
-	missingString = "If the the text doesn't fit in the popup look at the log.\nMissing the unlocks for: "
 	for _, item in ipairs(requiredUnlocks) do
+		requiredUnlocksTable[item] = true
 		if not unlocks[item] then
 			table.insert(missingUnlocks, item)
-			missingString = missingString .. item .. ", "
 		end
 	end
-	missingString = missingString:sub(1, -3)
-	local requiredUnlocksTable = {}
-	for _, item in ipairs (requiredUnlocks) do
-		requiredUnlocksTable[item] = true
-	end
-	local extraUnlocks = {}
-	missingString = missingString .. "\nUnlocks where vanilla ones should be: "
-	for i = 1, #requiredUnlocks do
-		local itemCfg = defaultUnlocks[i]
-		local item = defaultUnlocks[i].item or defaultUnlocks[i].name
-		if item and not requiredUnlocksTable[item] then
-			table.insert(extraUnlocks, item)
-			missingString = missingString .. item .. ", "
+	popupString = strings.numMissingUnlocks:gsub("<numMissing>", "<colour>" .. tostring(#missingUnlocks) .. "^reset;")
+	if #missingUnlocks > 0 then
+		popupString = popupString:gsub("<colour>", "^red;")
+		popupString = popupString .. "\n" .. strings.missingUnlocksPresent
+		logString = strings.logString
+		local issueUnlocks = {}
+		for _, item in ipairs (defaultUnlocks) do
+			local itemName = item.item or item.name
+			if itemName then
+				if requiredUnlocksTable[itemName] then
+					break;
+				else
+					table.insert(issueUnlocks, itemName)
+				end
+			end
 		end
+		logString = logString .. sb.printJson(issueUnlocks, 1)
+	else
+		popupString = popupString:gsub("<colour>", "^green;")
 	end
-	missingString = missingString:sub(1, -3)
 end
 
 function update(dt, fireMode, shiftHeld)
@@ -43,9 +47,9 @@ function update(dt, fireMode, shiftHeld)
 end
 
 function activate(fireMode, shiftHeld)
-	player.interact("ShowPopup", {message = missingString})
-	sb.logInfo(missingString)
-	--sb.logInfo(sb.printJson(missingUnlocks, 1))
-	--sb.logInfo(sb.printJson(extraUnlocks, 1))
+	player.interact("ShowPopup", {message = popupString})
+	if logString then
+		sb.logInfo(logString)
+	end
 	fired = true
 end

--- a/player.config.patch
+++ b/player.config.patch
@@ -699,6 +699,9 @@
 	//kibbles
 	[ { "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "robosnax"} } ],
 	[ { "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "meatkibble"} } ],
+	
+
+	[ { "op": "add", "path": "/defaultBlueprints/tier1/-", "value": {"item": "fu_defaultunlockdiagnoser"} } ],
 
 
 

--- a/recipes/emptyhands/fu_defaultunlockdiagnoser.recipe
+++ b/recipes/emptyhands/fu_defaultunlockdiagnoser.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [],
+  "output" : {
+    "item" : "fu_defaultunlockdiagnoser",
+    "count" : 1
+  },
+  "groups" : [ "plain", "all" ]
+}


### PR DESCRIPTION
- Makes the default unlock checker obtainable legitimately (crafted in the hand crafting menu) and improved it a bit.
    - It gives tells you how many default vanilla unlocks you are missing that you should have and if it's more than 0, it prints a list of unlocks that are likely causing the issue to your log.

