### PR TITLE
Fixed a number of mistakes

### DIFF
--- a/recipes/armory/ranged/throwables/bomb.recipe
+++ b/recipes/armory/ranged/throwables/bomb.recipe
@@ -7,6 +7,6 @@
     "item" : "bomb",
     "count" : 10
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/bomb.recipe
+++ b/recipes/armory/ranged/throwables/bomb.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "volatilepowder", "count" : 6 },
-    { "item" : "ironbar", "count" : 1 }
+    { "item" : "ironbar", "count" : 2 }
   ],
   "output" : {
     "item" : "bomb",

--- a/recipes/armory/ranged/throwables/chilibomb.recipe
+++ b/recipes/armory/ranged/throwables/chilibomb.recipe
@@ -8,6 +8,6 @@
     "item" : "chilibomb",
     "count" : 5
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/hivebomb.recipe
+++ b/recipes/armory/ranged/throwables/hivebomb.recipe
@@ -7,6 +7,6 @@
     "item" : "hivebomb",
     "count" : 5
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/hivebomb.recipe
+++ b/recipes/armory/ranged/throwables/hivebomb.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "fuhoney", "count" : 10 },
+    { "item" : "fu_liquidhoney", "count" : 10 },
     { "item" : "bee_honey_drone", "count" : 3 }
   ],
   "output" : {

--- a/recipes/armory/ranged/throwables/molotov.recipe
+++ b/recipes/armory/ranged/throwables/molotov.recipe
@@ -7,6 +7,6 @@
     "item" : "molotov",
     "count" : 5
   },
-  "groups" : [ "armor1y", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/molotov.recipe
+++ b/recipes/armory/ranged/throwables/molotov.recipe
@@ -7,6 +7,6 @@
     "item" : "molotov",
     "count" : 5
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armor1y", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/molotov.recipe
+++ b/recipes/armory/ranged/throwables/molotov.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "methanol", "count" : 10 },
-    { "item" : "wovencloth", "count" : 1 }
+    { "item" : "fabric", "count" : 1 }
   ],
   "output" : {
     "item" : "molotov",

--- a/recipes/armory/ranged/throwables/nailbomb.recipe
+++ b/recipes/armory/ranged/throwables/nailbomb.recipe
@@ -7,6 +7,6 @@
     "item" : "nailbomb",
     "count" : 1
   },
-  "groups" : [ "armory1", "consumables", "all" ],
+  "groups" : [ "armory2", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/nailbomb.recipe
+++ b/recipes/armory/ranged/throwables/nailbomb.recipe
@@ -7,6 +7,6 @@
     "item" : "nailbomb",
     "count" : 1
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/tarball.recipe
+++ b/recipes/armory/ranged/throwables/tarball.recipe
@@ -6,6 +6,6 @@
     "item" : "tarball",
     "count" : 3
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/throwingbones.recipe
+++ b/recipes/armory/ranged/throwables/throwingbones.recipe
@@ -3,7 +3,7 @@
     { "item" : "bone", "count" : 8 }
   ],
   "output" : {
-    "item" : "throwingbone",
+    "item" : "throwingbones",
     "count" : 3
   },
   "groups" : [ "armory", "consumables", "all" ],

--- a/recipes/armory/ranged/throwables/throwingbones.recipe
+++ b/recipes/armory/ranged/throwables/throwingbones.recipe
@@ -6,6 +6,6 @@
     "item" : "throwingbones",
     "count" : 3
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/throwingboulder.recipe
+++ b/recipes/armory/ranged/throwables/throwingboulder.recipe
@@ -6,6 +6,6 @@
     "item" : "throwingboulder",
     "count" : 3
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/throwingdart.recipe
+++ b/recipes/armory/ranged/throwables/throwingdart.recipe
@@ -6,6 +6,6 @@
     "item" : "throwingdart",
     "count" : 6
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/throwingspear.recipe
+++ b/recipes/armory/ranged/throwables/throwingspear.recipe
@@ -7,6 +7,6 @@
     "item" : "throwingspear",
     "count" : 5
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }

--- a/recipes/armory/ranged/throwables/waterballoon.recipe
+++ b/recipes/armory/ranged/throwables/waterballoon.recipe
@@ -7,6 +7,6 @@
     "item" : "waterballoon",
     "count" : 5
   },
-  "groups" : [ "armory", "consumables", "all" ],
+  "groups" : [ "armory1", "consumables", "all" ],
   "duration" : 0.05
 }


### PR DESCRIPTION
Various bugfixes, but nothing that requires updating the changelog beyond the first throwables PR. Tested to ensure it's all working and they're all craftable.

Mechanical changes from first throwables:
Iron bars in the bomb recipe changed from 1 -> 2, since volatile powder is pretty cheap and bombs are very strong.
Nailery bomb moved to t2 armory, since the nailery agricultural node is t2