### PR TITLE
Tweaked unlock requirements for Combustion Generator and Blast Furnace

### DIFF
--- a/zb/researchTree/fu_power.config
+++ b/zb/researchTree/fu_power.config
@@ -41,7 +41,7 @@
 						"icon" : "/objects/power/isn_thermalgenerator/isn_thermalgeneratoricon.png",
 						"position" : [40, 40],
 						"children" : [ "windpower", "blastfurnace" ],
-						"price" : [["fuscienceresource", 750], ["liquidoil", 10], ["advcircuit", 1] ],
+						"price" : [["fuscienceresource", 750], ["liquidoil", 10], ["cpu", 1] ],
 						"unlocks" : [ "isn_thermalgenerator" ]
 					},
 					"windpower" : {
@@ -55,7 +55,7 @@
 						"icon" : "/objects/power/fu_blastfurnace/fu_blastfurnace_inv.png",
 						"position" : [100, 40],
 						"children" : [ "arcsmelter" ],
-						"price" : [["fuscienceresource", 7200], ["advancealloy", 3], ["corefragmentore", 20]],
+						"price" : [["fuscienceresource", 7200], ["advancealloy", 3], ["fuprocessor", 1], ["corefragmentore", 20]],
 						"unlocks" : [ "fu_blastfurnace" ]
 					},
 					"fission" : {


### PR DESCRIPTION
Combustion generator's recipe was changed from advanced circuit to advanced processor, but the research node wasn't changed to match.

I've also added in the quantum processor as a requirement for the blast furnace node as players won't be able to craft one without it and the gap between required circuitry is much greater post-combustion-change.