### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/items/active/unsorted/bugnet/bugnet.activeitem.patch
+++ b/items/active/unsorted/bugnet/bugnet.activeitem.patch
@@ -2,7 +2,7 @@
   [
     { "op": "test", "path": "/learnBlueprintsOnPickup", "inverse" : true },
     { "op": "add", "path": "/learnBlueprintsOnPickup", "value": [] },
-    { "op": "replace", "path": "/description", "value": "Catch insects like bees, or collect wild types. Upgrade at ^orange;Tool Upgrade Table^reset;." }
+    { "op": "replace", "path": "/description", "value": "Catch insects like bees, or collect wild types. Upgrade using your ^orange;Tricorder^reset;." }
   ],
   [
  // { "op" : "add", "path" : "/learnBlueprintsOnPickup/-", "value" : "beestation" },
@@ -14,7 +14,7 @@
     "path": "/upgradeParameters",
     "value": {
       "shortdescription": "Superior Bug Net",
-      "description" : "Catch insects like bees, or collect wild types. Upgrade at ^orange;Tool Upgrade Table^reset;.",
+      "description" : "Catch insects like bees, or collect wild types. Upgrade using your ^orange;Tricorder^reset;.",
       "animation" : "/items/active/unsorted/bugnet/bugnet2.animation",
       "animationParts": {
         "bugnet": "bugnet2.png",
@@ -46,7 +46,7 @@
     "path": "/upgradeParameters2",
     "value": {
       "shortdescription": "UltiNet",
-      "description" : "Catch insects like bees, or collect wild types. Upgrade at ^orange;Tool Upgrade Table^reset;.",
+      "description" : "Catch insects like bees, or collect wild types. Upgrade using your ^orange;Tricorder^reset;.",
       "animation" : "/items/active/unsorted/bugnet/bugnet2.animation",
       "animationParts": {
         "bugnet": "bugnet3.png",
@@ -78,7 +78,7 @@
     "path": "/upgradeParameters3",
     "value": {
       "shortdescription": "UltiNet",
-      "description" : "Catch insects like bees, or collect wild types. Upgrade at ^orange;Tool Upgrade Table^reset;.",
+      "description" : "Catch insects like bees, or collect wild types. Upgrade using your ^orange;Tricorder^reset;.",
       "animation" : "/items/active/unsorted/bugnet/bugnet2.animation",
       "animationParts": {
         "bugnet": "bugnet3.png",
@@ -110,7 +110,7 @@
     "path": "/upgradeParameters4",
     "value": {
       "shortdescription": "UltiNet",
-      "description" : "Catch insects like bees, or collect wild types. Upgrade at ^orange;Tool Upgrade Table^reset;.",
+      "description" : "Catch insects like bees, or collect wild types. Upgrade using your ^orange;Tricorder^reset;.",
       "animation" : "/items/active/unsorted/bugnet/bugnet2.animation",
       "animationParts": {
         "bugnet": "bugnet3.png",
@@ -142,7 +142,7 @@
     "path": "/upgradeParameters5",
     "value": {
       "shortdescription": "UltiNet",
-      "description" : "Catch insects like bees, or collect wild types. Upgrade at ^orange;Tool Upgrade Table^reset;.",
+      "description" : "Catch insects like bees, or collect wild types. Upgrade using your ^orange;Tricorder^reset;.",
       "animation" : "/items/active/unsorted/bugnet/bugnet2.animation",
       "animationParts": {
         "bugnet": "bugnet3.png",
@@ -174,7 +174,7 @@
     "path": "/upgradeParameters6",
     "value": {
       "shortdescription": "UltiNet",
-      "description" : "Catch insects like bees, or collect wild types. Upgrade at ^orange;Tool Upgrade Table^reset;.",
+      "description" : "Catch insects like bees, or collect wild types. Upgrade using your ^orange;Tricorder^reset;.",
       "animation" : "/items/active/unsorted/bugnet/bugnet2.animation",
       "animationParts": {
         "bugnet": "bugnet3.png",
@@ -206,7 +206,7 @@
     "path": "/upgradeParameters7",
     "value": {
       "shortdescription": "UltiNet",
-      "description" : "Catch insects like bees, or collect wild types. Upgrade at ^orange;Tool Upgrade Table^reset;.",
+      "description" : "Catch insects like bees, or collect wild types. Upgrade using your ^orange;Tricorder^reset;.",
       "animation" : "/items/active/unsorted/bugnet/bugnet2.animation",
       "animationParts": {
         "bugnet": "bugnet3.png",


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.