### PR TITLE
Crew things

### DIFF
--- a/npcs/crew/crewmemberprecursor.npctype
+++ b/npcs/crew/crewmemberprecursor.npctype
@@ -21,7 +21,7 @@
             // Ephemeral effects gained upon leaving the ship
             "type" : "EphemeralEffect",
             "effect" : "researchBonus2",
-            "duration" : 120
+            "duration" : 300
           },
           {
             // Ephemeral effects gained upon leaving the ship

--- a/npcs/crew/crewmemberresearcher.npctype
+++ b/npcs/crew/crewmemberresearcher.npctype
@@ -21,10 +21,10 @@
             // Ephemeral effects gained upon leaving the ship
             "type" : "EphemeralEffect",
             "effect" : "researchBonus",
-            "duration" : 120
+            "duration" : 300
           }
         ],
-        "type" : "chemist",
+        "type" : "medic",
         "name" : "Researcher",
         "field" : "Researcher",
         "uniformColorIndex" : 3


### PR DESCRIPTION
Increased the buff durations on the researcher and precursor drone - it was hard to keep their buffs up reliably even when actively exploring or mining, due to the infrequency of crewmates reapplying their buffs. Also changed the researcher's crewtype from chemist to medic to give more of a compelling reason to bring them along over a soldier.