### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/unsorted/tunableoredetector/tunableoredetector1.activeitem
+++ b/items/active/unsorted/tunableoredetector/tunableoredetector1.activeitem
@@ -3,7 +3,7 @@
   "price" : 2500,
   "maxStack" : 1,
   "rarity" : "uncommon",
-  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade using your ^orange;Tricorder^reset;.",
   "shortdescription" : "Precision Ore Detector",
   "twoHanded" : false,
   "category" : "detector",
@@ -132,7 +132,7 @@
   
   
   "upgradeParameters" : {
-	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Precision Ore Detector MKII ^cyan;^reset;",  
 	  
 	  "inventoryIcon" : "tunableoredetectoricon2.png",
@@ -155,7 +155,7 @@
   },
   
 "upgradeParameters2" : {
-	"description" : "Shift+click to configure. Scans one ore at a time. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	"description" : "Shift+click to configure. Scans one ore at a time. Upgrade using your ^orange;Tricorder^reset;.",
 	"shortdescription" : "Precision Ore Detector MKIII ^yellow;^reset;",  
 	  
 	"inventoryIcon" : "tunableoredetectoricon3.png",
@@ -178,7 +178,7 @@
   },
   
   "upgradeParameters3" : {
-	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Precision Ore Detector MKIV ^yellow;^reset;",  
 	  
 	  "inventoryIcon" : "tunableoredetectoricon3.png",
@@ -201,7 +201,7 @@
   },
   
   "upgradeParameters4" : {
-	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Precision Ore Detector MKV ^cyan;^reset;",  
 	  
 	  "inventoryIcon" : "tunableoredetectoricon3.png",
@@ -224,7 +224,7 @@
   },
   
   "upgradeParameters5" : {
-	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Precision Ore Detector MKVI ^red;^reset;",  
 	  
 	  "inventoryIcon" : "tunableoredetectoricon3.png",
@@ -247,7 +247,7 @@
   },
   
   "upgradeParameters6" : {
-	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Precision Ore Detector MKVII ^red;^reset;",  
 	  
 	  "inventoryIcon" : "tunableoredetectoricon3.png",
@@ -270,7 +270,7 @@
   },
   
   "upgradeParameters7" : {
-	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Shift+click to configure. Scans one ore at a time. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Precision Ore Detector MKVIII ^#e43774;^reset;",  
 	  
 	  "inventoryIcon" : "tunableoredetectoricon3.png",


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.