### PR TITLE
Updated mech radio messages

### DIFF
--- a/radiomessages/mech.radiomessages.patch
+++ b/radiomessages/mech.radiomessages.patch
@@ -44,7 +44,7 @@
     "path": "/testdrive04",
     "value": {
       "unique": false,
-      "text": "Remember, you can create a ^orange;Mech Repair tool^reset; at your ^orange;Tinker Table^reset; and upgrade it to be more effective at a ^orange;Tool Upgrade Station^reset;.",
+      "text": "Remember, you can create a ^orange;Mech Repair tool^reset; at your ^orange;Tinker Table^reset; and upgrade it to be more effective using your ^orange;Tricorder's upgrade menu^reset;.",
       "portraitImage": "yell.<frame>",
       "textSpeed": 70
     }
@@ -54,7 +54,7 @@
     "path": "/futestdrive03b",
     "value": {
       "unique": false,
-      "text": "Your mech switches to a ground-movement configuration when in an environment with gravity, you can manually switch from ground-movement to flight-Mode ^#FF1493;double tapping the [UP] key^reset;. I would advise you continue to proceed in your mech.",
+      "text": "Your mech switches to a ground-movement configuration when in an environment with gravity, you can manually switch from ground-movement to flight-mode by ^#FF1493;double tapping the [UP] key^reset;, even on planets. Do so now to continue.",
       "portraitImage": "yell.<frame>",
       "textSpeed": 70
     }
@@ -131,7 +131,7 @@
     "path": "/biomeelectric_mech",
     "value": {
       "unique": false,
-      "text": "WARNING: Your vehicle is not certified \nfor this ^#6A5ACD;electric^reset; environment!\nDisregarding this warning may cause pilot death and/or invalidation of vehicle warranty.",
+      "text": "WARNING: Your vehicle is not certified \nfor this ^#6A5ACD;electrically charged^reset; environment!\nDisregarding this warning may cause pilot death and/or invalidation of vehicle warranty.",
       "portraitImage": "yell.<frame>",
       "textSpeed": 70
     }

--- a/radiomessages/mech.radiomessages.patch
+++ b/radiomessages/mech.radiomessages.patch
@@ -131,7 +131,7 @@
     "path": "/biomeelectric_mech",
     "value": {
       "unique": false,
-      "text": "WARNING: Your vehicle is not certified \nfor this ^#6A5ACD;electrically charged^reset; environment!\nDisregarding this warning may cause pilot death and/or invalidation of vehicle warranty.",
+      "text": "WARNING: Your vehicle is not certified \nfor this ^#6A5ACD;electrically-charged^reset; environment!\nDisregarding this warning may cause pilot death and/or invalidation of vehicle warranty.",
       "portraitImage": "yell.<frame>",
       "textSpeed": 70
     }


### PR DESCRIPTION
Clarified that you can use mech flight on planets - this came up in discord and multiple people didn't understand that the flight could be used both on planets and in zero-g space locations, so I've made it explicit.

Also removed a reference to the tool upgrade table, and changed 'electric environment' to 'electrically-charged environment'.