### PR TITLE
Added bar option to recipe

### DIFF
--- a/recipes/skathforge1/bars/hydrolium2.recipe
+++ b/recipes/skathforge1/bars/hydrolium2.recipe
@@ -1,0 +1,13 @@
+{
+  "input" : [
+    { "item" : "zerchesiumbar", "count" : 1 },
+    { "item" : "lead", "count" : 2 },
+	  { "item" : "liquidhealing", "count" : 10 }
+  ],
+  "output" : {
+    "item" : "hydrolium",
+    "count" : 2
+  },
+  "duration" : 0.15,
+  "groups" : [ "skathforge1", "bars", "all", "craftingfurnace2" ]
+}


### PR DESCRIPTION
Doubling the other ingredients and the output allows the player to use zerchesium bars instead of ore, lessening the need to hoard ore in case a recipe calls for the relatively rare hydrolium.