### PR TITLE
Travis: better JSON error messages: quote the part of file with error

### DIFF
--- a/tests/travis/check_json_assets.js
+++ b/tests/travis/check_json_assets.js
@@ -54,6 +54,36 @@ function sanitizeRelaxedJson( relaxedJson ) {
 	return sanitizedJson;
 }
 
+/**
+ * Make error from JSON.parse() more readable by adding "text before/after the position of error".
+ * Normal error like "Unexpected token { in JSON at position 1005" is inconvenient to troubleshoot.
+ * @param {Error} exception Exception thrown by JSON.parse().
+ * @param {string} sourceCode String that was passed to JSON.parse() as parameter.
+ * @return {string} Improved error message.
+ * Example of improved message:
+ * ... "path": "/a", "value": 123 } <<<SYNTAX ERROR HERE>>>{ "op": "add", "path": "/b" ...
+ */
+function addContextToJsonError( exception, sourceCode ) {
+	var errorMessage = exception.message;
+
+	var match = errorMessage.match( 'at position ([0-9]+)' );
+	if ( match ) {
+		// We are quoting symbolsToQuote before AND symbolsToQuote after the error position.
+		// As such, up to 2*symbolsToQuote symbols can be quoted.
+		var symbolsToQuote = 100,
+			position = parseInt( match[1] ),
+			quoteBefore = sourceCode.substring( 0, position ).replace( /\s+/g, ' ' ),
+			quoteAfter = sourceCode.substring( position ).replace( /\s+/g, ' ' );
+
+		quoteBefore = quoteBefore.substring( quoteBefore.length - symbolsToQuote );
+		quoteAfter = quoteAfter.substring( 0, symbolsToQuote );
+
+		errorMessage += '\n\t... ' + quoteBefore + '<<<SYNTAX ERROR HERE>>>' + quoteAfter + ' ...';
+	}
+
+	return errorMessage;
+}
+
 // This script is under tests/travis/
 var directory = __dirname + '/../..';
 
@@ -73,17 +103,18 @@ var totalCount = 0,
 	failedCount = 0;
 
 glob.sync( '**', globOptions ).forEach( ( filename ) => {
+	var jsonString = sanitizeRelaxedJson( fs.readFileSync( directory + '/' + filename ).toString() );
 	try {
-		JSON.parse( sanitizeRelaxedJson( fs.readFileSync( directory + '/' + filename ).toString() ) );
+		JSON.parse( jsonString );
 	} catch ( error ) {
-		console.log( filename, error );
+		console.log( '\n', filename, addContextToJsonError( error, jsonString ) );
 		failedCount ++;
 	}
 
-	if ( ++ totalCount % 200 == 0 ) {
+	if ( ++ totalCount % 2500 == 0 ) {
 		process.stdout.write( totalCount + ' ' );
 	}
 } );
 
-process.stdout.write( '\n' );
+process.stdout.write( '\nChecked ' + totalCount + ' JSON files. Errors: ' + failedCount + '.\n' );
 process.exit( failedCount > 0 ? 1 : 0 );


### PR DESCRIPTION
This improves messages like this: `Unexpected token { in JSON at position 1005`
with details like this:
`... "path": "/a", "value": 123 } <<<SYNTAX ERROR HERE>>>{ "op": "add", "path": "/b" ...`