### PR TITLE
Fixed reference to clothing fabricator

### DIFF
--- a/quests/fu_questlines/science/genetics/create_mutavisk.questtemplate
+++ b/quests/fu_questlines/science/genetics/create_mutavisk.questtemplate
@@ -2,7 +2,7 @@
   "id" : "create_mutavisk",
   "prerequisites" : [ "create_plastic" ],
   "title" : "Mutavisk Headware",
-  "text" : "A task for you: Use a ^orange;Clothing Fabricator^reset; and produce a ^orange;Mutavisk Helm^reset;. I'll pay well for it, as I am in dire need.",
+  "text" : "A task for you: Research ^cyan;Penumbrite Equipment^reset; and create a ^orange;Mutavisk Helm^reset;. I'll pay well for it, as I am in dire need.",
   "completionText" : "Thanks to you, I can finally take a trip to an ^orange;Irradiated^reset; world with my complete ^orange;Mutavisk Armor Set^reset;!",
   "moneyRange" : [720, 920],
   "rewards" : [ [ [ "fu_lootbox", 1 ] ] ],


### PR DESCRIPTION
Changed fabricator reference to a research instruction, as users at t3 do not need directing to the armory to craft armour.