### PR TITLE
Standardizing remaining cultists

### DIFF
--- a/npcs/cultist.npctype.patch
+++ b/npcs/cultist.npctype.patch
@@ -1,0 +1,2714 @@
+[
+  {
+    "op": "remove",
+    "path": "/items"
+  },
+  {
+    "op": "add",
+    "path": "/items",
+    "value": {
+      "override": [
+        [
+          0,
+          [
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcassaultrifle",
+                "npcassaultrifle",
+                "npcshotgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcassaultrifle",
+                "npcassaultrifle",
+                "npcshotgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcassaultrifle",
+                "npcassaultrifle",
+                "npcshotgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcsniperrifle"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcsniperrifle"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcrocketlauncher",
+                "npcrocketlauncher",
+                "commongrenadelauncher",
+                "burster"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistshortsword"
+              ]
+            }
+          ]
+        ],
+        [
+          2,
+          [
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "fucultistbow",
+                "fucultistbow"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietuspistol"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietuspistol"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietuspistol"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietuspistol"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcassaultrifle",
+                "npcassaultrifle",
+                "npcshotgun",
+                "thornslinger",
+                "wormgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcassaultrifle",
+                "npcassaultrifle",
+                "npcshotgun",
+                "thornslinger",
+                "wormgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcassaultrifle",
+                "npcassaultrifle",
+                "npcshotgun",
+                "thornslinger",
+                "wormgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcsniperrifle"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcsniperrifle"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcrocketlauncher",
+                "npcrocketlauncher",
+                "commongrenadelauncher",
+                "bushmaster",
+                "burster",
+                "telebriumrocketlauncher"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger"
+              ]
+            }
+          ]
+        ],
+        [
+          3,
+          [
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietuspistol"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietuspistol"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietuspistol"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietuspistol"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpistol",
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietuspistol"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "npcmachinepistol",
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcassaultrifle",
+                "npcshotgun",
+                "thornslinger",
+                "blistergun",
+                "wormgun",
+                "vashtagun",
+                "bonethresher"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcassaultrifle",
+                "npcshotgun",
+                "thornslinger",
+                "blistergun",
+                "wormgun",
+                "vashtagun",
+                "bonethresher"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcassaultrifle",
+                "npcshotgun",
+                "thornslinger",
+                "blistergun",
+                "wormgun",
+                "vashtagun",
+                "bonethresher"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "thornrifle"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "thornrifle"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcrocketlauncher",
+                "npcrocketlauncher",
+                "uncommongrenadelauncher",
+                "bushmaster",
+                "burster",
+                "telebriumrocketlauncher",
+                "eyecannon"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe"
+              ]
+            }
+          ]
+        ],
+        [
+          4,
+          [
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blisterpistol",
+                "quietuspistol",
+                "pistolquietusfu"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blisterpistol",
+                "quietuspistol",
+                "pistolquietusfu"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blisterpistol",
+                "quietuspistol",
+                "pistolquietusfu"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blisterpistol",
+                "quietuspistol",
+                "pistolquietusfu"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator",
+                "pistolquietusfu"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator",
+                "pistolquietusfu"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator",
+                "pistolquietusfu"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator",
+                "pistolquietusfu"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "thornslinger",
+                "blistergun",
+                "wormgun",
+                "vashtagun",
+                "bonethresher",
+                "biogun",
+                "goregun",
+                "quietusassaultrifle",
+                "quietusshotgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "thornslinger",
+                "blistergun",
+                "wormgun",
+                "vashtagun",
+                "bonethresher",
+                "biogun",
+                "goregun",
+                "quietusassaultrifle",
+                "quietusshotgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "thornslinger",
+                "blistergun",
+                "wormgun",
+                "vashtagun",
+                "bonethresher",
+                "biogun",
+                "goregun",
+                "quietusassaultrifle",
+                "quietusshotgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "thornrifle",
+                "riflequietusfu",
+                "quietussniper"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "thornrifle",
+                "riflequietusfu",
+                "quietussniper"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcrocketlauncher",
+                "npcrocketlauncher",
+                "uncommongrenadelauncher",
+                "bushmaster",
+                "burster",
+                "telebriumrocketlauncher",
+                "eyecannon",
+                "quietusrocketlauncher"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear"
+              ]
+            }
+          ]
+        ],
+        [
+          5,
+          [
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blisterpistol",
+                "quietuspistol",
+                "pistolquietusfu"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blisterpistol",
+                "quietuspistol",
+                "pistolquietusfu"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blisterpistol",
+                "quietuspistol",
+                "pistolquietusfu"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator",
+                "pistolquietusfu"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator",
+                "pistolquietusfu"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "scientisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcpetcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod",
+                "npccultistscandroidcapturepod"
+              ],
+              "sheathedprimary": [
+                "blisterpistol",
+                "quietussmg",
+                "murdermanipulator",
+                "pistolquietusfu"
+              ],
+              "alt": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blistergun",
+                "wormgun",
+                "vashtagun",
+                "bonethresher",
+                "biogun",
+                "goregun",
+                "quietusassaultrifle",
+                "quietusshotgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blistergun",
+                "wormgun",
+                "vashtagun",
+                "bonethresher",
+                "biogun",
+                "goregun",
+                "quietusassaultrifle",
+                "quietusshotgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "blistergun",
+                "wormgun",
+                "vashtagun",
+                "bonethresher",
+                "biogun",
+                "goregun",
+                "quietusassaultrifle",
+                "quietusshotgun"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "thornrifle",
+                "riflequietusfu",
+                "quietussniper"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "thornrifle",
+                "riflequietusfu",
+                "quietussniper"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "cultisthead"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "cultistchest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "cultistlegs"
+                }
+              ],
+              "primary": [
+                "npcrocketlauncher",
+                "npcrocketlauncher",
+                "uncommongrenadelauncher",
+                "bushmaster",
+                "burster",
+                "telebriumrocketlauncher",
+                "eyecannon",
+                "quietusrocketlauncher"
+              ],
+              "sheathedprimary": [
+                "npccultistbroadsword",
+                "npccultistbroadsword",
+                "fucultistaxe",
+                "fucultistdagger",
+                "fucultistspear",
+                "fucultistgreataxe",
+                "fucultistmace",
+                "spikesword",
+                "quietusrapier",
+                "quietusmace",
+                "quietusaxe",
+                "quietusspear",
+                "quietusscythe",
+                "fuatropusaxe",
+                "fuatropusbroadsword",
+                "fuatropusdagger",
+                "fuatropusgreataxe",
+                "fuatropushammer",
+                "fuatropusscythe",
+                "fuatropusshortsword",
+                "fuatropusspear",
+                "fucultistscythe"
+              ]
+            }
+          ]
+        ]
+      ]
+    }
+  }
+]

--- a/npcs/dungeon/aviannativevillage/devoutvillageguard.npctype.patch
+++ b/npcs/dungeon/aviannativevillage/devoutvillageguard.npctype.patch
@@ -1,0 +1,167 @@
+[
+  {
+    "op": "remove",
+    "path": "/items"
+  },
+  {
+    "op": "add",
+    "path": "/items",
+    "value": {
+      "avian": [
+        [
+          0,
+          [
+            {
+              "head": [
+                {
+                  "name": "aviantier1head"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "aviantier1chest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "aviantier1pants"
+                }
+              ],
+              "primary": [
+                "npcavianbroadsword"
+              ],
+              "sheathedprimary": [
+                "npcbow"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "aviantier1head"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "aviantier1chest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "aviantier1pants"
+                }
+              ],
+              "primary": [
+                "npcavianbroadsword"
+              ],
+              "sheathedprimary": [
+                "neb-commonbow"
+              ]
+            }
+          ]
+        ],
+        [
+          2,
+          [
+            {
+              "head": [
+                {
+                  "name": "aviantier2head"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "aviantier2chest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "aviantier2pants"
+                }
+              ],
+              "primary": [
+                "npcavianbroadsword"
+              ],
+              "sheathedprimary": [
+                "neb-commonbow"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "aviantier2head"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "aviantier2chest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "aviantier2pants"
+                }
+              ],
+              "primary": [
+                "npcavianbroadsword"
+              ],
+              "sheathedprimary": [
+                "neb-uncommonbow"
+              ]
+            }
+          ]
+        ],
+        [
+          3,
+          [
+            {
+              "head": [
+                {
+                  "name": "aviantier3head"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "aviantier3chest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "aviantier3pants"
+                }
+              ],
+              "primary": [
+                "npcavianbroadsword"
+              ],
+              "sheathedprimary": [
+                "neb-uncommonbow"
+              ]
+            },
+            {
+              "head": [
+                {
+                  "name": "aviantier3head"
+                }
+              ],
+              "chest": [
+                {
+                  "name": "aviantier3chest"
+                }
+              ],
+              "legs": [
+                {
+                  "name": "aviantier3pants"
+                }
+              ],
+              "primary": [
+                "npcavianbroadsword"
+              ],
+              "sheathedprimary": [
+                "neb-rarebow"
+              ]
+            }
+          ]
+        ]
+      ]
+    }
+  }
+]

--- a/stagehands/coordinator.stagehand.patch
+++ b/stagehands/coordinator.stagehand.patch
@@ -84,6 +84,7 @@
     "value": 40
   },
   
+  
   // ............................
   // Frackin Weapon editions.
   // This is not an ideal solution by any means, but it'll suffice untill we come up with a tag-based alternative system. Once we do that, we can get rid of this whole section.
@@ -721,10 +722,28 @@
       "maxRange": 45,
       "forceMoveRange": 30
     }
-  }, 
+  },   
+   {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/npcfirebow",
+    "value": {
+        "minRange" : 10,
+        "maxRange" : 45,
+        "forceMoveRange" : 40
+    }
+  },  
    {
     "op": "add",
     "path": "/npcCombat/rangedWeaponRanges/commonbow",
+    "value": {
+        "minRange" : 10,
+        "maxRange" : 45,
+        "forceMoveRange" : 40
+    }
+  },  
+   {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/neb-commonbow",
     "value": {
         "minRange" : 10,
         "maxRange" : 45,
@@ -742,7 +761,25 @@
   },  
    {
     "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/neb-uncommonbow",
+    "value": {
+        "minRange" : 10,
+        "maxRange" : 45,
+        "forceMoveRange" : 40
+    }
+  },  
+   {
+    "op": "add",
     "path": "/npcCombat/rangedWeaponRanges/rarebow",
+    "value": {
+        "minRange" : 10,
+        "maxRange" : 45,
+        "forceMoveRange" : 40
+    }
+  },  
+   {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/neb-rarebow",
     "value": {
         "minRange" : 10,
         "maxRange" : 45,
@@ -3716,9 +3753,178 @@
     }
   },   
   
+  
+  // Frackin UNIQUE Stynger
+  
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/advalloystynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/aetheriumstynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/carbonstynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ironstynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/lightningstynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/lunaristynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/telebriumstynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/tungstenstynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/xithricitestynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/zerchesiumstynger",
+    "value": {
+      "minRange": 10,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+  
   //...
   //Melees
   //
+  
+  // Vanilla weapons that NPCs use that CF forgot to add entries for. ... Really, CF? REALLY?!
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/npcavianbroadsword",
+    "value": {
+      "minRange": 2,
+      "maxRange": 4
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/npcbruisersword",
+    "value": {
+      "minRange": 2,
+      "maxRange": 4
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/npccultistbroadsword",
+    "value": {
+      "minRange": 2,
+      "maxRange": 4
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/npccultistshortsword",
+    "value": {
+      "minRange": 1.5,
+      "maxRange": 3
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/npcdeadbeataxe",
+    "value": {
+      "minRange": 1.5,
+      "maxRange": 3
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/npceyesword",
+    "value": {
+      "minRange": 2,
+      "maxRange": 4
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/npcfeneroxspear",
+    "value": {
+      "minRange": 3,
+      "maxRange": 5
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/npcgangbroadsword",
+    "value": {
+      "minRange": 2,
+      "maxRange": 4
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/meleeWeaponRanges/npcwrench",
+    "value": {
+      "minRange": 2,
+      "maxRange": 4
+    }
+  },
+  
   // Frackin RNG Melees
   
   {


### PR DESCRIPTION
Vanilla cultists (that are not the FU types) now have standardized weapons and loadouts. These cultists can be randomly one of the following:

- 7 out of 17 chance of cultistbasic
- 4 out of 17 chance of cultistscientist
- 3 out of 17 chance of cultistassault
- 2 out of 17 chance of cultistsniper
- 1 out of 17 chance of cultistrocket

with decreasing chance of cultistbasic at higher tiers.

I'm doing this instead of converting the remaining png dungeons... for now.

EDIT: Additional changes:

- Avian Devout Village Guards (the kluex culties) have the same loadout as the avian Temple Guards. 
- Coordinator entries for Styngers since Hylotls use them now (they have the same range definitions as pistols.) And a few vanilla NPC items that chuckefish forgot to define there because... potatoes.