### PR TITLE
Buffed Lunar Miner crewmate

### DIFF
--- a/npcs/crew/crewmemberminer.npctype
+++ b/npcs/crew/crewmemberminer.npctype
@@ -22,6 +22,12 @@
             "type" : "EphemeralEffect",
             "effect" : "nofalldamage",
             "duration" : 90
+          },
+          {
+            // Ephemeral effects gained upon leaving the ship
+            "type" : "EphemeralEffect",
+            "effect" : "fu_pickuprange2",
+            "duration" : 120
           }
         ],
         "type" : "soldier",


### PR DESCRIPTION
I expected the featherfall effect to be more powerful than I've found it to be, after a lot of testing. The duration is short enough that it's not consistent enough to rely on, but I don't want to make it a much longer duration because being up constantly would be too strong. Giving them the item magnet II buff in an effort to make them a more useful mining assistant, will test further and revise if needed.