### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/weapons/ranged/unique/furepairgun.activeitem
+++ b/items/active/weapons/ranged/unique/furepairgun.activeitem
@@ -4,7 +4,7 @@
   "inventoryIcon" : "repairgun.png",
   "maxStack" : 1,
   "rarity" : "rare",
-  "description" : "Repairs damaged mecha. Upgrade at the ^orange;Tool Upgrade Table^reset;.",
+  "description" : "Repairs damaged mecha. Upgrade using your ^orange;Tricorder^reset;.",
   "shortdescription" : "Mech Repair Tool",
   "category" : "mechrepairtool",
   "level" : 1,


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.