### PR TITLE
Updated description to reflect upgrade table changes

### DIFF
--- a/objects/crafting/fu_upgradetable/fu_upgradetable.object
+++ b/objects/crafting/fu_upgradetable/fu_upgradetable.object
@@ -3,7 +3,7 @@
   "colonyTags" : ["crafting","science"],
   "rarity" : "Rare",
   "printable" : false,
-  "description" : "Can be used to upgrade weapons, armor, and various tools (^green;Mining Laser, Mech Repair Gun, Bug Net^reset;).",
+  "description" : "Can be used to access your tricorder's upgrade interface. Largely cosmetic.",
   "shortdescription" : "^cyan;Upgrade Table^white;",
   "race" : "generic",
   "category" : "crafting",


### PR DESCRIPTION
Tools are now primarily upgraded through the tricorder, with the upgrade tables as a cosmetic alternative. The item tooltip now reflects this.