### PR TITLE
things

### DIFF
--- a/items/armors/tier2/diplomat/diplomat.chest
+++ b/items/armors/tier2/diplomat/diplomat.chest
@@ -5,8 +5,8 @@
   "maxStack" : 1,
   "rarity" : "common",
   "description" : "^orange;Set Bonuses^reset;: 
-^yellow;^reset; Rapier/Pistol: ^green;7.5^reset;/Defense x^green;1.15^reset;^reset;
-^yellow;^reset; +^green;25^reset;% Charisma, +^green;25^reset;% Mental Resistace;", 
+^yellow;^reset; Rapier/Pistol: Defense x^green;1.075^reset;/^green;1.15^reset;
+^yellow;^reset; +^green;25^reset;% Charisma, +^green;25^reset;% Mental Resistance", 
   "shortdescription" : "Diplomat's Jacket",
   "category" : "chestarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier2/diplomat/diplomat.head
+++ b/items/armors/tier2/diplomat/diplomat.head
@@ -5,8 +5,8 @@
   "maxStack" : 1,
   "rarity" : "common",
   "description" : "^orange;Set Bonuses^reset;: 
-^yellow;^reset; Rapier/Pistol: ^green;7.5^reset;/Defense x^green;1.15^reset;^reset;
-^yellow;^reset; +^green;25^reset;% Charisma, +^green;25^reset;% Mental Resistace;", 
+^yellow;^reset; Rapier/Pistol: Defense x^green;1.075^reset;/^green;1.15^reset;
+^yellow;^reset; +^green;25^reset;% Charisma, +^green;25^reset;% Mental Resistance", 
   "shortdescription" : "Diplomat's Glasses",
   "category" : "headarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier2/diplomat/diplomat.legs
+++ b/items/armors/tier2/diplomat/diplomat.legs
@@ -5,8 +5,8 @@
   "maxStack" : 1,
   "rarity" : "common",
   "description" : "^orange;Set Bonuses^reset;: 
-^yellow;^reset; Rapier/Pistol: ^green;7.5^reset;/Defense x^green;1.15^reset;^reset;
-^yellow;^reset; +^green;25^reset;% Charisma, +^green;25^reset;% Mental Resistace;", 
+^yellow;^reset; Rapier/Pistol: Defense x^green;1.075^reset;/^green;1.15^reset;
+^yellow;^reset; +^green;25^reset;% Charisma, +^green;25^reset;% Mental Resistance", 
   "shortdescription" : "Diplomat's Leggings",
   "category" : "legarmour",
   "tooltipKind" : "armornew2",

--- a/quests/scripts/tutorial/fu_start.lua
+++ b/quests/scripts/tutorial/fu_start.lua
@@ -4,12 +4,11 @@ require("/quests/scripts/questutil.lua")
 function init()
 	storage.hasPickaxe = storage.hasPickaxe or 0
 	setPortraits()
-	setStage(1)
 	message.setHandler("fu_completeTutorial", function() setStage(4) end)
 end
 
 function questStart()
-
+	setStage(1)
 end
 
 function questComplete()

--- a/radiomessages/fu_madness.radiomessages
+++ b/radiomessages/fu_madness.radiomessages
@@ -1,40 +1,56 @@
 {
-  "madness1" : {
-    "unique" : false,
-    "text" : "Why have you decided to suddenly munch on some plant fibre? Don't try to deny it. My sensors indicate you have ingested it."
-  },
-  "madness2" : {
-    "unique" : false,
-    "text" : "I am detecting abnormalities in your brain that seem to be causing you to have issues in utilizing your full physical capacity. It should pass, eventually."
-  },
-  "madnessroot" : {
-    "unique" : false,
-    "text" : "Your brain has stopped sending signals to your legs. It appears to be a synaptic issue, likely related to your bouts of insanity."
-  },
-  "madnessharm" : {
-    "unique" : false,
-    "text" : "I suggest you put that knife down. You just cut your own arm open and appear to be bleeding profusely."
-  },  
-  "madnessfood" : {
-    "unique" : false,
-    "text" : "Your brain and body are currently in dispute over your hunger."
-  },    
-  "sanitygain" : {
-    "unique" : false,
-    "text" : "You have recovered some of your lost mental stability."
-  },    
-  "combust" : {
-    "unique" : false,
-    "text" : "Well, it would appear that your current seat has randomly caught ^orange;on fire^reset;. That, or you set it on fire. Either way: it is ^orange;on fire^reset;. And so are you."
-  },
-  "crazycarry" : {
-    "unique" : false,
-    "senderName" : "Kevin",
-    "portraitImage": "/interface/chatbubbles/fukevintalkthumbs.png:<frame>",    
-    "portraitFrames" : 9,   
-    "portraitSpeed" : 3,  
-    "textSpeed" : 70,      
-    "persistTime" : 8.0,   
-    "text" : "You are carrying something that is making you slowly lose your mind. It may be something gross, spooky, horrifying or simply unknowable. The terrible secrets of the universe are fun!"
-  }             
+	"madness1" : {
+		"unique" : false,
+		"text" : "Why have you decided to suddenly munch on some plant fibre? Don't try to deny it. My sensors indicate you have ingested it."
+	},
+	"madness2" : {
+		"unique" : false,
+		"text" : "I am detecting abnormalities in your brain that seem to be causing you to have issues in utilizing your full physical capacity. It should pass, eventually."
+	},
+	"madnessroot" : {
+		"unique" : false,
+		"text" : "Your brain has stopped sending signals to your legs. It appears to be a synaptic issue, likely related to your bouts of insanity."
+	},
+	"madnessharm" : {
+		"unique" : false,
+		"text" : "I suggest you put that knife down. You just cut your own arm open and appear to be bleeding profusely."
+	},
+	"madnessfood" : {
+		"unique" : false,
+		"text" : "Your brain and body are currently in dispute over your hunger."
+	},
+	"madnessenergy" : {
+		"unique" : false,
+		"text" : "Did you just lick your battery pack? Don't deny it. My sensors indicate you did."
+	},
+	"madnessvuln" : {
+		"unique" : false,
+		"text" : "Run. Everything will kill you. Run! DROP EVERYTHING AND RUN!"
+	},
+	"sanitygain" : {
+		"unique" : false,
+		"text" : "You have recovered some of your lost mental stability."
+	},
+	"combust" : {
+		"unique" : false,
+		"text" : "Well, it would appear that your current seat has randomly caught ^orange;on fire^reset;. That, or you set it on fire. Either way: it is ^orange;on fire^reset;. And so are you."
+	},
+	"crazycarry" : {
+		"unique" : false,
+		"senderName" : "Kevin",
+		"portraitImage": "/interface/chatbubbles/fukevintalkthumbs.png:<frame>",
+		"portraitFrames" : 9,
+		"portraitSpeed" : 3,
+		"textSpeed" : 70,
+		"persistTime" : 8.0,
+		"text" : "You are carrying something that is making you slowly lose your mind. It may be something gross, spooky, horrifying or simply unknowable. The terrible secrets of the universe are fun!"
+	},
+	"madnessbeans":{
+		"unique" : false,
+		"text" : "Beans. All you can think of is beans, and now you are bloated and gassy like you ate some. Maybe you did eat some! Or maybe that was your toe."
+	},
+	"madnesscat":{
+		"unique" : false,
+		"text" : "Incoming message from 'Khe': Mew. Mew? Mew. Mewawew. Mewmewmew. Mew. Maow. Mrrrrdrrrr..."
+	}
 }

--- a/stats/effects/fu_weathereffects/new/insanity/duncetteinsanity.statuseffect
+++ b/stats/effects/fu_weathereffects/new/insanity/duncetteinsanity.statuseffect
@@ -1,108 +1,112 @@
 {
-  "name" : "duncetteinsanity",
-  "blockingStat" : "",
+	"name" : "duncetteinsanity",
+	"blockingStat" : "",
 
-  "effectConfig" : {
-    "resistanceTypes" : {
-      "cosmicResistance" : 1.0,
-      "shadowResistance" : 0.5
-    },
-    "resistanceThreshold" : 6.0,
-    "immunityStats" : [],
+	"effectConfig" : {
+		"resistanceTypes" : {
+			"cosmicResistance" : 1.0,
+			"shadowResistance" : 0.5
+		},
+		"resistanceThreshold" : 6.0,
+		"immunityStats" : [],
 
-    "healthDrain" : 0.15,
-    "hungerDrain" : 0.05,
-    "energyDrain" : 0,
-    "speedPenalty" : 0,
-    "jumpPenalty" : 0,
+		"healthDrain" : 0.15,
+		"hungerDrain" : 0.05,
+		"energyDrain" : 0,
+		"speedPenalty" : 0,
+		"jumpPenalty" : 0,
 
-    "debuffRate" : 8,
-    "debuffStartDelay" : 0,
-    "debuffs" : {
-      "protection" : {
-        "amount" : -1,
-        "cap" : -10
-      },
-      "maxEnergy" : {
-        "amount" : -1,
-        "cap" : -1
-      }
-    },
+		"debuffRate" : 8,
+		"debuffStartDelay" : 0,
+		"debuffs" : {
+			"healingBonus":{
+				"amount":-0.05,
+				"cap":-2
+			},
+			"protection" : {
+				"amount" : -1,
+				"cap" : -10
+			},
+			"maxEnergy" : {
+				"amount" : -1,
+				"cap" : -1
+			}
+		},
 
-    "colorMod" : [-160, -210, -210],
-    "saturation" : 0,
+		"colorMod" : [-160, -210, -210],
+		"saturation" : 0,
 
-    "chatterDelay" : {
-      "base" : 30,
-      "random" : 45
-    },
+		"chatterDelay" : {
+			"base" : 30,
+			"random" : 45
+		},
 
-    "darknessImmunityDelay" : 60,
+		"darknessImmunityDelay" : 60,
 
-    "modifiers" : {},
+		"modifiers" : {},
 
-    "messages" : {
-      "intro" : "fubiomeinsanity",
-      "wet" : "insanityeffectliquid",
-      "fast" : "insanityeffectfast",
-      "zeroG" : "insanityEffectgrav",
-      "airborne" : [
-        "insanityEffectair",
-        "insanityEffectair2",
-        "insanityEffectair3"
-      ],
-      "injured" : [
-        "insanityeffectdying",
-        "insanityeffectdying2",
-        "insanityeffectdying3",
-        "insanityeffectdying4",
-        "insanityeffectdying5",
-        "insanityeffectskin",
-        "insanityeffectwindy",
-        "insanityeffectducts",
-        "insanityeffectweirdo1",
-        "insanityeffectweirdo2",
-        "insanityeffectweirdo3",
-        "insanityeffectweirdo4",
-        "fu_kevin_insanity3",
-        "fu_kevin_insanity5",
-        "fu_kevin_insanity1"
-      ],
-      "random" : [
-        "insanityeffectkyle",
-        "insanityeffectmike",
-        "insanityeffectmusic",
-        "insanityeffectwee",
-        "insanityeffectneat",
-        "insanityeffectskin",
-        "insanityeffectwindy",
-        "insanityeffectducts",
-        "insanityeffectweirdo1",
-        "insanityeffectweirdo2",
-        "insanityeffectweirdo3",
-        "insanityeffectweirdo4",
-        "fu_kevin_insanity6",
-        "fu_kevin_insanity2",
-        "fu_kevin_insanity4"
-      ],
-      "hungry5" : "insanityeffecthungry4",
-      "hungry10" : "insanityeffecthungry3",
-      "hungry20" : "insanityeffecthungry2",
-      "hungry30" : "insanityeffecthungry1",
-      "hungry40" : "insanityeffecthungry5",
-      "hungry50" : "insanityeffecthungry6",
-      "hungry60" : "insanityeffecthungry7"
-    },
+		"messages" : {
+			"intro" : "fubiomeinsanity",
+			"wet" : "insanityeffectliquid",
+			"fast" : "insanityeffectfast",
+			"zeroG" : "insanityEffectgrav",
+			"airborne" : [
+				"insanityEffectair",
+				"insanityEffectair2",
+				"insanityEffectair3"
+			],
+			"injured" : [
+				"insanityeffectdying",
+				"insanityeffectdying2",
+				"insanityeffectdying3",
+				"insanityeffectdying4",
+				"insanityeffectdying5",
+				"insanityeffectskin",
+				"insanityeffectwindy",
+				"insanityeffectducts",
+				"insanityeffectweirdo1",
+				"insanityeffectweirdo2",
+				"insanityeffectweirdo3",
+				"insanityeffectweirdo4",
+				"fu_kevin_insanity3",
+				"fu_kevin_insanity5",
+				"fu_kevin_insanity1"
+			],
+			"random" : [
+				"insanityeffectkyle",
+				"insanityeffectmike",
+				"insanityeffectmusic",
+				"insanityeffectwee",
+				"insanityeffectneat",
+				"insanityeffectskin",
+				"insanityeffectwindy",
+				"insanityeffectducts",
+				"insanityeffectweirdo1",
+				"insanityeffectweirdo2",
+				"insanityeffectweirdo3",
+				"insanityeffectweirdo4",
+				"fu_kevin_insanity6",
+				"fu_kevin_insanity2",
+				"fu_kevin_insanity4"
+			],
+			"hungry5" : "insanityeffecthungry4",
+			"hungry10" : "insanityeffecthungry3",
+			"hungry20" : "insanityeffecthungry2",
+			"hungry30" : "insanityeffecthungry1",
+			"hungry40" : "insanityeffecthungry5",
+			"hungry50" : "insanityeffecthungry6",
+			"hungry60" : "insanityeffecthungry7"
+		},
 
-    "configPath" : "/stats/effects/fu_weathereffects/new/insanity/duncetteinsanity.statuseffect"
-  },
-  "defaultDuration" : 120,
+		"configPath" : "/stats/effects/fu_weathereffects/new/insanity/duncetteinsanity.statuseffect"
+	},
+	"defaultDuration" : 120,
 
-  "scripts" : [
-    "insanitynew.lua"
-  ],
+	"scripts" : [
+		"insanitynew.lua"
+	],
 
-  "animationConfig" : "insanitynew.animation",
+	"animationConfig" : "insanitynew.animation",
 
-  "icon" : "/interface/statuses/insanity.png"
+	"icon" : "/interface/statuses/insanity.png"
 }

--- a/stats/effects/medicalStationSpecials/toxiccloud/toxiccloudmadness.statuseffect
+++ b/stats/effects/medicalStationSpecials/toxiccloud/toxiccloudmadness.statuseffect
@@ -1,0 +1,17 @@
+{
+	"name" : "toxiccloudmadness",
+	"label" : "Toxic Cloud",
+	"icon" : "/interface/statuses/medicalStationSpecials/toxiccloud.png",
+
+	"defaultDuration" : 5,
+	"scripts" : [ "toxiccloud.lua" ],
+	
+	"effectConfig" : {
+		"cloudInterval" : 3,
+		"cloudDamage" : 50,
+		"cloudDamageType" : "poison",
+		"selfDamage" : 5,
+		"selfDamageType" : "poison",
+		"cloudDuration" : 5
+	}
+}

--- a/stats/effects/staffslow/madnessslow1.statuseffect
+++ b/stats/effects/staffslow/madnessslow1.statuseffect
@@ -1,0 +1,23 @@
+{
+	"name": "madnessslow1",
+	"effectConfig": {
+		"controlModifiers": {
+			"groundMovementModifier": 0.9,
+			"speedModifier": 0.9,
+			"airJumpModifier": 0.9
+		},
+		"stats": [{
+			"stat": "jumpModifier",
+			"amount": -0.1
+		}]
+	},
+	"defaultDuration": 1,
+
+	"scripts": [
+		"/stats/effects/fu_genericStatApplier.lua",
+		"/stats/effects/fu_genericControlModifiers.lua"
+	],
+
+	"label": "Slow",
+	"icon": "/interface/statuses/slow.png"
+}

--- a/stats/effects/staffslow/madnessslow2.statuseffect
+++ b/stats/effects/staffslow/madnessslow2.statuseffect
@@ -1,0 +1,23 @@
+{
+	"name": "madnessslow2",
+	"effectConfig": {
+		"controlModifiers": {
+			"groundMovementModifier": 0.8,
+			"speedModifier": 0.8,
+			"airJumpModifier": 0.8
+		},
+		"stats": [{
+			"stat": "jumpModifier",
+			"amount": -0.2
+		}]
+	},
+	"defaultDuration": 1,
+
+	"scripts": [
+		"/stats/effects/fu_genericStatApplier.lua",
+		"/stats/effects/fu_genericControlModifiers.lua"
+	],
+
+	"label": "Slow",
+	"icon": "/interface/statuses/slow.png"
+}


### PR DESCRIPTION
fixed diplomat set tooltip

minor adjustments to madness quest script:
'food' drain event removes and may randomly reapply well-fed bonus. food randomizer instead randomizes energy on casual. This makes them more relevant for casual players.
replaced application of  medical station toxic cloud with a madness specific variant. additionally, added a minor slow and a beans related message.
replaced usage of staffslow2 and slow with madness specific slows of reduced effectiveness. staffslow2 could be cheesed using heavy weapons anyway.
corrected flipped conditions in research bonus by tier, resulting in a bonus never applying for staying more than 25 minutes on a high tier planet.
max food reduction effect instead applies the gas cloud and slow effects for casual players.
added an alarming radio message when vulnerability is applied.
added a harmless message to the >1500 bracket, purely to confuse people further.

Crown of the Idiot: now applies a stacking healingBonus modifier of -0.5 per interval, stacking up to -2.0 (effectively negating any and all healingBonus increases), to mitigate AFK cheese by making the target decidedly...mortal.

tutorial quest: moved setStage(1) from init to questStart, to prevent quest restarting on leaving worlds etc.