### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/unsorted/parasol/parasol.activeitem.patch
+++ b/items/active/unsorted/parasol/parasol.activeitem.patch
@@ -17,7 +17,7 @@
     "op": "add",
     "path": "/upgradeParameters",
     "value": {  
-      "description": "Open to gently float while falling. Upgrade at the ^orange;Tool Upgrade Station^reset;.",
+      "description": "Open to gently float while falling. Upgrade using your ^orange;Tricorder^reset;.",
       "shortdescription": "Ultra Parasol ^#red;^reset;",
       "inventoryIcon": "parasol2.png:open",
       "animation": "parasol2.animation",
@@ -37,7 +37,7 @@
 	    "parasol" : "parasol3.png",
 	    "parasolfullbright" : "parasol3fullbright.png"
 	  },      
-      "description": "Open to gently float while falling. Upgrade at the ^orange;Tool Upgrade Station^reset;.",
+      "description": "Open to gently float while falling. Upgrade using your ^orange;Tricorder^reset;.",
       "shortdescription": "Omega Parasol ^#red;^reset;",
       "inventoryIcon": "parasol3.png:open",
       "animation": "parasol3.animation",
@@ -67,6 +67,6 @@
   {
     "op": "replace",
     "path": "/description",
-    "value": "Open to gently float while falling. Upgrade at the ^orange;Tool Upgrade Station^reset;."
+    "value": "Open to gently float while falling. Upgrade using your ^orange;Tricorder^reset;."
   }
 ]


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.