### PR TITLE
Travis CI: automatically run JSON linter on every asset for every commit/PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+dist: xenial
+language: node_js
+
+node_js:
+  - 14
+
+git:
+  depth: 1
+
+notifications:
+  email: false
+
+cache:
+  directories:
+    - $HOME/.npm
+
+before_script:
+- ( cd tests/travis && npm install )
+
+script:
+ - ( cd tests/travis && npm test )
+

--- a/projectiles/npc/pandorasboxdarkgas/pandorasboxdarkgas.projectile
+++ b/projectiles/npc/pandorasboxdarkgas/pandorasboxdarkgas.projectile
@@ -2,7 +2,7 @@
   "projectileName" : "pandorasboxdarkgas",
   "image" : "pandorasboxdarkgas.png",
   "physics" : "flame",
-  "animationCycle" : 1.,
+  "animationCycle" : 1.0,
   "animationLoops" : false,
   "frameNumber" : 8,
   "power" : 50,

--- a/projectiles/npc/pandorasboxicethrower/pandorasboxicethrower.projectile
+++ b/projectiles/npc/pandorasboxicethrower/pandorasboxicethrower.projectile
@@ -2,7 +2,7 @@
   "projectileName" : "pandorasboxicethrower",
   "image" : "pandorasboxicethrower.png",
   "physics" : "flame",
-  "animationCycle" : 1.,
+  "animationCycle" : 1.0,
   "animationLoops" : false,
   "damageKindImage" : "/interface/statuses/ice.png",
   "frameNumber" : 12,

--- a/tests/travis/.gitignore
+++ b/tests/travis/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package.lock

--- a/tests/travis/check_json_assets.js
+++ b/tests/travis/check_json_assets.js
@@ -1,0 +1,89 @@
+/**
+ * Find all JSON files and check them for correctness.
+ */
+
+'use strict';
+
+const fs = require( 'fs' ),
+	process = require( 'process' ),
+	glob = require( 'fast-glob' ),
+	stripJsonComments = require( 'strip-json-comments' );
+
+/**
+ * Turn non-strict JSON (with comments, newlines, etc.) into a string suitable for JSON.parse().
+ * From https://github.com/edwardspec/fudocgenerator/
+ * @param {string} relaxedJson
+ * @return {string}
+ */
+function sanitizeRelaxedJson( relaxedJson ) {
+	// Some input files have "new line" character within the JSON strings (between " and ").
+	// This is invalid JSON (would cause syntax error), but we must be tolerant to such input.
+	// This is especially important for weapons/tools, as most of them have multiline descriptions.
+	var sanitizedJson = '',
+		isInsideQuotes = false,
+		prevChar = '';
+
+	// Remove comments (JSON standard doesn't allow them).
+	relaxedJson = stripJsonComments( relaxedJson );
+
+	// Remove both \r and BOM (byte order mark) symbols, because they confuse JSON.parse().
+	relaxedJson = relaxedJson.replace( /(\uFEFF|\r)/g, '' );
+
+	// Iterate over each character, and if we find "new line" or "tab" characters inside the quotes,
+	// replace them with "\n" and "\t" respectively, making this a valid JSON.
+	[...relaxedJson].forEach( char => {
+		// Non-escaped " means that this is start/end of a string.
+		if ( char == '"' && prevChar != '\\' ) {
+			isInsideQuotes = !isInsideQuotes;
+		}
+
+		if ( isInsideQuotes ) {
+			switch ( char ) {
+				case '\n':
+					char = '\\n';
+					break;
+				case '\t':
+					char = '\\t';
+			}
+		}
+
+		sanitizedJson += char;
+		prevChar = char;
+	} );
+
+	return sanitizedJson;
+}
+
+// This script is under tests/travis/
+var directory = __dirname + '/../..';
+
+var globOptions = {
+	cwd: directory,
+	ignore: [
+		// Exclude everything that is not a JSON asset: images, documentation, examples, etc.
+		'tests',
+		'a_modders',
+		'_previewimage',
+		'**/*.{lua,png,xcf,wav,ogg,txt,md,ase,aseprite,tsx,aup,ico,tmx,pdn,zip,au,old,unused}'
+	],
+	caseSensitiveMatch: false
+};
+
+var totalCount = 0,
+	failedCount = 0;
+
+glob.sync( '**', globOptions ).forEach( ( filename ) => {
+	try {
+		JSON.parse( sanitizeRelaxedJson( fs.readFileSync( directory + '/' + filename ).toString() ) );
+	} catch ( error ) {
+		console.log( filename, error );
+		failedCount ++;
+	}
+
+	if ( ++ totalCount % 200 == 0 ) {
+		process.stdout.write( totalCount + ' ' );
+	}
+} );
+
+process.stdout.write( '\n' );
+process.exit( failedCount > 0 ? 1 : 0 );

--- a/tests/travis/package.json
+++ b/tests/travis/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "dependencies": {
+    "fast-glob": "^3.2.4",
+    "fs": "^0.0.2",
+    "strip-json-comments": "^3.1.1"
+  },
+  "devDependencies": {
+    "eslint": "^7.6.0"
+  },
+  "scripts" : {
+    "test" : "node check_json_assets.js"
+  }
+}


### PR DESCRIPTION
This will automatically notify us of any syntax errors in added/modified JSON assets.

If enabled in Travis CI (third-party service), this script will be called (on Travis side) after every commit OR pull request, and will mark them with either red "x" icon (if there were syntax errors) or green "check" icon.
