### PR TITLE
Increased metals_icecrystal requirements to reflect recipe

### DIFF
--- a/zb/researchTree/fu_geology.config
+++ b/zb/researchTree/fu_geology.config
@@ -312,7 +312,7 @@
 				"icon" : "/items/generic/crafting/icecrystal.png",
 				"children" : [  ],
 				"position" : [-170, 0],
-				"price" : [["fuscienceresource",  2700],["crystal", 1]],
+				"price" : [["fuscienceresource",  2700],["crystal", 10],["liquidcrystal",20]],
 				"unlocks" : ["icecrystal"]
 			},									
 			"metals_plasmiccrystal" : {


### PR DESCRIPTION
Liquified crystal is required to craft the ice crystals and requires research into the chemistry branch, but was not required to research the node. Increased crystal requirement additionally to reflect the higher-tier nature of ice crystals.