### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/objects/crafting/miningbench/miningbench.object
+++ b/objects/crafting/miningbench/miningbench.object
@@ -3,7 +3,7 @@
   "colonyTags" : ["tech", "fu", "science"],
   "printable" : false,
   "rarity" : "uncommon",
-  "description" : "Can be used to upgrade weapons, armor, and various tools (^green;Mining Laser, Mech Repair Gun, Bug Net^reset;).",
+  "description" : "Can be used to access your tricorder's upgrade interface. Largely cosmetic.",
   "shortdescription" : "^cyan;Upgrade Table^white;",
   "race" : "ancient",
   "category" : "other",


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.