### PR TITLE
Added missing crew beds to the Shipcrafting node

### DIFF
--- a/zb/researchTree/fu_engineering.config
+++ b/zb/researchTree/fu_engineering.config
@@ -329,7 +329,7 @@
 				"position" : [150, 0],
 				"children" : [ "shipdecorative", "spaceftl2" ],
 				"price" : [["fuscienceresource", 800], ["siliconboard", 5], ["liquidfuel", 20]],
-				"unlocks" : [ "fu_shipcraftingtable", "slopedhullpanel", "apexshipwall", "apexshipsupport", "apexshipdetails","fu_byoscaptainschair","fu_byosfuelhatch","fu_byosshipdoor","fu_byosshiphatch","fu_byosshiplocker","fu_byostechstationdeco","fu_byosteleporter","fu_byosteleporterdeco","fu_byospethouse", "fu_crewbed2","fu_crewbed3","fu_crewbed4","fu_crewdeed","fu_byostechstation", "fu_shipnameplate"]
+				"unlocks" : [ "fu_shipcraftingtable", "slopedhullpanel", "apexshipwall", "apexshipsupport", "apexshipdetails","fu_byoscaptainschair","fu_byosfuelhatch","fu_byosshipdoor","fu_byosshiphatch","fu_byosshiplocker","fu_byostechstationdeco","fu_byosteleporter","fu_byosteleporterdeco","fu_byospethouse", "fu_crewbed","fu_crewbed2","fu_crewbed3","fu_crewbed4","fu_crewbed5","fu_crewdeed","fu_byostechstation", "fu_shipnameplate"]
 			},
 			"shipdecorative" : {
 				"icon" : "/objects/crafting/fu_shipcraftingtable/fu_shipcraftingtableicon.png",


### PR DESCRIPTION
fu_crewbed and fu_crewbed5 were not unlockable anywhere. I've added them to the same node that unlocks all the other non-crappy crew beds