### PR TITLE
Spirit Tree Race compatibility

### DIFF
--- a/species/spirittree.raceeffect
+++ b/species/spirittree.raceeffect
@@ -1,0 +1,57 @@
+{
+	"stats": [
+		{ "stat": "maxHealth", "effectiveMultiplier": 0.80 },
+		{ "stat": "maxEnergy", "effectiveMultiplier": 1.30 },
+		
+		{ "stat": "fallDamageMultiplier", "effectiveMultiplier": 0 },
+		{ "stat": "foodDelta", "baseMultiplier": 0.9 },
+		{ "stat": "maxFood", "effectiveMultiplier": 0.8 },
+		
+		{ "stat": "jungleslowImmunity", "amount": 1 },
+		{ "stat": "fumudslowImmunity", "amount": 1 },
+		{ "stat": "mudslowImmunity", "amount": 1 },
+		{ "stat": "fuclayslowImmunity", "amount": 1 },
+		
+		{ "stat": "iceResistance", "amount": 0.1 },
+		{ "stat": "shadowResistance", "amount": 0.2 },
+		{ "stat": "darknessResistance", "amount": 0.2 },
+		
+		{ "stat": "physicalResistance", "amount": -0.15 },
+		{ "stat": "radioactiveResistance", "amount": -0.23 },
+		{ "stat": "poisonResistance", "amount": -0.23 },
+		{ "stat": "electricResistance", "amount": -0.23 },
+		{ "stat": "fireResistance", "amount": -0.23 }
+	],
+	"diet" : "herbivore",
+	
+	// All natural environments grant buffs.
+	"envEffects": [
+		{	
+			"biomes": [ "garden", "thickjungle", "forest", "jungle", "bog", "arboreal", "arborealdark" ],
+			"stats": [
+				{ "stat": "protection", "effectiveMultiplier": 1.15 },
+				{ "stat": "maxHealth", "effectiveMultiplier": 1.1 }
+			]
+		}
+	],
+	
+	// Wands / Staves grant bonus power.
+	"weaponEffects": [
+		{
+			"weapons": [ "wand", "staff" ],
+			"stats": [
+				{ "stat": "powerMultiplier", "effectiveMultiplier": 1.12 }
+			]
+		}
+	],
+	"scripts" : [
+		{
+			"script" : "/scripts/fr_scripts/healthRegen.lua",
+			"args" : {
+				"healingRate" : 0.01
+			}
+		}
+	]
+	//Note: Species patch mentions Glow in the Dark / Bioluminescense.
+	//GLOW IN THE DARK SHOULD NOT BE APPENDED HERE. This effect is now included vanilla via a passive race status effect similar to novakidglow.
+}

--- a/species/spirittree.species.patch
+++ b/species/spirittree.species.patch
@@ -1,0 +1,27 @@
+[
+{
+"op": "replace",
+"path" : "/charCreationTooltip/description",
+"value" :
+"Spirits are a kind of unique creatures. They are in the state of animals when they are young. They will remain as plants after death or growth. Only they can use and see the spiritual light in this world.
+
+  ^orange;Diet^reset;: Herbivore
+
+^orange;Perks^reset;
+  +^green;20^reset;% Speed, Jump. Energy x^green;1.3^reset;
+  +^green;1^reset;% Health Regen, -^green;10^reset;% Hunger Drain
+  ^cyan;Immune^reset;: Jungle Slow, Mud Slow, Clay Slow, Fall Damage
+  ^green;Resist^reset;: +^green;20^reset;% Shadow, Darkness, +^green;10% Ice^reset;
+  Glows
+
+^orange;Environment^reset;:
+  ^yellow;Jungle, Forest, Bog, Arboreal: ^reset; Defense x^green;1.15^reset;, Health x^green;1.1^reset;
+
+^orange;Weapon Bonuses^reset;:
+  Wand/Staff: Damage x^green;1.12^reset;
+
+^red;Weaknesses^reset;
+  ^red;Resist^reset;: -^red;23^reset;% Poison, Radioactive, Electric, Fire, -^red;15^reset;% Physical
+  Health x^red;0.8^reset;, Max Food x^red;0.8^reset;"
+}
+]


### PR DESCRIPTION
FR Support for Spirit Tree. They have the exact same stats as Spirit Guardian (Since the former is a remake of the latter)