### PR TITLE
Rename item "fureinforcedglass" to Reinforced Glass Block

### DIFF
--- a/tiles/materials/tilesandgreebles/fureinforcedglass.matitem
+++ b/tiles/materials/tilesandgreebles/fureinforcedglass.matitem
@@ -5,7 +5,7 @@
   "inventoryIcon" : "fureinforcedglassicon.png",
   "dropCollision" : [-2.5, -2.0, 2.5, 2.0],
   "description" : "Plasteel reinforced glass.",
-  "shortdescription" : "Reinforced Glass",
+  "shortdescription" : "Reinforced Glass Block",
 //  "learnBlueprintsOnPickup" : [ "fureinforcedglass" ],
   "materialId" : 6739
 }


### PR DESCRIPTION
There is another item (crafting material) called "Reinforced Glass", so we rename the block to avoid confusion.