### PR TITLE
Move hardcoded config from Liquid Condenser's Lua into .object file

### DIFF
--- a/objects/power/fu_liquidcondenser/fu_liquidcondenser.object
+++ b/objects/power/fu_liquidcondenser/fu_liquidcondenser.object
@@ -36,5 +36,38 @@
 		"spaceScan": 0.1,
 		"anchors": ["bottom"],
 		"collision": "platform"
-	}]
+	}],
+
+	// Outputs per biome
+	"liquids" : {
+		"aethersea": { "liquid": 100, "cooldown": 2 },
+		"moon": { "liquid": 49, "cooldown": 2 },
+		"moon_desert": { "liquid": 49, "cooldown": 2 },
+		"moon_shadow": { "liquid": 49, "cooldown": 2 },
+		"moon_stone": { "liquid": 49, "cooldown": 2 },
+		"moon_volcanic": { "liquid": 49, "cooldown": 2 },
+		"moon_toxic": { "liquid": 49, "cooldown": 2 },
+		"atropus": { "liquid": 53, "cooldown": 2 },
+		"atropusdark": { "liquid": 53, "cooldown": 2 },
+		"fugasgiant": { "liquid": 62, "cooldown": 2 },
+		"bog": { "liquid": 12, "cooldown": 2 },
+		"chromatic": { "liquid": 69, "cooldown": 2 },
+		"crystalmoon": { "liquid": 43, "cooldown": 2 },
+		"nitrogensea": { "liquid": 56, "cooldown": 2 },
+		"infernus": { "liquid": 2, "cooldown": 2 },
+		"infernusdark": { "liquid": 2, "cooldown": 2 },
+		"slimeworld": { "liquid": 13, "cooldown": 2 },
+		"strangesea": { "liquid": 41, "cooldown": 2 },
+		"sulphuric": { "liquid": 46, "cooldown": 2 },
+		"tarball": { "liquid": 42, "cooldown": 2 },
+		"toxic": { "liquid": 3, "cooldown": 2 },
+		"metallicmoon": { "liquid": 52, "cooldown": 3 },
+		"lightless": { "liquid": 100, "cooldown": 3 },
+		"penumbra": { "liquid": 60, "cooldown": 4 },
+		"protoworld": { "liquid": 44, "cooldown": 5 },
+		"irradiated": { "liquid": 47, "cooldown": 2 },
+
+		// Default for any biome that is not supported:
+		"other": { "liquid": 1, "cooldown": 2 }
+	}
 }

--- a/objects/power/fu_liquidcondenser/isn_resource_generator.lua
+++ b/objects/power/fu_liquidcondenser/isn_resource_generator.lua
@@ -3,35 +3,7 @@ require'/scripts/util.lua'
 require "/scripts/poly.lua"
 require "/scripts/vec2.lua"
 
-liquids = {
-	aethersea = {liquid=100,cooldown=2},
-	moon = {liquid=49,cooldown=2},
-	moon_desert = {liquid=49,cooldown=2},
-	moon_shadow = {liquid=49,cooldown=2},
-	moon_stone = {liquid=49,cooldown=2},
-	moon_volcanic = {liquid=49,cooldown=2},
-	moon_toxic = {liquid=49,cooldown=2},
-	atropus = {liquid=53,cooldown=2},
-	atropusdark = {liquid=53,cooldown=2},
-	fugasgiant = {liquid=62,cooldown=2},
-	bog = {liquid=12,cooldown=2},
-	chromatic = {liquid=69,cooldown=2},
-	crystalmoon = {liquid=43,cooldown=2},
-	nitrogensea = {liquid=56,cooldown=2},
-	infernus = {liquid=2,cooldown=2},
-	infernusdark = {liquid=2,cooldown=2},
-	slimeworld = {liquid=13,cooldown=2},
-	strangesea = {liquid=41,cooldown=2},
-	sulphuric = {liquid=46,cooldown=2},
-	tarball = {liquid=42,cooldown=2},
-	toxic = {liquid=3,cooldown=2},
-	metallicmoon = {liquid=52,cooldown=3},
-	lightless = {liquid=100,cooldown=3},
-	penumbra = {liquid=60,cooldown=4},
-	protoworld = {liquid=44,cooldown=5},
-	irradiated = {liquid=47,cooldown=2},
-	other = {liquid=1,cooldown=2}
-}
+local liquids
 
 function init()
 	--object.setInteractive(true)--useless, they dont do anything on interaction.
@@ -41,6 +13,7 @@ function init()
 	storage.outputPos=entity.position()
 	storage.outputPos[1]=storage.outputPos[1]+2+util.clamp(object.direction(),-1,0)
 	wellRange=config.getParameter("airWellRange",20)
+	liquids=config.getParameter("liquids")
 	wellInit()
 	setDesc()
 end


### PR DESCRIPTION
I'm moving the hardcoded configuration of Liquid Condenser ("which biome gives what liquid") away from Lua code (which can't be analyzed by third-party tools, including the tool that generates documentation for the wiki) into JSON asset file (which can be loaded from anywhere).

This change was tested (in-game) on several planets (Crystalline, Garden, Proto) to ensure that it changes nothing (neither production nor the Scan tooltip).
