### PR TITLE
stuff

### DIFF
--- a/interface/scripted/fu_matmodplacer/fu_matmodplacer.lua
+++ b/interface/scripted/fu_matmodplacer/fu_matmodplacer.lua
@@ -127,7 +127,7 @@ end
 function essentialCheck()
 	for _,v in pairs({ "beamaxe", "wiretool", "painttool", "inspectiontool"}) do
 		local test=player.essentialItem(v)
-		if test.name=="fu_matmodplacer" then
+		if test and test.name=="fu_matmodplacer" then
 			return true
 		end
 	end

--- a/interface/scripted/tunableoredetector/tunableoredetector_gui.lua
+++ b/interface/scripted/tunableoredetector/tunableoredetector_gui.lua
@@ -116,7 +116,7 @@ function detectorInHand()
 
 	for _,v in pairs({ "beamaxe", "wiretool", "painttool", "inspectiontool"}) do
 		local test=player.essentialItem(v)
-		if test.name=="tunableoredetector1" then
+		if test and test.name=="tunableoredetector1" then
 			inEssentialSlot=true
 			break
 		end

--- a/quests/madness/madnessdata.lua
+++ b/quests/madness/madnessdata.lua
@@ -65,7 +65,7 @@ function streakCheck(val)
 	if val <= 0 then
 		return false
 	end
-	
+
 	local index=0
 	for i,e in pairs(storage.streakTable) do
 		if e==val then
@@ -73,7 +73,12 @@ function streakCheck(val)
 			break
 		end
 	end
-	
+
+	--for some reason, someone had an error where the index was a string. maybe some failure in table serialization? idk.
+	if type(index)=="string" then
+		index=tonumber(index)
+	end
+
 	if index>0 then
 		return true
 	else
@@ -96,7 +101,7 @@ function randomEvent()
 	self.currentProtectionAbs=math.abs(self.currentProtection)
 
 	local didRng=false
-	
+
 	while (not didRng) or streakCheck(math.max(0,self.randEvent)) do
 		self.randEvent=math.random(1,100)
 		--mentalProtection can make it harder to be affected
@@ -369,13 +374,13 @@ function update(dt)
 
 		if (world.threatLevel() > 1) then --is the world a higher threat level?
 			if (self.environmentTimer > 300) then -- has at least 5 minutes elapsed? If so, begin applying exploration bonus
-				self.threatBonus = world.threatLevel() / 1.5 -- set the base calculation 
+				self.threatBonus = world.threatLevel() / 1.5 -- set the base calculation
                 if (self.threatBonus < 2) then -- make sure its never less than 2 if we are on a biome above tier 1
 					self.threatBonus = 1
-			    end				
+			    end
 				if (self.threatBonus > 6) then -- make sure we never surpass + 6 bonus
 					self.threatBonus = 6
-				end					
+				end
 			end
 			if afkLvl<=3 then
 				self.environmentTimer = self.environmentTimer + (dt/(afkLvl+1))

--- a/quests/madness/madnessdata.lua
+++ b/quests/madness/madnessdata.lua
@@ -57,6 +57,19 @@ function init()
 	status.setPersistentEffects("madnessAFKPenalty",{})
 end
 
+function indexOf(t,v1)
+	local index=0
+	local counter=0
+	for _,v2 in pairs(t) do
+		counter=counter+1
+		if v1==v2 then
+			index=counter
+			break
+		end
+	end
+	return index
+end
+
 function streakCheck(val)
 	if not storage.streakTable then
 		storage.streakTable={}
@@ -66,18 +79,7 @@ function streakCheck(val)
 		return false
 	end
 
-	local index=0
-	for i,e in pairs(storage.streakTable) do
-		if e==val then
-			index=i
-			break
-		end
-	end
-
-	--for some reason, someone had an error where the index was a string. maybe some failure in table serialization? idk.
-	if type(index)=="string" then
-		index=tonumber(index)
-	end
+	local index=indexOf(storage.streakTable,val)
 
 	if index>0 then
 		return true

--- a/quests/madness/madnessdata.lua
+++ b/quests/madness/madnessdata.lua
@@ -79,6 +79,7 @@ function streakCheck(val)
 		return false
 	end
 
+	--I wish I could use a better method, but for some reason someone managed to get a table with string indexes, a product of serialization I  expect.
 	local index=indexOf(storage.streakTable,val)
 
 	if index>0 then


### PR DESCRIPTION
fix for an error in madness streak prevention, because SB apparently sometimes serializes lists with strings as indexes.
fixed a derp error in matmod placer and precision ore detector