### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/unsorted/translocator/translocator.activeitem
+++ b/items/active/unsorted/translocator/translocator.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "category" : "translocator",
-  "description" : "Fires teleport-node discs. Quite useful. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+  "description" : "Fires teleport-node discs. Quite useful. Upgrade using your ^orange;Tricorder^reset;.",
   "shortdescription" : "Translocator",
 
   "twoHanded" : true,
@@ -31,7 +31,7 @@
   
   
   "upgradeParameters" : {
-	  "description" : "Fires teleport-node discs. Quite useful. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Fires teleport-node discs. Quite useful. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Translocator II ^cyan;^reset;",  
 	  "inventoryIcon" : "translocatorb.png",
 
@@ -42,7 +42,7 @@
 	  "teleportEnergy" : 55
   },
   "upgradeParameters2" : {
-	  "description" : "Fires teleport-node discs. Quite useful. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Fires teleport-node discs. Quite useful. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Translocator III ^yellow;^reset;",  
 	  "inventoryIcon" : "translocatorc.png",
 
@@ -53,7 +53,7 @@
 	  "teleportEnergy" : 50
   },  
   "upgradeParameters3" : {
-	  "description" : "Fires teleport-node discs. Quite useful. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Fires teleport-node discs. Quite useful. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Translocator IV ^red;^reset;",  
 	  "inventoryIcon" : "translocatord.png",
 


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.