### PR TITLE
JSON linter: don't skip .metadata

### DIFF
--- a/tests/travis/check_json_assets.js
+++ b/tests/travis/check_json_assets.js
@@ -102,7 +102,9 @@ var globOptions = {
 var totalCount = 0,
 	failedCount = 0;
 
-glob.sync( '**', globOptions ).forEach( ( filename ) => {
+var filenames = glob.sync( '**', globOptions ).concat( [ '.metadata' ] );
+
+filenames.forEach( ( filename ) => {
 	var jsonString = sanitizeRelaxedJson( fs.readFileSync( directory + '/' + filename ).toString() );
 	try {
 		JSON.parse( jsonString );


### PR DESCRIPTION
Previously `.metadata` wasn't linted, because files that start with `.` are skipped.