### PR TITLE
NPC Weapon Theming

### DIFF
--- a/npcs/dungeon/apexbase/labguard.npctype
+++ b/npcs/dungeon/apexbase/labguard.npctype
@@ -27,10 +27,78 @@
             "legs" : [ { "name" : "apextier3pants" } ],
             "back" : [ { "name" : "medicback" } ],
             "primary" : [
-              "npcsniperrifle"
+              "lasrifle"
             ],
             "sheathedprimary" : [
-              "npcdagger"
+              "curvedagger"
+            ]
+          }
+        ] ],
+      [3, [
+          {
+            "head" : [ { "name" : "apextier3head" } ],
+            "chest" : [ { "name" : "apextier3chest" } ],
+            "legs" : [ { "name" : "apextier3pants" } ],
+            "back" : [ { "name" : "medicback" } ],
+            "primary" : [
+              "lasrifle",
+			  "spaceplasmarifleminiknog",
+			  "protorifle"
+            ],
+            "sheathedprimary" : [
+              "curvedagger"
+            ]
+          }
+        ] ],
+      [4, [
+          {
+            "head" : [ { "name" : "apextier3head" } ],
+            "chest" : [ { "name" : "apextier3chest" } ],
+            "legs" : [ { "name" : "apextier3pants" } ],
+            "back" : [ { "name" : "medicback" } ],
+            "primary" : [
+			  "spaceplasmarifleminiknog",
+			  "protorifle",
+			  "isn_terawattlaser"
+            ],
+            "sheathedprimary" : [
+              "curvedagger"
+            ]
+          }
+        ] ],
+      [5, [
+          {
+            "head" : [ { "name" : "apextier3head" } ],
+            "chest" : [ { "name" : "apextier3chest" } ],
+            "legs" : [ { "name" : "apextier3pants" } ],
+            "back" : [ { "name" : "medicback" } ],
+            "primary" : [
+			  "spaceplasmarifleminiknog",
+			  "isn_terawattlaser",
+              "arconrifle",
+			  "longinus"
+            ],
+            "sheathedprimary" : [
+              "curvedagger"
+            ]
+          }
+        ] ],
+      [6, [
+          {
+            "head" : [ { "name" : "apextier3head" } ],
+            "chest" : [ { "name" : "apextier3chest" } ],
+            "legs" : [ { "name" : "apextier3pants" } ],
+            "back" : [ { "name" : "medicback" } ],
+            "primary" : [
+			  "isn_terawattlaser",
+              "arconrifle",
+			  "longinus",
+			  "densiniumrifle",
+			  "densiniumshotgun",
+			  "densiniumsniper"
+            ],
+            "sheathedprimary" : [
+              "curvedagger"
             ]
           }
         ] ]

--- a/npcs/dungeon/apexbase/labguardlookout.npctype
+++ b/npcs/dungeon/apexbase/labguardlookout.npctype
@@ -27,10 +27,78 @@
             "legs" : [ { "name" : "apextier3pants" } ],
             "back" : [ { "name" : "medicback" } ],
             "primary" : [
-              "npcsniperrifle"
+              "lasrifle"
             ],
             "sheathedprimary" : [
-              "npcdagger"
+              "curvedagger"
+            ]
+          }
+        ] ],
+      [3, [
+          {
+            "head" : [ { "name" : "apextier3head" } ],
+            "chest" : [ { "name" : "apextier3chest" } ],
+            "legs" : [ { "name" : "apextier3pants" } ],
+            "back" : [ { "name" : "medicback" } ],
+            "primary" : [
+              "lasrifle",
+			  "spaceplasmarifleminiknog",
+			  "protorifle"
+            ],
+            "sheathedprimary" : [
+              "curvedagger"
+            ]
+          }
+        ] ],
+      [4, [
+          {
+            "head" : [ { "name" : "apextier3head" } ],
+            "chest" : [ { "name" : "apextier3chest" } ],
+            "legs" : [ { "name" : "apextier3pants" } ],
+            "back" : [ { "name" : "medicback" } ],
+            "primary" : [
+			  "spaceplasmarifleminiknog",
+			  "protorifle",
+			  "isn_terawattlaser"
+            ],
+            "sheathedprimary" : [
+              "curvedagger"
+            ]
+          }
+        ] ],
+      [5, [
+          {
+            "head" : [ { "name" : "apextier3head" } ],
+            "chest" : [ { "name" : "apextier3chest" } ],
+            "legs" : [ { "name" : "apextier3pants" } ],
+            "back" : [ { "name" : "medicback" } ],
+            "primary" : [
+			  "spaceplasmarifleminiknog",
+			  "isn_terawattlaser",
+              "arconrifle",
+			  "longinus"
+            ],
+            "sheathedprimary" : [
+              "curvedagger"
+            ]
+          }
+        ] ],
+      [6, [
+          {
+            "head" : [ { "name" : "apextier3head" } ],
+            "chest" : [ { "name" : "apextier3chest" } ],
+            "legs" : [ { "name" : "apextier3pants" } ],
+            "back" : [ { "name" : "medicback" } ],
+            "primary" : [
+			  "isn_terawattlaser",
+              "arconrifle",
+			  "longinus",
+			  "densiniumrifle",
+			  "densiniumshotgun",
+			  "densiniumsniper"
+            ],
+            "sheathedprimary" : [
+              "curvedagger"
             ]
           }
         ] ]

--- a/npcs/dungeon/apexbase/labscientist.npctype.patch
+++ b/npcs/dungeon/apexbase/labscientist.npctype.patch
@@ -1,24 +1,191 @@
 [
-{"op" : "add", "path" : "/scriptConfig", "value" : {
-    "dialog" : {
-      "attack" : {
-        "default" : {
-          "default" : [ "Intruder!" ]
-        },
-        "apex" : {
-          "default" : [
-            "Guards! We have an intruder!",
-            "Looks like we've got ourselves a new test subject!",
-            "Intruder!",
-            "Guards!",
-            "You'll make a fine specimen!",
-            "For science!",
-            "I hope you're not too attached to your brain!",
-            "Stay away!"
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/sheathedprimary/0",
+    "value": "curvedagger"
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "scientisthead"
+            },
+            "",
+            "",
+            ""
+          ],
+          "chest": [
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 1
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 4
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 5
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 6
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 7
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 8
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 9
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 10
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 11
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "scientistlegs",
+              "parameters": {
+                "colorIndex": 1
+              }
+            }
+          ],
+          "primary": [
+            "zenith"
+          ],
+          "sheathedprimary": [
+            "curvedagger"
           ]
         }
-      }
-    }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      6,
+      [
+        {
+          "head": [
+            {
+              "name": "scientisthead"
+            },
+            "",
+            "",
+            ""
+          ],
+          "chest": [
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 1
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 4
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 5
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 6
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 7
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 8
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 9
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 10
+              }
+            },
+            {
+              "name": "scientistchest",
+              "parameters": {
+                "colorIndex": 11
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "scientistlegs",
+              "parameters": {
+                "colorIndex": 1
+              }
+            }
+          ],
+          "primary": [
+            "zenith",
+            "densiniumpistol"
+          ],
+          "sheathedprimary": [
+            "curvedagger"
+          ]
+        }
+      ]
+    ]
   }
-}
 ]

--- a/npcs/dungeon/apexbase/miniknoggeneral.npctype.patch
+++ b/npcs/dungeon/apexbase/miniknoggeneral.npctype.patch
@@ -1,0 +1,185 @@
+[
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/sheathedprimary/0",
+    "value": "lasrifle"
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      3,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead"
+            },
+            {
+              "name": "miniknoghead"
+            }
+          ],
+          "chest": [
+            {
+              "name": "miniknogchest",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "miniknogpants",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "primary": [
+            "npcpetcapturepod"
+          ],
+          "sheathedprimary": [
+            "lasrifle",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead"
+            },
+            {
+              "name": "miniknoghead"
+            }
+          ],
+          "chest": [
+            {
+              "name": "miniknogchest",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "miniknogpants",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "primary": [
+            "npcpetcapturepod"
+          ],
+          "sheathedprimary": [
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "isn_terawattlaser"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead"
+            },
+            {
+              "name": "miniknoghead"
+            }
+          ],
+          "chest": [
+            {
+              "name": "miniknogchest",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "miniknogpants",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "primary": [
+            "npcpetcapturepod"
+          ],
+          "sheathedprimary": [
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "isn_terawattlaser",
+            "arconrifle"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      6,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead"
+            },
+            {
+              "name": "miniknoghead"
+            }
+          ],
+          "chest": [
+            {
+              "name": "miniknogchest",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "miniknogpants",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "primary": [
+            "npcpetcapturepod"
+          ],
+          "sheathedprimary": [
+            "isn_terawattlaser",
+            "arconrifle",
+            "arconcannon",
+            "densiniumrifle",
+            "densiniumshotgun"
+          ]
+        }
+      ]
+    ]
+  }
+]

--- a/npcs/dungeon/apexcity/miniknogvillageguard.npctype.patch
+++ b/npcs/dungeon/apexcity/miniknogvillageguard.npctype.patch
@@ -1,0 +1,181 @@
+[
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      3,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead"
+            },
+            {
+              "name": "miniknoghead"
+            },
+            ""
+          ],
+          "chest": [
+            {
+              "name": "miniknogchest",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "miniknogpants",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "primary": [
+            "lasrifle",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead"
+            },
+            {
+              "name": "miniknoghead"
+            },
+            ""
+          ],
+          "chest": [
+            {
+              "name": "miniknogchest",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "miniknogpants",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "primary": [
+            "isn_terawattlaser",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead"
+            },
+            {
+              "name": "miniknoghead"
+            },
+            ""
+          ],
+          "chest": [
+            {
+              "name": "miniknogchest",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "miniknogpants",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "primary": [
+            "isn_terawattlaser",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "arconrifle"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      6,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead"
+            },
+            {
+              "name": "miniknoghead"
+            },
+            ""
+          ],
+          "chest": [
+            {
+              "name": "miniknogchest",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "miniknogpants",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "primary": [
+            "isn_terawattlaser",
+            "arconrifle",
+            "densiniumrifle",
+            "densiniumshotgun"
+          ]
+        }
+      ]
+    ]
+  }
+]

--- a/npcs/guard.npctype.patch
+++ b/npcs/guard.npctype.patch
@@ -1,134 +1,238 @@
 [
-	{ "op" : "add", "path" : "/items/skath",
-	  "value" : [
-			[0, [
-				{
-					"chest" : [
-						{ "name" : "skathtier1chest", "data" : { "colorIndex" : 8 } }
-					],
-					"legs" : [
-						{ "name" : "skathtier1pants", "data" : { "colorIndex" : 8 } }
-					],
-					"head" : [
-						{ "name" : "skathtier1head", "data" : { "colorIndex" : 8 } }
-					],
-					"primary" : [
-						"skathtier1shotgun",
-						"skathtier1minigun",
-						"skathtier1broadsword",
-						"skathtier1hammer",
-						"skathtier1spear"
-					]
-					}
-				]
-			],
-			[1, [
-				{
-					"chest" : [
-						{ "name" : "skathtier1chest", "data" : { "colorIndex" : 8 } }
-					],
-					"legs" : [
-						{ "name" : "skathtier1pants", "data" : { "colorIndex" : 8 } }
-					],
-					"head" : [
-						{ "name" : "skathtier1head", "data" : { "colorIndex" : 8 } }
-					],
-					"primary" : [
-						"skathtier1shotgun",
-						"skathtier1minigun",
-						"skathtier1broadsword",
-						"skathtier1hammer",
-						"skathtier1spear"
-					]
-					}
-				]
-			],
-			[2, [
-				{
-					"chest" : [
-						{ "name" : "skathtier1chest", "data" : { "colorIndex" : 8 } }
-					],
-					"legs" : [
-						{ "name" : "skathtier1pants", "data" : { "colorIndex" : 8 } }
-					],
-					"head" : [
-						{ "name" : "skathtier1head", "data" : { "colorIndex" : 8 } }
-					],
-					"primary" : [
-						"skathtier2shotgun",
-						"skathtier2minigun",
-						"skathtier2broadsword",
-						"skathtier2hammer",
-						"skathtier2spear"
-					]
-					}
-				]
-			],
-			[3, [
-				{
-					"chest" : [
-						{ "name" : "skathtier1chest", "data" : { "colorIndex" : 8 } }
-					],
-					"legs" : [
-						{ "name" : "skathtier1pants", "data" : { "colorIndex" : 8 } }
-					],
-					"head" : [
-						{ "name" : "skathtier1head", "data" : { "colorIndex" : 8 } }
-					],
-					"primary" : [
-						"skathtier2shotgun",
-						"skathtier2minigun",
-						"skathtier2broadsword",
-						"skathtier2hammer",
-						"skathtier2spear"
-					]
-					}
-				]
-			],
-			[4, [
-				{
-					"chest" : [
-						{ "name" : "skathtier1chest", "data" : { "colorIndex" : 8 } }
-					],
-					"legs" : [
-						{ "name" : "skathtier1pants", "data" : { "colorIndex" : 8 } }
-					],
-					"head" : [
-						{ "name" : "skathtier1head", "data" : { "colorIndex" : 8 } }
-					],
-					"primary" : [
-						"skathtier3shotgun",
-						"skathtier3minigun",
-						"skathtier3broadsword",
-						"skathtier3hammer",
-						"skathtier3spear"
-					]
-					}
-				]
-			],
-			[5, [
-				{
-					"chest" : [
-						{ "name" : "skathtier1chest", "data" : { "colorIndex" : 8 } }
-					],
-					"legs" : [
-						{ "name" : "skathtier1pants", "data" : { "colorIndex" : 8 } }
-					],
-					"head" : [
-						{ "name" : "skathtier1head", "data" : { "colorIndex" : 8 } }
-					],
-					"primary" : [
-						"skathtier3shotgun",
-						"skathtier3minigun",
-						"skathtier3broadsword",
-						"skathtier3hammer",
-						"skathtier3spear"
-					]
-					}
-				]
-			]
-	  ]
-	},
+  {
+    "op": "add",
+    "path": "/items/skath",
+    "value": [
+      [
+        0,
+        [
+          {
+            "chest": [
+              {
+                "name": "skathtier1chest",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "legs": [
+              {
+                "name": "skathtier1pants",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "head": [
+              {
+                "name": "skathtier1head",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "primary": [
+              "skathtier1shotgun",
+              "skathtier1minigun",
+              "skathtier1broadsword",
+              "skathtier1hammer",
+              "skathtier1spear"
+            ]
+          }
+        ]
+      ],
+      [
+        1,
+        [
+          {
+            "chest": [
+              {
+                "name": "skathtier1chest",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "legs": [
+              {
+                "name": "skathtier1pants",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "head": [
+              {
+                "name": "skathtier1head",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "primary": [
+              "skathtier1shotgun",
+              "skathtier1minigun",
+              "skathtier1broadsword",
+              "skathtier1hammer",
+              "skathtier1spear"
+            ]
+          }
+        ]
+      ],
+      [
+        2,
+        [
+          {
+            "chest": [
+              {
+                "name": "skathtier1chest",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "legs": [
+              {
+                "name": "skathtier1pants",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "head": [
+              {
+                "name": "skathtier1head",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "primary": [
+              "skathtier2shotgun",
+              "skathtier2minigun",
+              "skathtier2broadsword",
+              "skathtier2hammer",
+              "skathtier2spear"
+            ]
+          }
+        ]
+      ],
+      [
+        3,
+        [
+          {
+            "chest": [
+              {
+                "name": "skathtier1chest",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "legs": [
+              {
+                "name": "skathtier1pants",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "head": [
+              {
+                "name": "skathtier1head",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "primary": [
+              "skathtier2shotgun",
+              "skathtier2minigun",
+              "skathtier2broadsword",
+              "skathtier2hammer",
+              "skathtier2spear"
+            ]
+          }
+        ]
+      ],
+      [
+        4,
+        [
+          {
+            "chest": [
+              {
+                "name": "skathtier1chest",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "legs": [
+              {
+                "name": "skathtier1pants",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "head": [
+              {
+                "name": "skathtier1head",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "primary": [
+              "skathtier3shotgun",
+              "skathtier3minigun",
+              "skathtier3broadsword",
+              "skathtier3hammer",
+              "skathtier3spear"
+            ]
+          }
+        ]
+      ],
+      [
+        5,
+        [
+          {
+            "chest": [
+              {
+                "name": "skathtier1chest",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "legs": [
+              {
+                "name": "skathtier1pants",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "head": [
+              {
+                "name": "skathtier1head",
+                "data": {
+                  "colorIndex": 8
+                }
+              }
+            ],
+            "primary": [
+              "skathtier3shotgun",
+              "skathtier3minigun",
+              "skathtier3broadsword",
+              "skathtier3hammer",
+              "skathtier3spear"
+            ]
+          }
+        ]
+      ]
+    ]
+  },
   {
     "op": "add",
     "path": "/items/shadow",
@@ -376,7 +480,7 @@
         ]
       ]
     ]
-  },  
+  },
   {
     "op": "add",
     "path": "/items/fuizku",
@@ -500,7 +604,7 @@
         ]
       ]
     ]
-  },  
+  },
   {
     "op": "add",
     "path": "/items/radien",
@@ -624,7 +728,7 @@
         ]
       ]
     ]
-  },  
+  },
   {
     "op": "add",
     "path": "/items/fukirhos",
@@ -748,7 +852,7 @@
         ]
       ]
     ]
-  },  
+  },
   {
     "op": "add",
     "path": "/items/fumantis",
@@ -872,7 +976,7 @@
         ]
       ]
     ]
-  },  
+  },
   {
     "op": "add",
     "path": "/items/thelusian",
@@ -996,7 +1100,7 @@
         ]
       ]
     ]
-  },  
+  },
   {
     "op": "add",
     "path": "/items/fumantizi",
@@ -1120,5 +1224,390 @@
         ]
       ]
     ]
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/primary/0",
+    "value": "ironkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/sheathedprimary/0",
+    "value": "ironstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/0",
+    "value": "tungstenkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/0/primary/-",
+    "value": "coralkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/0/primary/-",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/0/primary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/0/primary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/sheathedprimary/0",
+    "value": "tungstenstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/0/sheathedprimary/-",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "titaniumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/0",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/-",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/-",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/-",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/3/1/0/primary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/primary/-",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/primary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/primary/-",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/primary/-",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/primary/-",
+    "value": "durasteelkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/primary/-",
+    "value": "advalloykatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/primary/-",
+    "value": "irradiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/primary/-",
+    "value": "triangliumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/3/1/0/sheathedprimary/0",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/sheathedprimary/-",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/sheathedprimary/-",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/3/1/0/sheathedprimary/-",
+    "value": "advalloystynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier4head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier4chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier4pants"
+            }
+          ],
+          "primary": [
+            "carbonkatana",
+            "zerchesiumkatana",
+            "advalloykatana",
+            "irradiumkatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana"
+          ],
+          "sheathedprimary": [
+            "zerchesiumstynger",
+            "carbonstynger",
+            "advalloystynger",
+            "lightningstynger"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/-",
+    "value": [
+      6,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier4head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier4chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier4pants"
+            }
+          ],
+          "primary": [
+            "carbonkatana",
+            "advalloykatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana",
+            "pyreitekatana",
+            "densiniumkatana",
+            "solariumkatana"
+          ],
+          "sheathedprimary": [
+            "advalloystynger",
+            "lightningstynger"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/0/1/0/alt",
+    "value": [
+      {
+        "name": "commonsmallshield"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/0/1/0/primary/0",
+    "value": "npcspear"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/0/1/0/primary/1",
+    "value": "npcaxe"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/0/1/0/primary/2",
+    "value": "npchammer"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/0/1/0/primary/-",
+    "value": "npcshortsword"
+  },
+  {
+    "op": "replace",
+    "path": "/items/glitch/0/1/0/sheathedprimary/0",
+    "value": {
+      "name": "npcbow"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/1/1/0/alt",
+    "value": [
+      {
+        "name": "commonsmallshield"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/1/1/0/primary/0",
+    "value": "npcspear"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/1/1/0/primary/1",
+    "value": "npcaxe"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/1/1/0/primary/2",
+    "value": "npchammer"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/1/1/0/primary/-",
+    "value": "npcshortsword"
+  },
+  {
+    "op": "replace",
+    "path": "/items/glitch/1/1/0/sheathedprimary/0",
+    "value": {
+      "name": "npcbow"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/2/1/0/alt",
+    "value": [
+      {
+        "name": "commonsmallshield"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/2/1/0/primary/0",
+    "value": "npcspear"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/2/1/0/primary/1",
+    "value": "npcaxe"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/2/1/0/primary/2",
+    "value": "npchammer"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/2/1/0/primary/-",
+    "value": "npcshortsword"
+  },
+  {
+    "op": "replace",
+    "path": "/items/glitch/2/1/0/sheathedprimary/0",
+    "value": {
+      "name": "npcbow"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/3/1/0/alt",
+    "value": [
+      {
+        "name": "commonsmallshield"
+      }
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/3/1/0/primary/0",
+    "value": "npcspear"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/3/1/0/primary/1",
+    "value": "npcaxe"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/3/1/0/primary/2",
+    "value": "npchammer"
+  },
+  {
+    "op": "add",
+    "path": "/items/glitch/3/1/0/primary/-",
+    "value": "npcshortsword"
+  },
+  {
+    "op": "replace",
+    "path": "/items/glitch/3/1/0/sheathedprimary/0",
+    "value": {
+      "name": "npcbow"
+    }
   }
 ]

--- a/npcs/mission/cultistassault.npctype
+++ b/npcs/mission/cultistassault.npctype
@@ -19,8 +19,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcassaultrifle", "npcassaultrifle", "npcshotgun", "ironassaultrifle", "ironassaultrifle", "ironshotgun" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana", "fubonescythe", "ironscythe", "stonescythe" ]
+            "primary" : [ "npcassaultrifle", "npcassaultrifle", "npcshotgun" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistshortsword" ]
           }
         ] ],
       [2, [
@@ -28,8 +28,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcassaultrifle", "npcassaultrifle", "npcassaultrifle", "npcshotgun", "npcshotgun", "ironassaultrifle", "ironshotgun", "lasrifle", "lunaririfle", "lunarishotgun", "npclongarm", "lunaririfle", "telebriumrifle", "telebriumshotgun" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana", "fubonescythe", "stonescythe", "ironscythe", "lunariscythe", "thelusscythe", "telebriumscythe", "lunarikatana", "telebriumkatana", "tungstenkatana" ]
+            "primary" : [ "npcassaultrifle", "npcassaultrifle", "npcshotgun", "thornslinger", "wormgun" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger" ]
           }
         ] ],
       [3, [
@@ -37,8 +37,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcassaultrifle", "npcassaultrifle", "npcassaultrifle", "npcshotgun", "npcshotgun", "ironassaultrifle", "ironshotgun", "lasrifle", "lunaririfle", "lunarishotgun", "npclongarm", "lunaririfle", "telebriumrifle", "telebriumshotgun", "funomadrifle", "k3rifle", "penumbriteassaultrifle", "verdantcarbine", "carbonshotgun", "crystalgun", "penumbriteshotgun" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana", "fubonescythe", "stonescythe", "titaniumscythe", "ironscythe", "lunariscythe", "thelusscythe", "telebriumscythe", "goldscythe", "penumbralscythe", "predatorscythe", "lunarikatana", "telebriumkatana", "tungstenkatana", "penumbritekatana", "carbonkatana", "coralkatana" ]
+            "primary" : [ "npcassaultrifle", "npcshotgun", "thornslinger", "blistergun", "wormgun", "vashtagun", "bonethresher" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe" ]
           }
         ] ],
       [4, [
@@ -46,8 +46,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcassaultrifle", "npcassaultrifle", "npcassaultrifle", "npcassaultrifle", "npcshotgun", "npcshotgun", "npcshotgun", "lasrifle", "lunaririfle", "lunarishotgun", "lunaririfle", "telebriumrifle", "telebriumshotgun", "funomadrifle", "k3rifle", "penumbriteassaultrifle", "verdantcarbine", "carbonshotgun", "crystalgun", "penumbriteshotgun", "curvesmg", "energyassault", "funomadassaultrifle", "ionrifle", "silverslayer", "protogun", "fugaussrifle", "zerchesiumassaultrifle", "swarmgun", "advalloyshotgun", "blastgun", "bonethresher", "fugaussshotgun", "longarm", "zerchesiumshotgun" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "titaniumscythe", "lunariscythe", "thelusscythe", "telebriumscythe", "goldscythe", "penumbralscythe", "predatorscythe", "lunarikatana", "telebriumkatana", "tungstenkatana", "penumbritekatana", "carbonkatana", "coralkatana", "fucultistscythe",  "irradiumscythe", "quietusscythe", "zerchesiumscythe", "advalloykatana",  "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana" ]
+            "primary" : [ "thornslinger", "blistergun", "wormgun", "vashtagun", "bonethresher", "biogun", "goregun", "quietusassaultrifle", "quietusshotgun" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear" ]
           }
         ] ],
       [5, [
@@ -55,17 +55,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcassaultrifle", "npcassaultrifle", "npcassaultrifle", "npcshotgun", "npcshotgun", "funomadrifle", "k3rifle", "penumbriteassaultrifle", "verdantcarbine", "carbonshotgun", "crystalgun", "penumbriteshotgun", "energyassault", "funomadassaultrifle", "invisiswarmgun", "ionrifle", "silverslayer", "protogun", "zerchesiumassaultrifle", "fuaegisaltminigunnpc", "fugaussmachinegun", "fuplasmagun", "goregun", "isn_flamethrower4", "mobiusrifle", "nitrogengun", "quietusassaultrifle", "reaperassault", "reapercarbine", "fuenergymachinegun", "isn_microwaveray", "isn_terawattlaser", "veilbreaker" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "titaniumscythe", "goldscythe", "penumbralscythe", "predatorscythe", "penumbritekatana", "carbonkatana", "coralkatana", "fucultistscythe",  "irradiumscythe", "quietusscythe", "zerchesiumscythe", "advalloykatana",  "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana", "fuatropusscythe", "diamondkatana", "blooddiamondkatana" ]
-          }
-        ] ],
-      [6, [
-          {
-            "head" : [ { "name" : "cultisthead" } ],
-            "chest" : [ { "name" : "cultistchest" } ],
-            "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcassaultrifle", "npcassaultrifle", "npcassaultrifle", "npcshotgun", "npcshotgun", "zerchesiumassaultrifle", "fuaegisaltminigunnpc", "fugaussmachinegun", "fuplasmagun", "goregun", "isn_flamethrower4", "mobiusrifle", "nitrogengun", "quietusassaultrifle", "reaperassault", "reapercarbine", "fuenergymachinegun", "isn_microwaveray", "isn_terawattlaser", "veilbreaker", "densiniumrifle", "fustingergun2", "swarmgun2", "xithriciteassaultrifle", "densiniumshotgun", "xithriciteshotgun" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "fucultistscythe",  "irradiumscythe", "quietusscythe", "zerchesiumscythe", "advalloykatana",  "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana", "densiniumscythe", "fuatropusscythe", "xithricitescythe", "isogenkatana", "pyreitekatana", "xithricitekatana"]
+            "primary" : [ "blistergun", "wormgun", "vashtagun", "bonethresher", "biogun", "goregun", "quietusassaultrifle", "quietusshotgun" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear", "quietusscythe", "fuatropusaxe", "fuatropusbroadsword", "fuatropusdagger", "fuatropusgreataxe", "fuatropushammer", "fuatropusscythe", "fuatropusshortsword", "fuatropusspear",  "fucultistscythe" ]
           }
         ] ]
     ]

--- a/npcs/mission/cultistbasic.npctype
+++ b/npcs/mission/cultistbasic.npctype
@@ -19,8 +19,17 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcpistol", "npcpistol", "npcpistol", "npcmachinepistol", "ironmachinepistol", "ironrevolver" ],
-            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana" ]
+            "primary" : [ "npcpistol", "npcpistol", "npcmachinepistol", "fucultistbow", "fucultistbow" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistshortsword" ]
+          }
+        ] ],
+      [2, [
+          {
+            "head" : [ { "name" : "cultisthead" } ],
+            "chest" : [ { "name" : "cultistchest" } ],
+            "legs" : [ { "name" : "cultistlegs" } ],
+            "primary" : [ "npcpistol", "npcpistol", "npcmachinepistol", "blisterpistol", "fucultistbow", "fucultistbow" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger" ]
           }
         ] ],
       [3, [
@@ -28,8 +37,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcpistol", "npcpistol", "npcpistol", "npcmachinepistol", "ironmachinepistol", "ironrevolver", "laspistol", "lunaripistol" , "lunarismg", "telebriummachinepistol", "telebriumpistol", "pistoltungstenfu" ],
-            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana", "lunarikatana", "telebriumkatana", "tungstenkatana" ]
+            "primary" : [ "npcpistol", "npcmachinepistol", "blisterpistol", "quietuspistol" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe" ]
           }
         ] ],
       [4, [
@@ -37,8 +46,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcpistol", "npcpistol", "npcpistol", "npcmachinepistol", "laspistol", "lunaripistol" , "lunarismg", "telebriummachinepistol", "telebriumpistol", "pistoltungstenfu", "blisterpistol", "crystalpistolfire", "crystalpistolice", "penumbritepistol", "pistoltitaniumfu", "protopistol", "quietuspistol", "zerchesiumpistol"  ],
-            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "lunarikatana", "telebriumkatana", "tungstenkatana", "carbonkatana", "coralkatana", "penumbritekatana", "fucultistkatana"]
+            "primary" : [ "blisterpistol", "quietuspistol", "pistolquietusfu" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear" ]
           }
         ] ],
       [5, [
@@ -46,17 +55,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcpistol", "npcpistol", "npcpistol", "npcmachinepistol", "blisterpistol", "crystalpistolfire", "crystalpistolice", "penumbritepistol", "pistoltitaniumfu", "protopistol", "biopistol", "curvepistol", "fugausspistol", "futriangliumpistol", "gravitonpistol", "irradiumpistol", "mobiuspistol", "nitrogenpistol", "pistoldurasteelfu", "reapermachinepistol", "reaperpistol", "zerchesiumpistol", "futriangliumsmg", "manstoppersmg", "zerchesiumsmg" ],
-            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "carbonkatana", "coralkatana", "advalloykatana",  "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana" ]
-          }
-        ] ],
-      [6, [
-          {
-            "head" : [ { "name" : "cultisthead" } ],
-            "chest" : [ { "name" : "cultistchest" } ],
-            "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcpistol", "npcpistol", "npcpistol", "npcmachinepistol", "biopistol", "curvepistol", "fugausspistol", "futriangliumpistol", "gravitonpistol", "irradiumpistol", "mobiuspistol", "nitrogenpistol", "pistoldurasteelfu", "reapermachinepistol", "reaperpistol", "zerchesiumpistol", "zerchesiumsmg", "futritaniumpistol", "isn_plasmapistol", "pistolaegisaltfu", "pistoleffigiumfu", "pistolferoziumfu", "pistolvioliumfu", "futriangliumsmg", "manstoppersmg", "zerchesiumsmg" ],
-            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "advalloykatana",  "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana", "diamondkatana", "blooddiamondkatana" ]
+            "primary" : [ "blisterpistol", "quietuspistol", "pistolquietusfu" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear", "quietusscythe", "fuatropusaxe", "fuatropusbroadsword", "fuatropusdagger", "fuatropusgreataxe", "fuatropushammer", "fuatropusscythe", "fuatropusshortsword", "fuatropusspear",  "fucultistscythe" ]
           }
         ] ]
     ]

--- a/npcs/mission/cultistrocket.npctype
+++ b/npcs/mission/cultistrocket.npctype
@@ -20,7 +20,7 @@
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
             "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "commongrenadelauncher", "burster" ],
-            "alt" : [ "npccultistbroadsword" ]
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistshortsword" ]
           }
         ] ],
       [2, [
@@ -28,8 +28,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "commongrenadelauncher", "bushmaster", "burster", "lunarirocketlauncher",  "telebriumrocketlauncher" ],
-            "alt" : [ "npccultistbroadsword" ]
+            "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "commongrenadelauncher", "bushmaster", "burster",  "telebriumrocketlauncher" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger" ]
           }
         ] ],
       [3, [
@@ -37,8 +37,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "uncommongrenadelauncher", "bushmaster", "burster", "lunarirocketlauncher",  "telebriumrocketlauncher", "blistergun", "slimelauncher", "blizzardcannon", "penumbriterocketlauncher" ],
-            "alt" : [ "npccultistbroadsword" ]
+            "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "uncommongrenadelauncher", "bushmaster", "burster", "telebriumrocketlauncher", "eyecannon" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe" ]
           }
         ] ],
       [4, [
@@ -46,8 +46,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "uncommongrenadelauncher", "bushmaster", "burster", "lunarirocketlauncher",  "telebriumrocketlauncher", "blistergun", "slimelauncher", "blizzardcannon", "penumbriterocketlauncher", "stormwarden", "friendmaker", "fuplasmacannon", "minirocketlauncher", "mobiusrailgun", "quietusrocketlauncher", "reaperrocket" ],
-            "alt" : [ "npccultistbroadsword" ]
+            "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "uncommongrenadelauncher", "bushmaster", "burster", "telebriumrocketlauncher", "eyecannon", "quietusrocketlauncher" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear" ]
           }
         ] ],
       [5, [
@@ -55,17 +55,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "raregrenadelauncher", "blistergun", "slimelauncher", "blizzardcannon", "penumbriterocketlauncher", "stormwarden", "friendmaker", "fuplasmacannon", "minirocketlauncher", "mobiusrailgun", "quietusrocketlauncher", "reaperrocket" ],
-            "alt" : [ "npccultistbroadsword" ]
-          }
-        ] ],	
-      [6, [
-          {
-            "head" : [ { "name" : "cultisthead" } ],
-            "chest" : [ { "name" : "cultistchest" } ],
-            "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "raregrenadelauncher", "stormwarden", "friendmaker", "fuplasmacannon", "minirocketlauncher", "mobiusrailgun", "quietusrocketlauncher", "reaperrocket", "minirocketlauncher2", "xithriciterocketlauncher" ],
-            "alt" : [ "npccultistbroadsword" ]
+            "primary" : [ "npcrocketlauncher", "npcrocketlauncher", "uncommongrenadelauncher", "bushmaster", "burster", "telebriumrocketlauncher", "eyecannon", "quietusrocketlauncher" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear", "quietusscythe", "fuatropusaxe", "fuatropusbroadsword", "fuatropusdagger", "fuatropusgreataxe", "fuatropushammer", "fuatropusscythe", "fuatropusshortsword", "fuatropusspear",  "fucultistscythe" ]
           }
         ] ]
     ]

--- a/npcs/mission/cultistscientistpet.npctype
+++ b/npcs/mission/cultistscientistpet.npctype
@@ -20,8 +20,18 @@
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
             "primary" : [ "npcpetcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod" ],
-            "sheathedprimary" : [ "npcmachinepistol", "npcmachinepistol", "ironmachinepistol" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana" ]
+            "sheathedprimary" : [ "npcmachinepistol", "blisterpistol" ],
+            "alt" : [  "npccultistbroadsword", "npccultistshortsword" ]
+          }
+        ] ],
+      [2, [
+          {
+            "head" : [ { "name" : "scientisthead" } ],
+            "chest" : [ { "name" : "cultistchest" } ],
+            "legs" : [ { "name" : "cultistlegs" } ],
+            "primary" : [ "npcpetcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod" ],
+            "sheathedprimary" : [ "npcmachinepistol", "blisterpistol", "quietuspistol" ],
+            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger" ]
           }
         ] ],
       [3, [
@@ -30,8 +40,8 @@
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
             "primary" : [ "npcpetcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod" ],
-            "sheathedprimary" : [ "npcmachinepistol", "npcmachinepistol", "ironmachinepistol", "laspistol", "lunarismg", "telebriummachinepistol" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana", "lunarikatana", "telebriumkatana", "tungstenkatana" ]
+            "sheathedprimary" : [ "npcmachinepistol", "blisterpistol", "quietussmg", "murdermanipulator" ],
+            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe" ]
           }
         ] ],
       [4, [
@@ -40,8 +50,8 @@
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
             "primary" : [ "npcpetcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod" ],
-            "sheathedprimary" : [ "npcmachinepistol", "npcmachinepistol", "npcmachinepistol", "laspistol", "lunarismg", "telebriummachinepistol", "zerchesiumsmg"  ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "lunarikatana", "telebriumkatana", "tungstenkatana", "carbonkatana", "coralkatana", "penumbritekatana", "fucultistkatana"]
+            "sheathedprimary" : [ "blisterpistol", "quietussmg", "murdermanipulator", "pistolquietusfu" ],
+            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear" ]
           }
         ] ],
       [5, [
@@ -50,18 +60,8 @@
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
             "primary" : [ "npcpetcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod" ],
-            "sheathedprimary" : [  "npcmachinepistol", "npcmachinepistol", "futriangliumsmg", "manstoppersmg", "zerchesiumsmg" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "carbonkatana", "coralkatana", "advalloykatana",  "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana" ]
-          }
-        ] ],
-      [6, [
-          {
-            "head" : [ { "name" : "scientisthead" } ],
-            "chest" : [ { "name" : "cultistchest" } ],
-            "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcpetcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod", "npccultistscandroidcapturepod" ],
-            "sheathedprimary" : [ "npcmachinepistol", "npcmachinepistol", "futriangliumsmg", "manstoppersmg", "zerchesiumsmg", "xithricitesmg" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "advalloykatana",  "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana", "diamondkatana", "blooddiamondkatana" ]
+            "sheathedprimary" : [ "blisterpistol", "quietussmg", "murdermanipulator", "pistolquietusfu" ],
+            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear", "quietusscythe", "fuatropusaxe", "fuatropusbroadsword", "fuatropusdagger", "fuatropusgreataxe", "fuatropushammer", "fuatropusscythe", "fuatropusshortsword", "fuatropusspear",  "fucultistscythe" ]
           }
         ] ]
     ]

--- a/npcs/mission/cultistsniper.npctype
+++ b/npcs/mission/cultistsniper.npctype
@@ -19,8 +19,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcsniperrifle", "fuhuntingrifle", "rifleironfu" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana" ]
+            "primary" : [ "npcsniperrifle" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistshortsword" ]
           }
         ] ],
       [2, [
@@ -28,8 +28,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcsniperrifle", "npcsniperrifle", "fuhuntingrifle", "rifleironfu", "lunarisniper", "telebriumsniperrifle" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana", "lunarikatana", "telebriumkatana", "tungstenkatana" ]
+            "primary" : [ "npcsniperrifle" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger" ]
           }
         ] ],
       [3, [
@@ -37,8 +37,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcsniperrifle", "npcsniperrifle", "fuhuntingrifle", "rifleironfu", "lunarisniper", "telebriumsniperrifle", "penumbritesniperrifle", "protorifle", "rifletitaniumfu", "teslagun", "thornrifle" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "ironbroadsword", "ironkatana", "lunarikatana", "telebriumkatana", "tungstenkatana", "penumbritekatana", "carbonkatana", "coralkatana" ]
+            "primary" : [ "thornrifle" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe" ]
           }
         ] ],
       [4, [
@@ -46,8 +46,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcsniperrifle", "npcsniperrifle", "penumbritesniperrifle", "protorifle", "rifletitaniumfu", "teslagun", "thornrifle", "fucellgun", "fugausssniper", "fuhuntingrifle2", "irradiumrifle", "quietussniper", "rifledurasteelfu", "rifleirradiumfu", "riflequietusfu", "rifletriangliumfu", "verdantrailgun", "zerchesiumsniper" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "advalloykatana",  "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana" ]
+            "primary" : [ "thornrifle", "riflequietusfu", "quietussniper" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear" ]
           }
         ] ],
       [5, [
@@ -55,17 +55,8 @@
             "head" : [ { "name" : "cultisthead" } ],
             "chest" : [ { "name" : "cultistchest" } ],
             "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcsniperrifle", "npcsniperrifle", "swtjc_ewg_rareantimaterialrifle", "fucellgun", "fugausssniper", "fuhuntingrifle2", "irradiumrifle", "quietussniper", "rifledurasteelfu", "rifleirradiumfu", "riflequietusfu",  "rifletriangliumfu", "verdantrailgun", "zerchesiumsniper", "farsight", "furailgun", "longinus", "rifleaegisaltfu", "rifleeffigiumfu" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "advalloykatana",  "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana", "fuatropusscythe", "diamondkatana", "blooddiamondkatana" ]
-          }
-        ] ],
-      [6, [
-          {
-            "head" : [ { "name" : "cultisthead" } ],
-            "chest" : [ { "name" : "cultistchest" } ],
-            "legs" : [ { "name" : "cultistlegs" } ],
-            "primary" : [ "npcsniperrifle", "swtjc_ewg_rareantimaterialrifle", "swtjc_ewg_rareantimaterialrifle", "farsight", "furailgun", "longinus", "rifleaegisaltfu", "rifleeffigiumfu", "densiniumsniper", "fuhuntingrifle3", "hellraiser", "tentabane", "xithricitesniper" ],
-            "alt" : [  "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "npccultistbroadsword", "advalloykatana", "fucultistkatana", "fucultistkatana", "durasteelkatana", "quietuskatana", "triangliumkatana", "zerchesiumkatana", "isogenkatana", "pyreitekatana", "xithricitekatana"]
+            "primary" : [ "thornrifle", "riflequietusfu", "quietussniper" ],
+            "sheathedprimary" : [  "npccultistbroadsword", "npccultistbroadsword", "fucultistaxe", "fucultistdagger", "fucultistspear", "fucultistgreataxe", "fucultistmace", "spikesword", "quietusrapier", "quietusmace", "quietusaxe", "quietusspear", "quietusscythe", "fuatropusaxe", "fuatropusbroadsword", "fuatropusdagger", "fuatropusgreataxe", "fuatropushammer", "fuatropusscythe", "fuatropusshortsword", "fuatropusspear",  "fucultistscythe" ]
           }
         ] ]
     ]

--- a/npcs/threats/miniknogagent.npctype.patch
+++ b/npcs/threats/miniknogagent.npctype.patch
@@ -1,0 +1,131 @@
+[
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/primary/1",
+    "value": "curvedagger"
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier2head",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier2chest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier2pants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "zenith",
+            "violiumshortsword"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier2head",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier2chest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier2pants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "zenith",
+            "densiniumpistol",
+            "violiumshortsword"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier2head",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier2chest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier2pants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "zenith",
+            "densiniumpistol",
+            "violiumshortsword"
+          ]
+        }
+      ]
+    ]
+  }
+]

--- a/npcs/threats/miniknogassassin.npctype.patch
+++ b/npcs/threats/miniknogassassin.npctype.patch
@@ -1,0 +1,231 @@
+[
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "remove",
+    "path": "/items/override/0/1/0/primary/1"
+  },
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/1/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "remove",
+    "path": "/items/override/0/1/1/primary/1"
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier5mhead",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier5mchest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier5mpants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "zenith",
+            "longinus"
+          ]
+        },
+        {
+          "head": [
+            {
+              "name": "apextier5shead",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier5schest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier5spants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "zenith",
+            "longinus"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier5mhead",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier5mchest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier5mpants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "zenith",
+            "densiniumpistol",
+            "longinus",
+            "densiniumsniper"
+          ]
+        },
+        {
+          "head": [
+            {
+              "name": "apextier5shead",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier5schest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier5spants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "zenith",
+            "densiniumpistol",
+            "longinus",
+            "densiniumsniper"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      6,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier5mhead",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier5mchest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier5mpants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "densiniumpistol",
+            "densiniumsniper"
+          ]
+        },
+        {
+          "head": [
+            {
+              "name": "apextier5shead",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier5schest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier5spants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "densiniumpistol",
+            "densiniumsniper"
+          ]
+        }
+      ]
+    ]
+  }
+]

--- a/npcs/threats/miniknogscout.npctype.patch
+++ b/npcs/threats/miniknogscout.npctype.patch
@@ -1,0 +1,181 @@
+[
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      3,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier1chest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier1pants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "laspistol",
+            "lasrifle",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier1chest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier1pants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "isn_terawattlaser"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier1chest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier1pants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "isn_terawattlaser",
+            "zenith",
+            "arconrifle"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      6,
+      [
+        {
+          "head": [
+            {
+              "name": "visorhead",
+              "parameters": {
+                "colorIndex": 0
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier1chest",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier1pants",
+              "parameters": {
+                "colorIndex": 3
+              }
+            }
+          ],
+          "primary": [
+            "isn_terawattlaser",
+            "arconrifle",
+            "densiniumrifle",
+            "densiniumrifle",
+            "densiniumshotgun",
+            "arconcannon"
+          ]
+        }
+      ]
+    ]
+  }
+]

--- a/npcs/threats/roguesamurai.npctype.patch
+++ b/npcs/threats/roguesamurai.npctype.patch
@@ -1,0 +1,288 @@
+[
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/primary/0",
+    "value": "ironkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/override/0/1/0/sheathedprimary/0",
+    "value": "ironstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      2,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier2head",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier2chest",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier2pants",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "primary": [
+            "tungstenkatana",
+            "coralkatana",
+            "telebriumkatana",
+            "lunarikatana",
+            "lunarikatana"
+          ],
+          "sheathedprimary": [
+            "tungstenstynger",
+            "telebriumstynger"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      3,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier2head",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier2chest",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier2pants",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "primary": [
+            "coralkatana",
+            "telebriumkatana",
+            "lunarikatana",
+            "carbonkatana",
+            "zerchesiumkatana",
+            "titaniumkatana"
+          ],
+          "sheathedprimary": [
+            "telebriumstynger",
+            "lunaristynger",
+            "zerchesiumstynger",
+            "carbonstynger"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier2head",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier2chest",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier2pants",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "primary": [
+            "coralkatana",
+            "telebriumkatana",
+            "lunarikatana",
+            "carbonkatana",
+            "zerchesiumkatana",
+            "durasteelkatana",
+            "advalloykatana",
+            "irradiumkatana",
+            "triangliumkatana"
+          ],
+          "sheathedprimary": [
+            "lunaristynger",
+            "zerchesiumstynger",
+            "carbonstynger",
+            "advalloystynger"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier2head",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier2chest",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier2pants",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "primary": [
+            "carbonkatana",
+            "zerchesiumkatana",
+            "advalloykatana",
+            "irradiumkatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana"
+          ],
+          "sheathedprimary": [
+            "zerchesiumstynger",
+            "carbonstynger",
+            "advalloystynger",
+            "lightningstynger"
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/override/-",
+    "value": [
+      6,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier2head",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier2chest",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier2pants",
+              "parameters": {
+                "colorIndex": [
+                  1
+                ]
+              }
+            }
+          ],
+          "primary": [
+            "carbonkatana",
+            "advalloykatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana",
+            "pyreitekatana",
+            "densiniumkatana",
+            "solariumkatana"
+          ],
+          "sheathedprimary": [
+            "advalloystynger",
+            "lightningstynger"
+          ]
+        }
+      ]
+    ]
+  }
+]

--- a/npcs/villageguard.npctype.patch
+++ b/npcs/villageguard.npctype.patch
@@ -1,0 +1,828 @@
+[
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/0/1/0/primary/2"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/0/1/0/primary/2"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/0/1/0/primary/2"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/sheathedprimary/0",
+    "value": "curvedagger"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/0/1/0/sheathedprimary/1"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/1/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/1/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/0/1/1/primary/2"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/1/sheathedprimary/0",
+    "value": "curvedagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/1/1/0/primary/2"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/1/1/0/primary/2"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/1/1/0/primary/2"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/sheathedprimary/0",
+    "value": "curvedagger"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/1/1/0/sheathedprimary/1"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/1/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/1/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/1/1/1/primary/2"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/1/sheathedprimary/0",
+    "value": "curvedagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/2",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/3",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/4",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/sheathedprimary/0",
+    "value": "curvedagger"
+  },
+  {
+    "op": "remove",
+    "path": "/items/apex/2/1/0/sheathedprimary/1"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/1/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/1/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/1/primary/2",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/2/1/1/primary/-",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/2/1/1/primary/-",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/1/sheathedprimary/0",
+    "value": "curvedagger"
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier3pants"
+            }
+          ],
+          "primary": [
+            "laspistol",
+            "lasrifle",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog"
+          ],
+          "sheathedprimary": [
+            "curvedagger"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        },
+        {
+          "head": [
+            {
+              "name": "apextier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier3pants"
+            }
+          ],
+          "primary": [
+            "isn_terawattlaser",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog"
+          ],
+          "sheathedprimary": [
+            "violiumbroadsword",
+            "violiumshortsword"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier3pants"
+            }
+          ],
+          "primary": [
+            "laspistol",
+            "lasrifle",
+            "arconrifle",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog"
+          ],
+          "sheathedprimary": [
+            "violiumbroadsword",
+            "violiumshortsword"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/-",
+    "value": [
+      6,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier3pants"
+            }
+          ],
+          "primary": [
+            "isn_terawattlaser",
+            "arconrifle",
+            "densiniumrifle",
+            "densiniumrifle",
+            "densiniumshotgun",
+            "arconcannon"
+          ],
+          "sheathedprimary": [
+            "violiumbroadsword",
+            "violiumshortsword"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/primary/0",
+    "value": "ironkatana"
+  },
+  {
+    "op": "remove",
+    "path": "/items/hylotl/0/1/0/primary/1"
+  },
+  {
+    "op": "remove",
+    "path": "/items/hylotl/0/1/0/primary/1"
+  },
+  {
+    "op": "remove",
+    "path": "/items/hylotl/0/1/0/primary/1"
+  },
+  {
+    "op": "remove",
+    "path": "/items/hylotl/0/1/0/primary/1"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/sheathedprimary/0",
+    "value": "ironstynger"
+  },
+  {
+    "op": "remove",
+    "path": "/items/hylotl/0/1/0/sheathedprimary/1"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/1/primary/0",
+    "value": "ironstynger"
+  },
+  {
+    "op": "remove",
+    "path": "/items/hylotl/0/1/1/primary/1"
+  },
+  {
+    "op": "remove",
+    "path": "/items/hylotl/0/1/1/primary/1"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/1/sheathedprimary/0",
+    "value": "ironkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/0",
+    "value": "tungstenkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/1",
+    "value": "coralkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/2",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/3",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/4",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/sheathedprimary/0",
+    "value": "tungstenstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/sheathedprimary/1",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/1/primary/0",
+    "value": "tungstenstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/1/primary/1",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "remove",
+    "path": "/items/hylotl/1/1/1/primary/2"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/0",
+    "value": "tungstenkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/-",
+    "value": "coralkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/-",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/1",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/2",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/3",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/4",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "titaniumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/0",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/1",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/-",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/-",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/1/primary/0",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/1/primary/1",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/1/primary/2",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/primary/-",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "titaniumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants"
+            }
+          ],
+          "primary": [
+            "coralkatana",
+            "telebriumkatana",
+            "lunarikatana",
+            "carbonkatana",
+            "zerchesiumkatana",
+            "durasteelkatana",
+            "advalloykatana",
+            "irradiumkatana",
+            "triangliumkatana"
+          ],
+          "sheathedprimary": [
+            "lunaristynger",
+            "zerchesiumstynger",
+            "carbonstynger",
+            "advalloystynger"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        },
+        {
+          "head": [
+            {
+              "name": "hylotltier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants"
+            }
+          ],
+          "primary": [
+            "lunaristynger",
+            "zerchesiumstynger",
+            "carbonstynger",
+            "advalloystynger"
+          ],
+          "sheathedprimary": [
+            "coralkatana",
+            "telebriumkatana",
+            "lunarikatana",
+            "carbonkatana",
+            "zerchesiumkatana",
+            "durasteelkatana",
+            "advalloykatana",
+            "irradiumkatana",
+            "triangliumkatana"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants"
+            }
+          ],
+          "primary": [
+            "carbonkatana",
+            "zerchesiumkatana",
+            "advalloykatana",
+            "irradiumkatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana"
+          ],
+          "sheathedprimary": [
+            "lunaristynger",
+            "zerchesiumstynger",
+            "carbonstynger",
+            "advalloystynger"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        },
+        {
+          "head": [
+            {
+              "name": "hylotltier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants"
+            }
+          ],
+          "primary": [
+            "zerchesiumstynger",
+            "carbonstynger",
+            "advalloystynger",
+            "lightningstynger"
+          ],
+          "sheathedprimary": [
+            "carbonkatana",
+            "zerchesiumkatana",
+            "advalloykatana",
+            "irradiumkatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants"
+            }
+          ],
+          "primary": [
+            "carbonkatana",
+            "advalloykatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana",
+            "pyreitekatana",
+            "densiniumkatana",
+            "solariumkatana"
+          ],
+          "sheathedprimary": [
+            "advalloystynger",
+            "lightningstynger"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        },
+        {
+          "head": [
+            {
+              "name": "hylotltier3head"
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest"
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants"
+            }
+          ],
+          "primary": [
+            "advalloystynger",
+            "lightningstynger"
+          ],
+          "sheathedprimary": [
+            "carbonkatana",
+            "advalloykatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana",
+            "pyreitekatana",
+            "densiniumkatana",
+            "solariumkatana"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  }
+]

--- a/npcs/villageguardcaptain.npctype.patch
+++ b/npcs/villageguardcaptain.npctype.patch
@@ -1,0 +1,872 @@
+[
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/primary/2",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/primary/3",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/primary/4",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/sheathedprimary/0",
+    "value": "curvebroadsword"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/0/1/0/sheathedprimary/1",
+    "value": "curvedagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/primary/2",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/primary/3",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/primary/4",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/sheathedprimary/0",
+    "value": "curvebroadsword"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/0/sheathedprimary/1",
+    "value": "curvedagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/1/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/1/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/1/primary/2",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/1/1/1/primary/-",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/1/1/1/primary/-",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/1/1/1/sheathedprimary/0",
+    "value": "curvebroadsword"
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/1/1/1/sheathedprimary/-",
+    "value": "curvedagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/0",
+    "value": "laspistol"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/1",
+    "value": "lasrifle"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/2",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/3",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/primary/4",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/sheathedprimary/0",
+    "value": "curvebroadsword"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/0/sheathedprimary/1",
+    "value": "curvedagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/1/primary/0",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/1/primary/1",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/1/primary/2",
+    "value": "spaceplasmarifleminiknog"
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/2/1/1/primary/-",
+    "value": "isn_terawattlaser"
+  },
+  {
+    "op": "replace",
+    "path": "/items/apex/2/1/1/sheathedprimary/0",
+    "value": "violiumbroadsword"
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/2/1/1/sheathedprimary/-",
+    "value": "violiumshortsword"
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier3head",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier3chest",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier3pants",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "back": [
+            {
+              "name": "simplecapeback",
+              "parameters": {
+                "colorIndex": 1
+              }
+            }
+          ],
+          "primary": [
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "spaceplasmarifleminiknog",
+            "isn_terawattlaser",
+            "zenith",
+            "arconrifle"
+          ],
+          "sheathedprimary": [
+            "violiumbroadsword",
+            "violiumshortsword"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/apex/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "apextier3head",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "apextier3chest",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "apextier3pants",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "back": [
+            {
+              "name": "simplecapeback",
+              "parameters": {
+                "colorIndex": 1
+              }
+            }
+          ],
+          "primary": [
+            "isn_terawattlaser",
+            "arconrifle",
+            "densiniumrifle",
+            "densiniumrifle",
+            "densiniumshotgun",
+            "arconcannon"
+          ],
+          "sheathedprimary": [
+            "violiumbroadsword",
+            "violiumshortsword"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/primary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/primary/1",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/primary/2",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/primary/3",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/primary/4",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/0/1/0/primary/-",
+    "value": "titaniumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/sheathedprimary/0",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/0/sheathedprimary/1",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/0/1/0/sheathedprimary/-",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/0/1/0/sheathedprimary/-",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/1/primary/0",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/1/primary/1",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/1/primary/2",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/0/1/1/primary/-",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/0/1/1/sheathedprimary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/0/1/1/sheathedprimary/-",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/0/1/1/sheathedprimary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/0/1/1/sheathedprimary/-",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/0/1/1/sheathedprimary/-",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/0/1/1/sheathedprimary/-",
+    "value": "titaniumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/1",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/2",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/3",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/primary/4",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/0/primary/-",
+    "value": "titaniumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/sheathedprimary/0",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/0/sheathedprimary/1",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/0/sheathedprimary/-",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/0/sheathedprimary/-",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/1/primary/0",
+    "value": "telebriumstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/1/primary/1",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/1/primary/2",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/primary/-",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/-",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/-",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/-",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/1/1/1/sheathedprimary/-",
+    "value": "titaniumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/1",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/2",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/3",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/primary/4",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "durasteelkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "advalloykatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "irradiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/primary/-",
+    "value": "triangliumkatana"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/0",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/1",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/-",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/0/sheathedprimary/-",
+    "value": "advalloystynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/1/primary/0",
+    "value": "lunaristynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/1/primary/1",
+    "value": "zerchesiumstynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/1/primary/2",
+    "value": "carbonstynger"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/primary/-",
+    "value": "advalloystynger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/0",
+    "value": "coralkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "telebriumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "lunarikatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "carbonkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "zerchesiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "durasteelkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "advalloykatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "irradiumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/2/1/1/sheathedprimary/-",
+    "value": "triangliumkatana"
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/-",
+    "value": [
+      4,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier3head",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "back": [
+            {
+              "name": "simplecapeback",
+              "parameters": {
+                "colorIndex": 1
+              }
+            }
+          ],
+          "primary": [
+            "carbonkatana",
+            "zerchesiumkatana",
+            "advalloykatana",
+            "irradiumkatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana"
+          ],
+          "sheathedprimary": [
+            "zerchesiumstynger",
+            "carbonstynger",
+            "advalloystynger",
+            "lightningstynger"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        },
+        {
+          "head": [
+            {
+              "name": "hylotltier3head",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "back": [
+            {
+              "name": "simplecapeback",
+              "parameters": {
+                "colorIndex": 1
+              }
+            }
+          ],
+          "primary": [
+            "zerchesiumstynger",
+            "carbonstynger",
+            "advalloystynger",
+            "lightningstynger"
+          ],
+          "sheathedprimary": [
+            "carbonkatana",
+            "zerchesiumkatana",
+            "advalloykatana",
+            "irradiumkatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  },
+  {
+    "op": "add",
+    "path": "/items/hylotl/-",
+    "value": [
+      5,
+      [
+        {
+          "head": [
+            {
+              "name": "hylotltier3head",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "back": [
+            {
+              "name": "simplecapeback",
+              "parameters": {
+                "colorIndex": 1
+              }
+            }
+          ],
+          "primary": [
+            "carbonkatana",
+            "advalloykatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana",
+            "pyreitekatana",
+            "densiniumkatana",
+            "solariumkatana"
+          ],
+          "sheathedprimary": [
+            "advalloystynger",
+            "lightningstynger"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        },
+        {
+          "head": [
+            {
+              "name": "hylotltier3head",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "chest": [
+            {
+              "name": "hylotltier3chest",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "legs": [
+            {
+              "name": "hylotltier3pants",
+              "parameters": {
+                "colorIndex": 6
+              }
+            }
+          ],
+          "back": [
+            {
+              "name": "simplecapeback",
+              "parameters": {
+                "colorIndex": 1
+              }
+            }
+          ],
+          "primary": [
+            "advalloystynger",
+            "lightningstynger"
+          ],
+          "sheathedprimary": [
+            "carbonkatana",
+            "advalloykatana",
+            "triangliumkatana",
+            "diamondkatana",
+            "isogenkatana",
+            "pyreitekatana",
+            "densiniumkatana",
+            "solariumkatana"
+          ],
+          "alt": [
+            {
+              "name": "commonsmallshield"
+            },
+            {
+              "name": "commonlargeshield"
+            }
+          ]
+        }
+      ]
+    ]
+  }
+]

--- a/stagehands/coordinator.stagehand.patch
+++ b/stagehands/coordinator.stagehand.patch
@@ -2508,7 +2508,16 @@
       "maxRange": 45,
       "forceMoveRange": 35
     }
-  }, 
+  },     
+   {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/spaceplasmarifleminiknog",
+    "value": {
+      "minRange": 10,
+      "maxRange": 45,
+      "forceMoveRange": 35
+    }
+  },  
   
   // Frackin UNIQUE Sniper Rifles
   

--- a/weapons/ranged/unrand/spaceplasmarifle/spaceplasmarifleminiknog.activeitem
+++ b/weapons/ranged/unrand/spaceplasmarifle/spaceplasmarifleminiknog.activeitem
@@ -1,0 +1,158 @@
+{
+  "itemName" : "spaceplasmarifleminiknog",
+  "level" : 3,
+  "price" : 1080,
+  "maxStack" : 1,
+  "rarity" : "Legendary",
+  "description" : "A state-of-the-art assault rifle hardened for use in extreme environments.",
+  "shortdescription" : "Plasma Assault Rifle",
+  "tooltipKind" : "base",
+  "category" : "uniqueWeapon",
+  "twoHanded" : true,
+  "itemTags" : ["weapon","ranged"],
+
+  "inventoryIcon" : "spaceplasmarifle.png",
+
+  "animation" : "/items/active/weapons/ranged/gun.animation",
+  "animationParts" : {
+    "butt" : "",
+    "middle" : "/items/active/weapons/ranged/unrand/spaceplasmarifle/spaceplasmarifle.png",
+    "barrel" : "",
+    "muzzleFlash" : "/items/active/weapons/ranged/unrand/spaceplasmarifle/muzzleflash.png"
+  },
+  "animationCustom" : {
+    "animatedParts" : { "stateTypes" : { "middle" : {
+      "default" : "idle",
+      "states" : {
+        "idle" : {
+          "frames" : 8,
+          "cycle" : 0.6,
+          "mode" : "loop"
+        }
+      }}},
+      "parts" : { "middlefullbright" : {
+        "properties" : {
+          "centered" : true,
+          "offset" : [0.625, 0.125],
+          "zLevel" : 1,
+          "transformationGroups" : ["weapon"],
+          "fullbright" : true
+        },
+        "partStates" : {
+          "middle" : {
+            "idle" : {
+              "properties" : {
+                "image" : "/items/active/weapons/ranged/unrand/spaceplasmarifle/spaceplasmariflefullbright.png:<frame><paletteSwaps>"
+              }
+            }
+          }
+        }
+      }}
+    },
+    "sounds" : {
+      "fire" : ["/sfx/gun/plasma_ar4.ogg"],
+      "altFire" : [ "/sfx/gun/plasma_shotgun1.ogg" ]
+    }
+  },
+  "baseOffset" : [0.625, 0.125],
+  "muzzleOffset" : [1.875, 0.125],
+
+  "scripts" : ["/items/active/weapons/ranged/gun.lua"],
+
+  "elementalType" : "physical",
+
+  "primaryAbility" : {
+    "scripts" : ["/items/active/weapons/ranged/gunfire.lua"],
+    "class" : "GunFire",
+
+    "fireTime" : 0.3,
+    "baseDps" : 10.5,
+    "energyUsage" : 30,
+    "projectileCount" : 1,
+    "inaccuracy" : 0.015,
+
+    "burstCount" : 3,
+    "burstTime" : 0.1,
+    "fireType" : "burst",
+
+    "projectileType" : "spaceplasma",
+    "projectileParameters" : {},
+
+    "stances" : {
+      "idle" : {
+        "armRotation" : 0,
+        "weaponRotation" : 0,
+        "twoHanded" : true,
+
+        "allowRotate" : true,
+        "allowFlip" : true
+      },
+      "fire" : {
+        "duration" : 0,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
+        "twoHanded" : true,
+
+        "allowRotate" : false,
+        "allowFlip" : true
+      },
+      "cooldown" : {
+        "duration" : 0.1,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
+        "twoHanded" : true,
+
+        "allowRotate" : false,
+        "allowFlip" : true
+      }
+    }
+  },
+
+  "altAbility" : {
+    "name" : "Sticky Plasma Mines",
+    "scripts" : ["/items/active/weapons/ranged/abilities/altfire.lua"],
+    "class" : "AltFireAttack",
+
+    "fireTime" : 1.5,
+    "energyUsage" : 35,
+    "projectileCount" : 3,
+    "inaccuracy" : 0.09,
+    "fireType" : "auto",
+
+    "useParticleEmitter" : false,
+
+    "projectileType" : "stickyplasma",
+    "projectileParameters" : {},
+
+    "stances" : {
+      "idle" : {
+        "armRotation" : 0,
+        "weaponRotation" : 0,
+        "twoHanded" : true,
+
+        "allowRotate" : true,
+        "allowFlip" : true
+      },
+      "fire" : {
+        "duration" : 0,
+        "armRotation" : 8,
+        "weaponRotation" : 8,
+        "twoHanded" : true,
+
+        "allowRotate" : false,
+        "allowFlip" : false
+      },
+      "cooldown" : {
+        "duration" : 0.2,
+        "armRotation" : 8,
+        "weaponRotation" : 8,
+        "twoHanded" : true,
+
+        "allowRotate" : false,
+        "allowFlip" : false
+      }
+    }
+  },
+
+  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+}


### PR DESCRIPTION
- The Miniknog (hostile nor friendly) no longer uses aftermarket RNG weapons. They are a uniform faction with a uniform military, so they use high-end (frackin) energy weapons, as well as a (lower-tier) variant of the space plasma rifle (this is their standard issue arm.) For backup they'll use a breach knife or a violin short/broadsword. In other words, they are an actual threat now.
- Hylotl guards use Katanas and Styngers now instead of broadswords and RNG pistols.
- The Occassus has had their massive arsenal narrowed down to fit their theme better. They still use RNG weapons (especially at lower tier), but they'll use fleshy and poisonous type weapons as well, as fits their 'God'.