### PR TITLE
Fix typo in dockingfieldsmall.recipe (crafts the wrong item)

### DIFF
--- a/recipes/fu_shipcraftingtable/furniture/dockingfieldsmall.recipe
+++ b/recipes/fu_shipcraftingtable/furniture/dockingfieldsmall.recipe
@@ -3,7 +3,7 @@
 	{ "item" : "money", "count" : 300 }
   ],
   "output" : {
-    "item" : "dockingfield",
+    "item" : "dockingfieldsmall",
     "count" : 1
   },
   "groups" : [ "fu_shipcrafting", "furniture", "all" ],


### PR DESCRIPTION
There is already dockingfield.recipe that crafts "dockingfield".