### PR TITLE
fission and dynamo missing connections fix

### DIFF
--- a/interface/kheAA/kheAA_terminal/kheAA_terminalGui.lua
+++ b/interface/kheAA/kheAA_terminal/kheAA_terminalGui.lua
@@ -35,6 +35,15 @@ end
 function update(dt)
 	deltatime=deltatime+dt
 	
+	if updateFilterQueueTimer then
+		if updateFilterQueueTimer<=0.0 then
+			filterText = widget.getText("filterBox")
+			refreshingList = coroutine.create(refreshList)
+			updateFilterQueueTimer=nil
+		else
+			updateFilterQueueTimer=updateFilterQueueTimer-dt
+		end
+	end
 	if refreshingList and coroutine.status(refreshingList) ~= "dead" then
 		local a, b = coroutine.resume(refreshingList)
 		--sb.logInfo(tostring(a).." : "..tostring(b))
@@ -100,8 +109,7 @@ function refreshList()
 end
 
 function filterBox()
-	filterText = widget.getText("filterBox")
-	refreshingList = coroutine.create(refreshList)
+	updateFilterQueueTimer=0.10
 end
 
 function comparableFilter()

--- a/objects/kheAA/kheAA_terminal/kheAA_terminal.object
+++ b/objects/kheAA/kheAA_terminal/kheAA_terminal.object
@@ -7,7 +7,7 @@
   "category": "wire",
   "price": 500,
   "description": "Provides access to the contents of connected storage containers.\n^blue;Input: ^white;item network^reset; ^red;UNRELIABLE AT RANGE!^reset;",
-  "shortdescription": "Terminal",
+  "shortdescription": "Item Network Terminal",
   "race": "generic",
 
   "inventoryIcon": "kheAA_terminalicon.png",

--- a/objects/power/hydraulicdynamo/hydraulicdynamo.lua
+++ b/objects/power/hydraulicdynamo/hydraulicdynamo.lua
@@ -1,7 +1,6 @@
 require "/scripts/kheAA/transferUtil.lua"
 require "/scripts/fupower.lua"
 require "/scripts/effectUtil.lua"
-
 function init()
     power.init()
 	transferUtil.init()
@@ -12,21 +11,19 @@ function init()
 		{amount = 4, state = 'fast'},
 		{amount = 0, state = 'off'}
 	}
-	
     storage.fuels = config.getParameter("fuels")
 	storage.active = true
 	storage.active2 = (not object.isInputNodeConnected(0)) or object.getInputNodeLevel(0)
 end
 
 function onInputNodeChange(args)
-	storage.active2 = (not object.isInputNodeConnected(0)) or object.getInputNodeLevel(0)
+	onNodeConnectionChange(args)
 end
 
 function onNodeConnectionChange(args)
 	storage.active2 = (not object.isInputNodeConnected(0)) or object.getInputNodeLevel(0)
+	power.onNodeConnectionChange(nil,0)
 end
-
-
 
 function update(dt)
 	if not deltaTime or deltaTime > 1 then
@@ -35,25 +32,20 @@ function update(dt)
 	else
 		deltaTime=deltaTime+dt
 	end
-
-
 	if (not storage.active) or (not storage.active2) then
 		animator.setAnimationState("screen", "off")
 		power.setPower(0)
 		power.update(dt)
 		return
 	end
-
 	if storage.active2 then
 		for i=0,2 do
 			if isn_slotDecayCheck(i) then isn_doSlotDecay(i) end
 		end
 			if isn_slotDecayCheckWater(3) then isn_doSlotDecay(3) end
 	end
-
 	local powerout = isn_getCurrentPowerOutput()
 	power.setPower(powerout)
-	
 	for _,dink in pairs(powerStates) do
         if powerout >= dink.amount then
             animator.setAnimationState("screen", dink.state)
@@ -61,8 +53,6 @@ function update(dt)
             break
         end
 	end
-
-	
 	power.update(dt)
 end
 
@@ -75,29 +65,21 @@ end
 function isn_slotDecayCheck(slot)
 	local item = world.containerItemAt(entity.id(),slot)
 	local myLocation = entity.position()
-
     if item and isn_slotDecayCheckWater(3) and storage.fuels[item.name] and math.random(1, storage.fuels[item.name].decayRate) == 1 then
         return true
     end
-
 	return false
 end
 
 function isn_slotDecayCheckWater(slot)
 	local item = world.containerItemAt(entity.id(),slot)
 	local myLocation = entity.position()
-
     if item and item.name == "liquidwater" and math.random(1, 4) == 1 then
         return true
     end
-
 	return false
 end
-
-
-
 function isn_doSlotDecay(slot)
-
 	world.containerConsumeAt(entity.id(),slot,1) --consume resource
 --	local waste = world.containerItemAt(entity.id(),3)
 --	local wastestack
@@ -120,13 +102,10 @@ function isn_doSlotDecay(slot)
 --	if wastestack  and (wastestack.count > 0) then
 --		world.spawnItem(wastestack.name,entity.position(),wastestack.count) --drop it on the ground
 --	end
-
 end
-
 function isn_getCurrentPowerOutput()
 	local water = world.containerItemAt(entity.id(),3)
-
-	if storage.active and water and water.name == "liquidwater" then 
+	if storage.active and water and water.name == "liquidwater" then
 		local powercount = 0
 		for i=0,2 do
 			powercount = powercount + isn_powerSlotCheck(i)


### PR DESCRIPTION
fission reactor and hydraulic dynamo were missing function calls for node connection and input changes, making them not act properly in some cases. fixed.
Renamed the item network terminal to Item Network Terminal. was Terminal
item network terminal now has a  0.1s delay before it starts searching, for performance reasons.