### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/weapons/ranged/unique/miners/minertest/basicminertest.activeitem
+++ b/items/active/weapons/ranged/unique/miners/minertest/basicminertest.activeitem
@@ -7,7 +7,7 @@
   "rarity" : "common",
   "tooltipKind" : "gun2",
   "description" : "A neat little mining weapon. Does a bit of damage, too.
-Upgrade at ^orange;Tool Upgrade Table^reset;.",
+Upgrade using your ^orange;Tricorder^reset;.",
   "shortdescription" : "Mining Laser",
   "category" : "upgradeableTool",
   "itemTags" : [ "weapon","ranged", "tool", "mininggun", "mininglaser","theaUninfusable","upgradeableTool" ],


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.