### PR TITLE
Changed aegisalt requirement to durasteel

### DIFF
--- a/recipes/mech/arm/mecharmdrill3.recipe
+++ b/recipes/mech/arm/mecharmdrill3.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "diamond", "count" : 6 },
     { "item" : "hydroliumcircuitry", "count" : 4 },
-    { "item" : "refinedaegisalt", "count" : 20 } 
+    { "item" : "durasteelbar", "count" : 20 } 
   ],
   "duration" : 3,
   "output" : { "item" : "mecharmdrill3", "count" : 1 },


### PR DESCRIPTION
The diamond drill is unlocked by the durasteel-tier Advanced Mech Weapons node, while aegisalt isn't required until the Superior Mech Weapons node.