### PR TITLE
Moved ancient rapier to the 1h armory tab

### DIFF
--- a/recipes/armory/melee/rapier/ancientrapier.recipe
+++ b/recipes/armory/melee/rapier/ancientrapier.recipe
@@ -8,5 +8,5 @@
     "item" : "ancientrapier",
     "count" : 1
   },
-  "groups" : [ "armory3", "melee2", "all" ]
+  "groups" : [ "armory3", "melee", "all" ]
 }


### PR DESCRIPTION
Was incorrectly listed in the 2h melee tab, despite being a 1h weapon.