### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/unsorted/oredetector/t1/cavedetector1.activeitem
+++ b/items/active/unsorted/oredetector/t1/cavedetector1.activeitem
@@ -3,7 +3,7 @@
   "price" : 1500,
   "maxStack" : 1,
   "rarity" : "uncommon",
-  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade using your ^orange;Tricorder^reset;.",
   "shortdescription" : "Cave Detector",
   "twoHanded" : false,
   "category" : "detector",
@@ -42,7 +42,7 @@
   "pingCooldown" : 2.0,
   
   "upgradeParameters" : {
-	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Cave Detector MKII ^cyan;^reset;",  
 	  
 	  "inventoryIcon" : "cavedetector2icon.png",
@@ -68,7 +68,7 @@
 	  "pingCooldown" : 1.8
   },
   "upgradeParameters2" : {
-	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Cave Detector MKIII ^cyan;^reset;",  
 	  
 	  "inventoryIcon" : "cavedetector3icon.png",
@@ -94,7 +94,7 @@
 	  "pingCooldown" : 1.5
   },
   "upgradeParameters3" : {
-	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Cave Detector MKIV ^cyan;^reset;",  
 	  
 	  "inventoryIcon" : "cavedetector3icon.png",
@@ -120,7 +120,7 @@
 	  "pingCooldown" : 1.4
   },
   "upgradeParameters4" : {
-	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Cave Detector MKV ^cyan;^reset;",  
 	  
 	  "inventoryIcon" : "cavedetector3icon.png",
@@ -146,7 +146,7 @@
 	  "pingCooldown" : 1.35
   },
   "upgradeParameters5" : {
-	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Cave Detector MKVI ^red;^reset;",  
 	  
 	  "inventoryIcon" : "cavedetector3icon.png",
@@ -172,7 +172,7 @@
 	  "pingCooldown" : 1.3
   },
   "upgradeParameters6" : {
-	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Cave Detector MKVII ^red;^reset;",  
 	  
 	  "inventoryIcon" : "cavedetector3icon.png",
@@ -198,7 +198,7 @@
 	  "pingCooldown" : 1.25
   },
   "upgradeParameters7" : {
-	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade at a ^orange;Tool Upgrade Station^reset;.",
+	  "description" : "Emits pulses to analyse the composition of nearby caverns. Upgrade using your ^orange;Tricorder^reset;.",
 	  "shortdescription" : "Cave Detector MKVIII ^#e43774;^reset;",  
 	  
 	  "inventoryIcon" : "cavedetector3icon.png",


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.