### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/unsorted/relocator/relocator.activeitem.patch
+++ b/items/active/unsorted/relocator/relocator.activeitem.patch
@@ -16,14 +16,14 @@
   {
     "op": "replace",
     "path": "/description",
-    "value": "Holds 3 creatures in stasis in order to relocate them. Upgrade at ^orange;Tool Upgrade Station^reset;."
+    "value": "Holds 3 creatures in stasis in order to relocate them. Upgrade using your ^orange;Tricorder^reset;."
   },  
   {
     "op": "add",
     "path": "/upgradeParameters",
     "value": {
       "shortdescription": "Relocator II ^cyan;^reset;",
-      "description" : "Holds 4 creatures in stasis in order to relocate them. Upgrade at ^orange;Tool Upgrade Station^reset;.",
+      "description" : "Holds 4 creatures in stasis in order to relocate them. Upgrade using your ^orange;Tricorder^reset;.",
       "animationParts": {
         "middle": "relocator2.png",
         "lit": "relocator2lit.png"
@@ -40,7 +40,7 @@
     "path": "/upgradeParameters2",
     "value": {
       "shortdescription": "Relocator III ^red;^reset;",
-      "description" : "Holds 5 creatures in stasis in order to relocate them. Upgrade at ^orange;Tool Upgrade Station^reset;.",
+      "description" : "Holds 5 creatures in stasis in order to relocate them. Upgrade using your ^orange;Tricorder^reset;.",
       
       "animationParts": {
         "middle": "relocator3.png",


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.