### PR TITLE
Updated nodes with more accurate requirements

### DIFF
--- a/zb/researchTree/fu_power.config
+++ b/zb/researchTree/fu_power.config
@@ -90,35 +90,35 @@
 						"icon" : "/objects/power/isn_battery_t1/isn_battery_t1icon.png",
 						"position" : [0, 40],
 						"children" : [ "battery2" ],
-						"price" : [["fuscienceresource", 210], ["ff_silicon", 5]],
+						"price" : [["fuscienceresource", 210], ["tungstenbar", 5], ["ff_silicon", 5]],
 						"unlocks" : [ "isn_battery_t1" ]
 					},	
 					"battery2" : {
 						"icon" : "/objects/power/isn_battery_t2/isn_battery_t2_inv.png",
 						"position" : [0, 70],
 						"children" : [ "battery3" ],
-						"price" : [["fuscienceresource", 720], ["titaniumbar", 5]],
+						"price" : [["fuscienceresource", 720], ["titaniumbar", 5], ["advcircuit", 1]],
 						"unlocks" : [ "isn_battery_t2" ]
 					},	
 					"battery3" : {
 						"icon" : "/objects/power/isn_battery_t3_ceru/isn_battery_t3_ceru_inv.png",
 						"position" : [0, 100],
 						"children" : [ "battery4" ],
-						"price" : [["fuscienceresource", 1350], ["fuprocessor", 4]],
+						"price" : [["fuscienceresource", 1350], ["protocitebar", 5], ["fuprocessor", 1]],
 						"unlocks" : [ "isn_battery_t3_ceru" ]
 					},						
 					"battery4" : {
 						"icon" : "/objects/power/isn_battery_t3_fero/isn_battery_t3_fero_inv.png",
 						"position" : [0, 130],
 						"children" : [ "battery5a" ],//"battery5b"
-						"price" : [["fuscienceresource", 2700], ["fuprocessor", 4]],
+						"price" : [["fuscienceresource", 2700], ["quietusbar", 5], ["aichip", 2], ["particlecore", 1]],
 						"unlocks" : [ "isn_battery_t3_fero" ]
 					},
 					"battery5a" : {
 						"icon" : "/objects/power/isn_battery_t4_fero/isn_battery_t4_fero_inv.png",
 						"position" : [20, 150],
 						"children" : [],
-						"price" : [["fuscienceresource", 7200], ["liquidmetallichydrogen", 50]],
+						"price" : [["fuscienceresource", 7200], ["densiniumbar", 8], ["liquidmetallichydrogen", 50]],
 						"unlocks" : [ "isn_battery_t4_fero" ]
 					},	
 					"centrifuge1" : {
@@ -132,7 +132,7 @@
 						"icon" : "/objects/power/centrifuge/centrifugeicon.png",
 						"position" : [-40, 80],
 						"children" : [ "centrifuge3" ],
-						"price" : [["fuscienceresource", 3600], ["protocitebar", 5]],
+						"price" : [["fuscienceresource", 3600], ["protocitebar", 5], ["fuprocessor", 1]],
 						"unlocks" : [ "centrifuge" ]
 					},
 					"sifter2" : {
@@ -146,7 +146,7 @@
 						"icon" : "/objects/power/centrifuge2/centrifuge2icon.png",
 						"position" : [-40, 120],
 						"children" : [ ],
-						"price" : [["fuscienceresource", 10800], ["morphiteore", 5]],
+						"price" : [["fuscienceresource", 10800], ["morphiteore", 5], ["effigiumbar", 3], ["ff_focusingarray", 1]],
 						"unlocks" : [ "centrifuge2" ]
 					},
 					"itemnetwork" : {
@@ -382,7 +382,7 @@
 //	"SOLAR2", "SOLAR3", "WINDPOWER", "FISSION", "BLASTFURNACE", "QUANTUMPOWER", "ARCSMELTER", "QUANTUMEXTRACTOR", "BATTERY2", "BATTERY3", "BATTERY4", "BATTERY5A", "BATTERY5B", "CENTRIFUGE2", "SIFTER2", "CENTRIFUGE3", "WORKER2", "WORKER3", "WORKER4", "WIRINGADV", "TURRETS", "MANUFACTURING", "ANSIBLE", "CONDENSER" "MIXER", "FILTER", "REGULATOR", "REGENMATRIX", "SOLAR1", "COMBUSTION", "BATTERY1", "ITEMNETWORK", "FISSION", "LIQUIDCOLLECTOR"
 	
 	"versions":{
-	  "fu_power" : "0.12"
+	  "fu_power" : "0.13"
 	},	
 	"initiallyResearched" : {
 		"fu_power" : ["BASICTRAINING"]


### PR DESCRIPTION
Reduces likelihood of players researching nodes and being unable to actually create the machines. Changed: Lab centrifuge, gas centrifuge, battery branch.

Check the version number, not sure on the format used (though shouldn't be necessary for unlock changes only?)