### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/weapons/ranged/bomblauncher/translocatorexplosive/bomblauncher.activeitem
+++ b/items/active/weapons/ranged/bomblauncher/translocatorexplosive/bomblauncher.activeitem
@@ -7,7 +7,7 @@
   "category" : "translocator",
   "description" : "Fires explosive discs.
 ^yellow;40^reset; damage
-Upgrade at ^orange;Tool Upgrade Station^reset;.",
+Upgrade using your ^orange;Tricorder^reset;.",
   "shortdescription" : "Blastcap Launcher",
 
   "twoHanded" : true,


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.