### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/unsorted/oredetector/t1/oredetector1.activeitem
+++ b/items/active/unsorted/oredetector/t1/oredetector1.activeitem
@@ -3,7 +3,7 @@
   "price" : 2500,
   "maxStack" : 1,
   "rarity" : "uncommon",
-  "description" : "Analyzes the composition of nearby minerals. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+  "description" : "Analyzes the composition of nearby minerals. Upgrade using your ^orange;Tricorder^reset;.",
   "shortdescription" : "Multi-ore Detector",
   "twoHanded" : false,
   "category" : "detector",
@@ -56,7 +56,7 @@
   
   
   "upgradeParameters" : {
-	  "description" : "Analyzes the composition of nearby minerals. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Analyzes the composition of nearby minerals. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Multi-ore Detector MKII ^cyan;^reset;",  
 	  
 	  "inventoryIcon" : "oredetector2icon.png",
@@ -108,7 +108,7 @@
 	  "pingCooldown" : 0.8
   },
   "upgradeParameters2" : {
-	  "description" : "Analyzes the composition of nearby minerals. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Analyzes the composition of nearby minerals. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Multi-ore Detector MKIII ^yellow;^reset;",  
 	  
 	  "inventoryIcon" : "oredetector3icon.png",
@@ -174,7 +174,7 @@
 	  "pingCooldown" : 0.5
   },
   "upgradeParameters3" : {
-	  "description" : "Analyzes the composition of nearby minerals. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Analyzes the composition of nearby minerals. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Multi-ore Detector MKIV ^yellow;^reset;",  
 	  
 	  "inventoryIcon" : "oredetector3icon.png",
@@ -240,7 +240,7 @@
 	  "pingCooldown" : 0.45
   },
   "upgradeParameters4" : {
-	  "description" : "Analyzes the composition of nearby minerals. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Analyzes the composition of nearby minerals. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Multi-ore Detector MKV ^cyan;^reset;",  
 	  
 	  "inventoryIcon" : "oredetector3icon.png",
@@ -306,7 +306,7 @@
 	  "pingCooldown" : 0.4
   },
   "upgradeParameters5" : {
-	  "description" : "Analyzes the composition of nearby minerals. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Analyzes the composition of nearby minerals. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Multi-ore Detector MKVI ^red;^reset;",  
 	  
 	  "inventoryIcon" : "oredetector3icon.png",
@@ -372,7 +372,7 @@
 	  "pingCooldown" : 0.35
   },
   "upgradeParameters6" : {
-	  "description" : "Analyzes the composition of nearby minerals. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Analyzes the composition of nearby minerals. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Multi-ore Detector MKVII ^red;^reset;",  
 	  
 	  "inventoryIcon" : "oredetector3icon.png",
@@ -438,7 +438,7 @@
 	  "pingCooldown" : 0.3
   },
   "upgradeParameters7" : {
-	  "description" : "Analyzes the composition of nearby minerals. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Analyzes the composition of nearby minerals. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Multi-ore Detector MKVIII ^#e43774;^reset;",  
 	  
 	  "inventoryIcon" : "oredetector3icon.png",


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.