### PR TITLE
Updated description to improve clarity

### DIFF
--- a/objects/fu_watcher/fu_watcher.object
+++ b/objects/fu_watcher/fu_watcher.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "creepy", "tech", "power", "lab" ],
   "printable" : false,
   "rarity" : "uncommon",
-  "description" : "Used to keep machines ^blue;within 20 tiles^reset; running while away from home. Shuts off when you leave the planet.",
+  "description" : "Used to keep ^blue;everything within 20 tiles^reset; loaded while away, if turned on. Shuts off when you leave the planet.",
   "shortdescription" : "Watcher",
   "race" : "human",
 

--- a/objects/fu_watcher/fu_watcher.object
+++ b/objects/fu_watcher/fu_watcher.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "creepy", "tech", "power", "lab" ],
   "printable" : false,
   "rarity" : "uncommon",
-  "description" : "Used to keep wired stations ^blue;within 20 tiles^reset; running while away from home. Shuts off when you leave the planet.",
+  "description" : "Used to keep machines ^blue;within 20 tiles^reset; running while away from home. Shuts off when you leave the planet.",
   "shortdescription" : "Watcher",
   "race" : "human",
 


### PR DESCRIPTION
Myself and others were initially under the impression that 'wired stations' meant stations wired to the watcher, rather than every sector within range. This should be clearer, and doesn't overflow the description box.