### PR TITLE
Fix Pharitu bonus to Magnorbs not being applied

### DIFF
--- a/species/juux.raceeffect
+++ b/species/juux.raceeffect
@@ -78,7 +78,7 @@
 			]
 		},		
 		{
-			"weapons": ["magnorbs"],
+			"weapons": ["magnorb"],
 			"stats": [
 				{
 					"stat": "powerMultiplier",


### PR DESCRIPTION
All magnorb weapons are tagged "magnorb",
but Pharitu racial bonus is added to items tagged "magnorbs" (there are no such items, so the bonus wasn't applied).