### PR TITLE
Fix typo in feneroxchestsmall.recipe

### DIFF
--- a/recipes/furniture1/fenerox/feneroxchestsmall.recipe
+++ b/recipes/furniture1/fenerox/feneroxchestsmall.recipe
@@ -4,6 +4,6 @@
 	{ "item" : "darkwoodmaterial", "count" : 5 },
 	{ "item" : "leather", "count" : 5 }
   ],
-  "output" : { "item" : "feneroxchestlarge", "count" : 1 },
+  "output" : { "item" : "feneroxchestsmall", "count" : 1 },
   "groups" : [ "craftingfurniture", "storage", "all" ]
 }


### PR DESCRIPTION
This recipe is for Small Fenerox Chest,
there is already feneroxchestlarge.recipe for Large Fenerox Chest.