### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/grapplinghooks/autohookshot/fuautohookshot.activeitem
+++ b/items/active/grapplinghooks/autohookshot/fuautohookshot.activeitem
@@ -6,7 +6,7 @@
   "maxStack" : 1,
   "level" : 1,
   "upmod" : 3,
-  "description" : "It pulls you up automatically! Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+  "description" : "It pulls you up automatically! Upgrade using your ^orange;Tricorder^reset;.",
   "shortdescription" : "Hookshot",
   "largeImage" : "autohookshotbig.png",
   "category" : "hookshot",


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.