### PR TITLE
Added the Mech Platform to the mech research branch

### DIFF
--- a/recipes/prototyper/labs/tools/mechplatform.recipe
+++ b/recipes/prototyper/labs/tools/mechplatform.recipe
@@ -1,0 +1,14 @@
+{
+  "input" : [
+	{ "item" : "titaniumbar", "count" : 5 },
+	{ "item" : "electromagnet", "count" : 2 },
+	{ "item" : "powercore", "count" : 1 },
+	{ "item" : "upgrademodule", "count" : 1 }
+  ],
+  "output" : {
+    "item" : "mechplatform",
+    "count" : 1
+  },
+  "groups" : [ "prototyper1", "genetics", "all" ],
+  "duration" : 1
+}

--- a/zb/researchTree/fu_engineering.config
+++ b/zb/researchTree/fu_engineering.config
@@ -343,7 +343,7 @@
 				"position" : [95, -80],
 				"children" : [ "mechsbody1", "mechsmobility1", "mechsweapons1", "mechsmodules1" ],
 				"price" : [["fuscienceresource", 300], ["tungstenbar", 5], ["liquidoil", 20]],
-				"unlocks" : [ "mechcraftingtable", "mechassemblystation",  "mechdefensefield", "mechenergyfield", "mechmobility", "mechrepairpod", "furepairgun", "mechlegssimpleupgrade", "mechlegssimpleupgrade2", "mechboostersimpleupgrade", "mechboostersimpleupgrade2" ]
+				"unlocks" : [ "mechcraftingtable", "mechassemblystation",  "mechdefensefield", "mechenergyfield", "mechmobility", "mechplatform", "mechrepairpod", "furepairgun", "mechlegssimpleupgrade", "mechlegssimpleupgrade2", "mechboostersimpleupgrade", "mechboostersimpleupgrade2" ]
 			},
 			"mechsbody1" : {
 				"icon" : "/items/generic/mechparts/body/mechbodybrute.png",


### PR DESCRIPTION
The mech platform was added by CF in the same way that most objects were - through the pixel printer, scanned in the world. Unlocking it through the research system will incentivise players to use their mechs more, and thus continue with the mech research branch, as well as making mechs easier to use and less distinct from the rest of the game.