### PR TITLE
Made precursorsmelter a usable item

### DIFF
--- a/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
+++ b/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
@@ -3,7 +3,7 @@
   "colonyTags" : [ "precursor"],
   "printable" : false,
   "rarity" : "legendary",
-  "description" : "Some sort of bulky machine.",
+  "description" : "Built to process entire worlds into cyberspheres.",
   "shortdescription" : "Precursor Forge",
   "race" : "precursor",
   "category" : "crafting",

--- a/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
+++ b/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
@@ -6,8 +6,13 @@
   "description" : "Some sort of bulky machine.",
   "shortdescription" : "Precursor Forge",
   "race" : "precursor",
-  "category" : "decorative",
-  "price" : 500,
+  "category" : "crafting",
+  "price" : 2000,
+  "interactAction" : "OpenCraftingInterface",
+  "interactData" : {
+    "config" : "/interface/windowconfig/fissionfurnace.config",
+    "filter" : [ "fissionfurnace" ]
+  },
 
   "inventoryIcon" : "precursorsmeltericon.png",
   "orientations" : [

--- a/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
+++ b/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
@@ -15,7 +15,10 @@
     "paneLayoutOverride": {
       "windowtitle": {
         "title": " Precursor Forge",
-        "subtitle": " ^#b9b5b2;Ancient Smelting"
+        "subtitle": " ^#b9b5b2;Ancient Smelting",
+        "icon": {
+          "file": "/interface/crafting/craftingfurnace4.png"
+        }
       }
     }
   },

--- a/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
+++ b/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
@@ -11,14 +11,11 @@
   "interactAction" : "OpenCraftingInterface",
   "interactData" : {
     "config" : "/interface/windowconfig/fissionfurnace.config",
-    "filter" : [ "craftingfurnace", "craftingfurnace2", "craftingfurnace3", "fissionfurnace" ]
+    "filter" : [ "craftingfurnace", "craftingfurnace2", "craftingfurnace3", "fissionfurnace" ],
     "paneLayoutOverride": {
       "windowtitle": {
         "title": " Precursor Forge",
-        "subtitle": " ^#b9b5b2;Ancient Smelting",
-        "icon": {
-          "file": "/interface/crafting/craftingfurnace4.png"
-        }
+        "subtitle": " ^#b9b5b2;Ancient Smelting"
       }
     }
   },

--- a/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
+++ b/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
@@ -11,7 +11,7 @@
   "interactAction" : "OpenCraftingInterface",
   "interactData" : {
     "config" : "/interface/windowconfig/fissionfurnace.config",
-    "filter" : [ "fissionfurnace" ]
+    "filter" : [ "craftingfurnace", "craftingfurnace2", "craftingfurnace3", "fissionfurnace" ]
   },
 
   "inventoryIcon" : "precursorsmeltericon.png",

--- a/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
+++ b/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
@@ -14,8 +14,7 @@
     "filter" : [ "craftingfurnace", "craftingfurnace2", "craftingfurnace3", "fissionfurnace" ]
     "paneLayoutOverride" : {
       "windowtitle" : {
-        "title" : " Precursor Forge",
-        "subtitle" : " ^#b9b5b2;Ancient metalsmithing"
+        "title" : " Precursor Forge"
       }
     }
   },

--- a/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
+++ b/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
@@ -12,6 +12,12 @@
   "interactData" : {
     "config" : "/interface/windowconfig/fissionfurnace.config",
     "filter" : [ "craftingfurnace", "craftingfurnace2", "craftingfurnace3", "fissionfurnace" ]
+    "paneLayoutOverride" : {
+      "windowtitle" : {
+        "title" : " Precursor Forge",
+        "subtitle" : " ^#b9b5b2;Ancient metalsmithing"
+      }
+    }
   },
 
   "inventoryIcon" : "precursorsmeltericon.png",

--- a/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
+++ b/objects/minibiome/precursor/precursorsmelter/precursorsmelter.object
@@ -12,9 +12,13 @@
   "interactData" : {
     "config" : "/interface/windowconfig/fissionfurnace.config",
     "filter" : [ "craftingfurnace", "craftingfurnace2", "craftingfurnace3", "fissionfurnace" ]
-    "paneLayoutOverride" : {
-      "windowtitle" : {
-        "title" : " Precursor Forge"
+    "paneLayoutOverride": {
+      "windowtitle": {
+        "title": " Precursor Forge",
+        "subtitle": " ^#b9b5b2;Ancient Smelting",
+        "icon": {
+          "file": "/interface/crafting/craftingfurnace4.png"
+        }
       }
     }
   },

--- a/objects/vanity/underworld/fuunderworldfountain.object
+++ b/objects/vanity/underworld/fuunderworldfountain.object
@@ -1,7 +1,7 @@
 {
   "objectName" : "fuunderworldfountain",
-  "colonyTags" : [  "atropus", "creepy", "flesh" ],
-  "rarity" : "legendary",
+  "colonyTags" : [ "atropus", "creepy", "flesh" ],
+  "rarity" : "Legendary",
   "printable" : false,
   "description" : "Cheery and uplifting",
   "shortdescription" : "Flesh Fountain",

--- a/objects/vanity/underworld/fuunderworldfountain.object
+++ b/objects/vanity/underworld/fuunderworldfountain.object
@@ -1,12 +1,12 @@
 {
   "objectName" : "fuunderworldfountain",
   "colonyTags" : [  "atropus", "creepy", "flesh" ],
-  "rarity" : "Essential",
+  "rarity" : "legendary",
   "printable" : false,
   "description" : "Cheery and uplifting",
   "shortdescription" : "Flesh Fountain",
   "race" : "generic",
-  "category" : "crafting",
+  "category" : "decorative",
   "price" : 450,
   
   "lightColor" : [60, 60, 100],

--- a/objects/vanity/underworld/fuunderworldfountain2.object
+++ b/objects/vanity/underworld/fuunderworldfountain2.object
@@ -1,12 +1,12 @@
 {
   "objectName" : "fuunderworldfountain2",
   "colonyTags" : [ "atropus", "creepy", "flesh"],
-  "rarity" : "Essential",
+  "rarity" : "Legendary",
   "printable" : false,
   "description" : "Tasteful, yet horrific",
   "shortdescription" : "Flesh Fountain",
   "race" : "generic",
-  "category" : "crafting",
+  "category" : "decorative",
   "price" : 450,
   
   "lightColor" : [60, 60, 100],


### PR DESCRIPTION
The precursor forge was already a decorative item ingame; it's placed in the boss room of the precursor mission and drops as loot from the precursor table occasionally. I gave it the fission furnace's crafting interface so it can be used in people's bases.

Also corrected the item type and rarity of the two atropus fountains