### PR TITLE
Duplicate cell ingredients

### DIFF
--- a/dungeon_worlds.config.patch
+++ b/dungeon_worlds.config.patch
@@ -52,12 +52,6 @@
 		"path": "/outpost/environmentStatusEffects",
 		"value": ["nofallinvis"]
 	},
-	//Player Space Stations - Change tier from 6 to 5, change size from 1650x500 to 64000x24000
-	{
-		"op": "replace",
-		"path": "/playerstation/threatLevel",
-		"value": 5
-	},
 	{
 		"op": "replace",
 		"path": "/playerstation/worldSize/1",

--- a/dungeon_worlds.config.patch
+++ b/dungeon_worlds.config.patch
@@ -44,6 +44,37 @@
 	},
 	{
 		"op": "add",
+		"path": "/playerstation/environmentStatusEffects/-",
+		"value": "nofallinvis"
+	},
+	{
+		"op": "add",
+		"path": "/outpost/environmentStatusEffects",
+		"value": ["nofallinvis"]
+	},
+	//Player Space Stations - Change tier from 6 to 5, change size from 1650x500 to 64000x24000
+	{
+		"op": "replace",
+		"path": "/playerstation/threatLevel",
+		"value": 5
+	},
+	{
+		"op": "replace",
+		"path": "/playerstation/worldSize/1",
+		"value": 24000
+	},
+	{
+		"op": "replace",
+		"path": "/playerstation/worldSize/0",
+		"value": 64000
+	},
+	{
+		"op": "replace",
+		"path": "/playerstation/dungeonBaseHeight",
+		"value": 12000
+	},
+	{
+		"op": "add",
 		"path": "/nightfort",
 		"value": {
 			"primaryDungeon": "nightfort",
@@ -77,7 +108,7 @@
 			"ambientLightLevel": [80, 80, 80],
 			"biome": "thickjungle",
 			"musicTrack": "/music/scienceoutpost.ogg",
-			"environmentStatusEffects": []
+			"environmentStatusEffects": ["nofallinvis"]
 		}
 	},
 	{

--- a/dungeons/other/ship/ship1.json
+++ b/dungeons/other/ship/ship1.json
@@ -1,12 +1,21 @@
 { "backgroundcolor":"#000000",
+ "compressionlevel":-1,
+ "editorsettings":
+    {
+     "export":
+        {
+         "target":"."
+        }
+    },
  "height":159,
  "infinite":false,
  "layers":[
         {
          "compression":"zlib",
-         "data":"eJzt3T2S48YBQGHeYuRALvgEylylAyhX5FSpE9\/AZ9JxLGVKLW2VZOkEXloLC4sFGt1A\/4Lfq3q1szMYAgRBvGkQBH98PB4\/kiRJkiR5c\/9NkiSLqr0kSdZVe0mSrKv2kiRZV+0lSbKu2kuSZF21lyTJumovSZJ11V6SJOuqvSRJ1lV7SZKsq\/aSJFlX7SVJsq7aS5JkXbWXJMm6ai9JknXVXpIk63qlvQAAvALaCwBAXbQXAIC6aC8AAHXRXgAA6qK9AADURXsBAKiL9iLEd28fCwC4jvbiiHV\/NRgArqG9iEWDASAP2otUNBgArqG9OIP+AsB5tBdX0GAASEd7cZWt\/mowAOyjvciF\/gJAHNqLnBgDA8Ax2osSaDAA7KO9KMVef7UYwKujvShJSn+\/+SAA3B3tRWli+\/vNSgC4K9qLGpztrw4DuCPai1rE9HevvRoM4E5oL2qS0t\/pgzoM4G5oL2qT2t5ZY2IAd0F70YKj9xvNPf31ZIsBoGe0Fy0409610yNtXKzNAHpBe9GKZXc\/\/+wPn8S0d6vF89e\/JPyeNgOojfaiJTnbu5x2r71Xm6zNAHKgva9Hb9dzbNXeqYDaDCAG7X1Nerqucqv2ptz2mePeIwmgLtr7uvT02Qa52jvfj2Vj37394S+LaX59+\/hnuSzR9Kt\/DyzVXaA92vva9NTfJbnbO3+9bm+J1oXeF1XalPnqLtAO7cWT3hp8l\/bWHAOnzHd6nD8+DuA62ouZlp+xW\/qYc8\/tnT67bup832W47wDOo71Y06K\/e+2dEk1pb+ptp7ic95E52rt+nTnmtewz63d53zQYOI\/2YovaY+C99p411N4SY92YMXCrcW+OMe5Hy\/vQYOAq2os9avZXe\/O3dz3GzTFfDQbyoL0IUau\/uY45p7Q39bbPLEfr9paYp3EwcB3txRGhz\/srRUq7tqaNaW+Oc622+tbLec612qvBQDraixhq91d727b3ynJMj+0GXxG4G9qLWI4+8\/4Kua8pOS18tzqneZT2Xrme1pX2bq3DK2ov8CnaixRK9XfU9\/futTfXdStTlmVrvlfa25N\/ixAYCe1FKkf9PdPgo\/bunuezOtcotb05rt8cWo6U5U\/93tF8z7T3o2k6Mqa9GoyR0F6cIaa\/KQ1u1d7Qbad4h\/a2HtuGTGmv\/mIEtBdnie1vTIdHPeZ8tBy1z7XKPaYvZen26i96R3txhVztXfP\/8VmivVxTssY8Ssy3xt8Itdqrv+gZ7cVVYttba\/x31Oyay9HCK\/cztN5aqr24G9qLHMSMc2v25zm+\/cvjU2tfU7JkW6cOluXuAqXQXuRi3d6913B\/frvuu43vLfeZy\/a+e9tu7zSoz\/W597PWrbq7QC60FzlJae\/3F3y3+v+6vzHtLXEe1Oer84VDr22upz07j637Mw1o7LJ\/+96v3vv1e\/++8OsP3\/+2wDJpMXKjvchNTHtj+vrDwqP2fr9q7xSwRnv33v+7fD\/PPG3q9R1j2ht7357T\/enxu0fLMU8XM\/08zdZypFwLbOuxi2nv3u\/GrpPQ\/LUYOdBelOBqe3\/YMKW9KePe0PtbU3+2bO96urPt3ZvHyO2NuR7mVqOnR\/y49+zfT+tl\/uqDqS0GQmgvShBq758\/C\/vTh33x2uf352nevW3\/bm\/tDbU0pb3L+cS2N\/Ya0LXbu\/7bZO\/vhr37H9PeK+89Xq+7ub1b006PuBYDa7QXpTj7eu9PO+PenwLj3t5e7+2hvbFjvFHaO6+D2GPOZw2Ne4+cFuowQmgvSnH2mPOZ9l455lyyvTHTnp3H3du7Z8\/t1WHEor0oRcv2TgFjpjlr6P0\/V6aN\/b1lP+ZmhFy2t4QpyxG77DHtjZlnaFm2vn+l51uP0dOz1wxx3ZDx0V6Uovdxbwl7Gvdqbz\/t3evwlfbq79hoL0rR+7lWNdpb+\/Xe1M9w6OmYc+yyj3LMOeR8m1fbq8Xjor0oRc1zrc6Me6cCtn6P0VG\/1u877rm9I55r1bq9+jsO2osSXHl\/71Z31+\/xHe1cqyvtnafJ1d7lv9ob394SlmivHo+B9iI3V69rdaa9V99jFBpn5mjveh6x7V3+\/NXau6f26u8d0F7kJMf1nHO0dwq43sfGHOc9096tazOltHer13vtne9bq88NzmHsste4nvNWe6\/0fG2L9upvX2gvchH7OUZH51qF2nt0rtU87zPXtYoZc8a2d298N9\/mUXu3vr83jyly2e7iPK7dau\/y51dcrtM7tVd\/+0F7kYO9z+9dfj3vd0qOe0do7960Z+Yxnfj90a3R3uW6vVt79bcPtBdX2eruVoefzPueo\/bGXHc3V3v\/t5\/N\/HrvbMn2TqvvTxvOP3ueI967ofuxtPQx5\/U6vWN79bc92osrxDZ3Ztnevf7O7V2Od+f\/b417f3673t5c1mrvtPretLg\/y\/OoSrX3XwXb2\/pcq611e8f26m9btBdnSe3uzFF\/U9r789v59k4FPHudyNR5bLUipr1H5zIfOXf3t0V\/c9zmur2h4x0p7T37WUbT49N1nKL24gjtxRnOdve7xT42dK7VXntjr2s1Bcw91m3p8v7cqb2h+1x63Lu1bnP\/rvZCe5HKme6up5n3QbnHvfPttrqmZKvu1mzv+pjzXdtbsr\/aC+1FLCnnVB39bqi9e+c6b013pb1TJnPfXup8a7e3xri35WcprL3yuGw9TtqLJ9qLGHJ290x\/Y7rb4pqSZz4zt5TaW6a9Z1p91N\/53C3tfV20F0ecbe7R7x6198hQe6eAudsbey3EFu2dl22EY869XFNyq5Op5zlPG\/\/vTe1ti\/YixJXuxvz+sr9LY1ubY9w7N2D59fr\/669D7Y35\/RJf12pvqXHvaO3dO0d6r789inZoL7bY62xsc\/duY6+9T2Laqr2v3d7pEX9tjRrtPfpezuXQ3nuhvVhzdawbcxvr29nbN2x1Ncaar\/eOdMy552trHK3HKXF9pE6\/55X2zsvRm\/rbHu3FkqvNjbmdrdvK3aEpYO594nyfct1eTku1t4RH6zH3dpDilfbmvibl1dv7auM2UB\/txUyO5oZu58ptxjLvS0Lj3uX4KvY6RzH7tJTby23OMXfupub+uyplO8jltPG9Udurv32gvcjZx5bdnUltb659Yq1jzlvL3HN7l9cbu2oKudf7FPE4jNbeeZ2eWb+4hva+Njnb2EN3nzz3Iev2zuZu7\/r13lrj3FB7kZe9\/o7eXttKW7T3dcnZxV66O7Ns79LU9h71L9e5Vjn+BtDecmz1d9T26m4faO\/rUaKJPXX3yRRw75yeve6GWtlje+1Xy7Du78jaRtqjva9FiR72NuadSe3X9Dg+pjhKe+1by3DlMepRtEN7cYUemztzdn80Pe7RXvvWMrTupf7eA+3FWXrubiyh\/s5qL3pBP++D9uIMd+juklDXpsf+8WjtBXAG7UUqvb6+m5PYDrds7\/QIj88B9Iv2IoW7N3eL2PbVNtRlAH2jvYjl1Zq7xZXjwqUFMA7aixh091Nat1ZvgXHRXhyhuwCQF+1FCM0FgPxoL0JoLgDkR3uxh+4CQBm0F1toLgCUQ3uxRndfm+dn3ecUwKdoL9boLgCURXuxRnsBoCzaCwBAXbQXAIC6aC8AAHXRXgAA6qK9AIBX5T8ra6G9AIA7E2rrur21Gqy9AIC7stfWGEuivQCAO3Klu6X7q70AgDuSo72lGqy9uBOtXrsB0Jacna2xH9FejE4Px48AHJP7eVmjt6X2JdqLkWn9tyuAMCWeny2bm2ufor0YmaPngQYDZbjSqi8Pfl5inr01WHsxMrHbfYm\/W1GfkuMQxNO6cT0bi\/biVbDfHpca4xAc07proxiD9o6P\/U4a9tl902I\/iDCtWzaqIe7e3js+R1vfp7vtD0dYxtbUXD9Xth+PZX5Kd6l1H0sa4k7tvVMPtii9LfSyTbZilOWsTe3HMte8ens8e1qWFPaWOcdzv+Y+p7f90sjtHXm9n6H1dvkK63qU5axBq8c317rvZfvrYRlKcXWbeOX9z4jtHXE956B1L++4Trd4lfu5x522kZbLNsL6ucqXAWPuY8x2dDSPUbfN0do70rrtAe09x6vcz5lX+Dut5nL1vi5ykftxj23vHdbnKO0d9fneA+v1cqf9KX6nZDtjtoVRtpXW6wlh9tbdnZo7M0J7beflsB8Zn5Y92doWet5Welg\/CPMq67L39trO62Idj4eepGEdoQd6bq\/tHDjmzHPBcwpoS6\/ttW8AANyVHturuQCAO9NTe2dD3U09bo08rB\/Xtf98718\/\/Hs0bS2Xy\/RF\/lUCAEnk7m3p9p49bo18jNjeL1YCuQld9+GVxDYlW3vU3prnXtoGynHUueXzsHVzt5bJtoEStG5eL2Kbmv1r2V6vBZdDe4FPad28XsQ22ouraC\/wKa2b14vY5pXaOxuzvfyjgq2fE7R\/QDlab9O9iG1esb099Lf184H2DyhL6226F7FNy\/aO0F++hkBuWm\/T7MeWndt73a3lMukvSbKkrRsXOu+l9bK1fmxIkvezddtizz3VX5LkHRyhuT01mCTJEc35PszW94UkyV6tcT2E1veRJMnWtr42EUmSJEmSPfpfwgq2Vg==",
+         "data":"eJzt3U2O48YBQGEdo7NjTuBdAB\/Ae2\/i7OytPcAYzj5HGSM38MXiXS6QETxEaDZZrCLrl\/oe8DA93WqSoii+Loqifn88Hr+TJEmSJHlz\/0OSJIuqvSRJ1lV7SZKsq\/aSJFlX7SVJsq7aS5JkXbWXJMm6ai9JknXVXpIk66q9JEnWVXtJkqyr9pIkWVftJUmyrtpLkmRdtZckybpqL0mSddVekiTreqW9AAC8AtoLAEBdtBcAgLpoLwAAddFeAADqor0AANRFewEAqIv2IsR3b38WAHAd7cUR6\/5qMABcQ3sRiwYDQB60F6loMABcQ3txBv0FgPNoL66gwQCQjvbiKlv91WAA2Ed7kQv9BYA4tBc5MQYGgGO0FyXQYADYR3tRir3+ajGAV0d7UZKU\/v7wRQC4O9qL0sT294eVAHBXtBc1ONtfHQZwR7QXtYjp7157NRjAndBe1CSlv9MXdRjA3dBe1Ca1vbPGxADugvaiBUfvN5p7+svJFgNAz2gvWnCmvWunR9q4WJsB9IL2ohXL7n5a+CSmvVstnr\/+OeH3tBlAbbQXLcnZ3uVt99p7tcnaDCAH2vt69HY9x1btnQqpzQCO0N7XpKfrKrdqb8q0Uyw13ZICqIv2vi49fbZBrvbO92PZ2A9v\/\/fnxW1+efvzz3LZW3unR\/icNAD10d7Xpqf+Lsnd3vnrdXtLtC70vqjSpsxXd4F2aC+e9Nbgu7S35hg4Zb7TI\/19WbMArqO9mGn5Gbuljzn33N5\/v103db4fMtx3AOfRXqxp0d+99k6JprQ3ddopLud9ZI72rl9njnkt+8z6Xd43DQbOo73YovYYeK+9Zw21t8RYN2YM3Grcm2OMu3R6aDBwFe3FHjX7q73527se4+aYrwYDedBehKjV31zHnFPamzrtM8vRur0l5mkcDFxHe3FE6PP+SpHSrq3bxrQ3x7lWW33r5TznWu3VYCAd7UUMtfurvW3be2U5psf59y\/tCdwN7UUsR595f4Xc15ScFj4btPz\/KO29cj2tK+3dWodX1F7gPdqLFEr1d9T39+61N9d1K1OWZWu+V9rbk99FCIyE9iKVo\/6eafBRe\/e6sD7XKLW9Oa7fHFqOlOVP\/d7RfM+0d3mbqSNj2qvBGAntxRli+pvS4FbtDU07xTu0t\/XYNmRKe\/UXI6C9OEtsf2M6POox56PlqH2uVe4xfSlLt1d\/0Tvaiyvkau+aeZ87JdrLNSVrzKPEfGv8jVCrvfqLntFeXCW2vbXGf0fNrrkcLbxyP0PrraXai7uhvchBzDi3Zn+e49u\/Pt5b+5qSJds6dbAsdxcohfYiF+v27r2G+\/Htuh82vrfcZy7b++Ftu73ToH4KHFNu3aq7C+RCe5GTlPb+44IfVv9f9zemvSXOg\/q0mmbotc31bc\/OY+v+TAMau+y\/ffabz3772R8Xfvvl+78VWCYtRm60F7mJaW9MX79feNTeub8x++8a7d17\/+\/y\/Tyfdn529N6fmPbG3rfn7f7y+MOj5ZhvF3P7+TZby5FyLbCtxy6mvXu\/G7tOQvPXYuRAe1GCq+39fsOU9qaMe0Pvb0392bK969udbe\/ePEZub8z1MLcaPT3ix71n\/35aL\/M3X0xtMRBCe1GCUHt\/fQv705d98dqfFrf5sPO7vbU31NKU9i7nE9ve2GtA127v+m+Tvb8b9u5\/THuvvPd4ve7m9m7ddnrEtRhYo70oxdnXe5+N3Rr3\/vS2P+7t7fXeHtobO8Ybpb3zOog95nzW0Lj3yOmhw4hDe1GKs8ecz7T3yjHnku2Nue3Zedy9vXv23F4dRizai1K0bO8UMOY2Zw29\/+fKbWN\/b9mPuRkhl+0tYcpyxC57THtj5hlalq3vX+n51mP09Ow1Q1w3ZHy0F6Xofdxbwp7GvdrbT3v3Onylvfo7NtqLUvR+rlWN9tZ+vTf1Mxx6OuYcu+yjHHMOOU\/zanu1eFy0F6Woea7VmXHvVMDW7zE66tf6fcc9t3fEc61at1d\/x0F7UYIr7+\/d6u76Pb6jnWt1pb3zbXK1d\/mv9sa3t4Ql2qvHY6C9yM3V61qdae\/V9xiFxpk52rueR2x7lz9\/tfbuqb36ewe0FznJcT3nHO2dAq73sTHHec+0d+vaTCnt3er1Xnvn+9bqc4NzGLvsNa7nvNXeKz1f26K9+tsX2otcxH6O0dG5VqH2Hp1rNc\/7zHWtYsacse3dG9\/N0zxq79b39+YxRS7bXZzHtVvtXf78ist1eqf26m8\/aC9ysPf5vcuv5\/1OyXHvCO3du+2ZeUwnfn90a7R3uW7v1l797QPtxVW2urvV4SfzvueovTHX3c3V3qe5X++dLdneafX9acP5Z89zxHs3dD+Wlj7mvF6nd2yv\/rZHe3GF2ObOLNu719+5vcvx7vz\/rXHvx7fr7c1lrfZOq+9Ni\/uzPI+qVHv\/XrC9rc+12lq3d2yv\/rZFe3GW1O7OHPU3pb0f3863dyrg2etEps5jqxUx7T06l\/nIubv\/XPQ3xzTX7Q0d70hp79nPMpoe79dxitqLI7QXZzjb3e8W+9jQuVZ77Y29rtUUMPdYt6XL+3On9obuc+lx79a6zf272gvtRSpnuru+zbwPyj3unafb6pqSrbpbs73rY853bW\/J\/movtBexpJxTdfS7ofbuneu8dbsr7Z0ymXt6qfOt3d4a496Wn6Ww9srjsvU4aS+eaC9iyNndM\/2N6W6La0qe+czcUmpvmfaeafVRf+dzt7T3ddFeHHG2uUe\/e9TeI0PtnQLmbm\/stRBbtHdethGOOfdyTcmtTqae5zxt\/L83tbct2osQV7ob8\/vL\/i6NbW2Oce\/cgOXX6\/+vvw61N+b3S3xdq72lxr2jtXfvHOm9\/vYo2qG92GKvs7HN3ZvGXnufxLRVe1+7vdMj\/toaNdp79L2cy6G990J7sebqWDdmGuvp7O0btroaY83Xe0c65tzztTWO1uOUuD5Sb7\/nlfbOy9Gb+tse7cWSq82Nmc7WtHJ3aAqYe58436dc08tpqfaW8Gg95t4OUrzS3tzXpLw6vW82poH6aC9mcjQ3NJ0r04xl3peExr3L8VXsdY5i9mkp08ttzjF37qbm\/rsqZTvI5bTxvVHbq799oL3I2ceW3Z1JbW+ufWKtY85by9xze3\/NuGwp5F7vU8TjMFp753V6Zv3iGtr72uRsYw\/dffLch6zbO5u7vevXe2uNc0PtRV72+jt6e20rbdHe1yVnF3vp7syyvUtT23vUv1znWuX4G0B7y7HV31Hbq7t9oL2vR4km9tTdJ1PAvXN69robamWP7bVfLcO6vyNrG2mP9r4WJXrY25h3JrVf0+P4mOIo7bVvLcOVx6hH0Q7txRV6bO7M2f3R9LhHe+1by9C6l\/p7D7QXZ+m5u7GE+jurvegF\/bwP2osz3KG7S0Jdmx77x6O1F8AZtBep9Pr6bk5iO9yyvdMjPD4H0C\/aixTu3twtYttX21CXAfSN9iKWV2vuFleOC5cWwDhoL2LQ3fe0bq3eAuOivThCdwEgL9qLEJoLAPnRXoTQXADIj\/ZiD90FgDJoL7bQXAAoh\/Zije6+Ns\/Pus8pgPdoL9boLgCURXuxRnsBoCzaCwBAXbQXAIC6aC8AAHXRXgAA6qK9AIBX5b8ra6G9AIA7E2rrur21Gqy9AIC7stfWGEuivQCAO3Klu6X7q70AgDuSo72lGqy9uBOtXrsB0Jacna2xH9FejE4Px48AHJP7eVmjt6X2JdqLkWn9tyuAMCWeny2bm2ufor0YmaPngQYDZbjSqq8Pfl5inr01WHsxMrHbfYm\/W1GfkuMQxNO6cT0bi\/biVbDfHpca4xAc07proxiD9o6P\/U4a9tl902I\/iDCtWzaqIe7e3js+R1vfp7vtD0dYxtbUXD9Xth+PZX5Kd6l1H0sa4k7tvVMPtii9LfSyTbZilOWsTe3HMte8ens8e1qWFPaWOcdzv+Y+p7f90sjtHXm9n6H1dvkK63qU5axBq8c317rvZfvrYRlKcXWbeOX9z4jtHXE956B1L++4Trd4lfu5x522kZbLNsL6ucrXAWPuY8x2dDSPUbfN0do70rrtAe09x6vcz5lX+Dut5nL1vi5ykftxj23vHdbnKO0d9fneA+v1cqf9Kf6gZDtjtoVRtpXW6wlh9tbdnZo7M0J7beflsB8Zn5Y92doWet5Welg\/CPMq67L39trO62Idj4eepGEdoQd6bq\/tHDjmzHPBcwpoS6\/ttW8AANyVHturuQCAO9NTe2dD3U09bo08rB\/Xtf\/67N++\/Ht021oul+mr\/KsEAJLI3dvS7T173Br5GLG9X60EchO67sMriW1KtvaovTXPvbQNlOOoc8vnYevmbi2TbQMlaN28XsQ2NfvXsr1eCy6H9gLvad28XsQ22ouraC\/wntbN60Vs80rtnY3ZXj5WsPVzgvYPKEfrbboXsc0rtreH\/rZ+PtD+AWVpvU33IrZp2d4R+svXEMhN622a\/diyc3uvu7VcJv0lSZa0deNC5720XrbWjw1J8n62blvsuaf6S5K8gyM0t6cGkyQ5ojnfh9n6vpAk2as1rofQ+j6SJNna1tcmIkmSJEmyR\/8H1H4dWA==",
          "encoding":"base64",
          "height":159,
+         "id":1,
          "name":"back",
          "opacity":0.5,
          "type":"tilelayer",
@@ -17,9 +26,10 @@
         }, 
         {
          "compression":"zlib",
-         "data":"eJzt3U1y7LYVBlDtIh44WVamXr0nGdk7SF65VOlHk8QFCeAC5DlVt+wntUgQf1+z1ZK+vgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAkX77KABgHBkMADl++5LDAJBhm8FyGADG2MtgOQwA\/clgABjvKH9lMAD0JYMBII8MBoAcMhgAcng9GgDyyF8AGM89MADkkL8AMJ7vBQPAeGf5K4MBoI9tzsphAOjrKFvdEwNAO\/\/65eeK5KkcBoDrrmTvVum+WDYDwL5\/Xszer6+6\/O1VALA1e060yN7IY+QvAKPNmhWjsreHWfsUgLnMlhcrZ+\/n8VcqAHLMshffyd5ZZGep3AVYS8a+3OJ9zsTpX4A5jczgp2VvVvtrz+s+GWA+Gfvuk15znv28XqsGmNfIfVf2zn1eGQwwzqh7n8\/svVq\/n9ST38c08rzZ1wrwJr0zpkX21rZf9t4\/pwwG6Ktn1qz+872jzjHTeT\/PLYMB+mqVwa3e5yx783NPBgP01yJ\/n5q9NXX2PepSzZh3K792D7CKVvtmi9ecIznV05vve7dkL0BfLfbPJ\/yM0epGvx+8VP8OFMDb3clg2Zvr9+wGXCSDAf5yJX9lb55Vc\/eT\/AX4S00Gy94cT8jdb\/IX4C9n+fu0v6Wwmifl7jf5CzD+\/TkztGG1ehLZC7zR0b2s7FUtxrIk67wAsyh9D\/fX\/33+P\/+I14\/Hb0X3zCfvq9kZOVMGZ58fIFvk\/VPR\/N3L3W+yd91r22v71fwbde8MMLPoe5d\/\/eXvr1V\/1lnufn39\/xzZv9cqy8rXVvO86ehxvXNRFgMrqfm5oV9\/Oa4S973rXtuKbZfDwMxG\/cyu7F332lZu+zc5DMxE9o6x8rWt3PY9chjIJnvHWPnaVm57iRwGMozOXu+1Ws\/Kba\/xmb2Rv8\/k7zYBV81439uj7vy9+5a1opXbnkH+AiVvyd4fnvi7kZmTe2HgzIzZ25P8JYP8BT698ed75S8ZfG8Y+Db691rdfUwr8pcZyF94p8\/srXk\/Um3N+D5n+csM5C+8z6jv90ZktKNn\/vZ+z\/SstafVsZ\/6fEn+wvMd\/f3ebFnt6LGfvzV3e2ev\/AWeILJvjm5Lhpb7+TZ398zQ31GztFX+AquruWcZJbsNLfbzSO5+BT4\/k5naKn+BVV15zXBkuzLd2c+jufsVfMwsZmvr0\/NX9sKzlPL2cz\/LfJ\/zEyo6FiuYsa1Xx2WFrJa98Aw1GdFrn625F1y9WvXHLGZt61PzV\/bC+mozYobsHXnOLDO3bWultp5ZJX9lL6xrtnsy2fuzmdu2tVJbS1bIX9kL67mTudtj9GjXTL\/XineaPX9lL6zlbubuHauVjPteOJL9noAW7xkAcvVYt72Od\/cx0Ep2vspeWFOv9Zq1p9h31lT782Ezvs47C\/kLc+u1Rns\/n\/f93me5+nPZ8vectQBz6f28+Og+dfv3F\/acPaZHm6P7fs+\/jVjze0V6Pm\/JbFfN2PZ4LvdU8hfyjXgtquc5Wh\/3e89tlQk9jcy2Gp9\/w2pk2+Rv2W8f\/51hDsMbjVh\/vbOq5bFX22tn3T\/\/efD6RUnkNZCWxzh67FPzd8a5Am8y6t5t5D31XSvusU\/L3pk8LX9nnCfwFiNfLx2d73esurfO9Pr3pydk7w9Pyt\/Z5gi8xcg9Oivjr3w\/b+U9dbbvP397Svb+0Pp7yNkFjDF63WWe704Gr2jWvfVJ2ftDdl7KX+BMxvo+e2\/N3ueelL+z7qtPy94jd98bFvn6mvxs8V41YB2z7f0RT7gPlr0A7zTbvn\/Vijk8Y+7+IHsB+pltz29l1hxe5Xt4shegvVn3\/B6y3xezSt5+kr0Abc2+7\/eUnbWr9LvsBWhjtf2\/p9r3k\/Z+\/GxkL8B9MpcashfgHrlLLdkLcI3XmLlK9gLUk7ncIXsB4tzrvtPvjUv2AsTIXAAYR+4CAAAAAAAAAAAAAAAAAAAAAADwJn8ECwC4Jpq1Mhj4Zn9Y392939jX08fAFfaJtfXOW+P\/d\/oWftZ67v85sO0Z7Blryszbt469PoWftZznf27qyfPfXrGG7Dx96zzI7r8n9SXP0np+H+XuE+e\/fWNe2fv8m+dAdj89qS+f6M1jWntNRzl69Lg\/P\/79hP7aajFPIn3zpD4bJXtPH1Ezye6L0X35hDHLUOqfO\/vhCv185VpK97FHj7nblz2vKeN8n\/3SYp7xs1bzYKUaLft6M\/ty+\/i9dRxd209X2\/dX+3H2Pr7T\/qNM3f7\/2WPeXkd91KveJnt8s6u37OvL7tO9z2\/X8Z21\/SS11370\/GWVtXHkbrv3MiN6fyt7x2furPOwl+zxnbFayb6OWSu6H7Ze7zO7249n\/bta\/\/WeX9H73OysyaqzfpqtVpTdZ9uxzm5Dy7HNbnOrMWk9LmfrudX974jx7aFmLI7u2872ypb92Uuv+XX1Od7M+1KPapG5WTm9isxxnWGcVHysWo3P2T1G5nPsHlqPQ+neLJotvfo2s49Kcyh6zxs9ZulYM1bkOdmVa4p+zch+mtEM4779WPacXKFGzduzfavVsY\/O1fp8NXVmpnE\/65vSvdwqGdGqn8767ygbWrQjuy9a9E3tXCtdf9acm0nm2O+N9yxjNFPVPi\/veb6W5ywd98nZ0GJMau4pSnvs2ddnX\/vdfor0yd4xSue48rFo20f0zV477+Ru5DpmmVOZes\/9yDjW7B3ZYzWySvvlH199+mRvDe19vPU1RvvgrXVlH7zTr6v1+dF+c3a9kTV21q+lr5khd8\/mTamfzubJlT092q+ja7TRa6A0B47GaKX133KN1MzzHudvcZ6rX1tz7qfPj0iG7PVHqV+urs3ZKjJfzzI3Mt\/O+mV73L3j17R\/1Ny5mqVn8yRy7LM2ZtZIo9fB0XourZHsMem1Fo76rKY\/R43Z3bralruPyR7vbXvvzpe7\/XLWpp5zrFd\/RvMg+rVHj4mMRW3fte7rq2ux1Bela4\/uX3vHm2mO9dZ7PUTnaGnuzbYH3Dl\/ZH1H+nNkX0TatW3b3r9r+i66D17ZX7LmzJ32nPVzdLwij43kTHZdnQc18ygyv2v6NHodR2MdnVNX18SV9XT1caWPz1ItjVwXpXlTmq+z1p29887eMNNcLbW99JjosWv77sq869U3e3Pm6ONX+j167jvHn3Wu1c6JmjnZes0dfV0ks65+\/ZW+2J6r1LbSPDnaF1rN1VF1JLtdkXmX3YbW1xOZM5E1v\/fYmnWSee2117Bdf6W9JHLuUj9l982VfT9yjtrPXWl\/9HxX1sLVOVbq68i1RI9de41Xxmyvb6LzI7Ierq7RmnZF1uDdeT9LbWW3540V3QPvrIXt5\/84Oeeo6629jtI1Hl1npH9Kj+893tE96+g6rrRh9PjunXPv2qLzIHLuK23e66erc+dKn7Qat8g5o2us9Ni9tpX6p3RN0fWwam1lt+eNVbNGol93tkZWuM7o5yLXXLO\/bD834tqje2K0H+\/s7a2vdfvxs39H+\/6sP662dXvcs+Pt9Xfpus\/GetQ6O5tb0TbWrtvIcUrjcneMZ62t7Pa8sUr7zNWsyb6u6HXsPa7mOKV+jOwxPfotOk6lj0f6MTKXRo3xUVui11bbr63aXjv\/9v591L6RazOau1fGJrpmI9kaGY+aebFabWW3R\/1VV9bprPMzkhORa22Rk6P7qLQv38nPns8beo1\/6\/7MbF\/tnB3d13vZX3p87bX2uK6Znk\/2rD3ZbVLPr+h9xqp1do9wdN21WfrUvluhau7PR7Ypep9d85zAHGtfR7LbpZ5ds9+n6RPVakxHnSd6n2iezVFnstumnlnWvVJtqmYtydx5Kiq7nUoppf5es32vWZ3XVdntVkopVS6ZO1e1lH0tSiml\/l4yd44aIfsalVLq7SVz8wuAd\/jOXAAAYv4LerxaHg==",
+         "data":"eJzt3V1u5DYWBlAvIyub1zzPmpJZXxaQLGCmERhTrUjipUTyktI5wEXStlyi+PeVymX76wsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGOnXjwIAxpHBAJDj1y85DAAZthkshwFgjL0MlsMA0J8MBoDxjvJXBgNAXzIYAPLIYADIIYMBIIfXowEgj\/wFgPHcAwNADvkLAOP5XjAAjHeWvzIYAPrY5qwcBoC+jrLVPTEAtPOfX36uSJ7KYQC47kr2bpXui2UzAOz7\/WL2fn3V5W\/PAoBPs2dEi+yNHCN\/ARht1pwYlb29zNqvAMxjtqxYPXs\/z7FKAZBjlr34TvbOIjtL5S7AWjL25Rbvc57J7O2fvX0AbzUyg2VvznndJwPMJ2PffdJrzrOf12vVAPMaue\/K3rnPK4MBxhl17\/OZvVfrj5N68vuYRp43+1oB3qR3xrTI3tr2y97755TBAH31zJon\/XzvaJn5J4MBxmiVwa3e5yx783NPBgP01yJ\/n5q9NXX2PepSzZh3K792D7CKVvtmi9ecIznV05vve7dkL0BfLfbPJ\/yM0epGvx+8VP8KFMDb3clg2Zvrj+wGXCSDAf52JX9lb55Vc\/eT\/AX4W00Gy94cT8jdb\/IX4G9n+fu0v6Wwmifl7jf5CzD+\/TkztGG1ehLZC7zR0b2s7FUtxrIk67wAsyh9D\/e3\/33+3xX14\/it6J755H01OyNnyuDs8wNki7x\/Kpq\/e7n7Tfaue217bb+af6PunQFmFn3v8m+\/\/PO16s86y92vr\/+fI\/v3WmVZ+dpqnjcdHdc7F2UxsJKanxv67ZfjKnHfu+61rdh2OQzMbNTP7Mreda9t5bZ\/k8PATGTvGCtf28pt3yOHgWyyd4yVr23ltpfIYSDD6Oz1Xqv1rNz2Gp\/ZG\/n7TP5uE3DVjPe9PerO37tvWStaue0Z5C9Q8pbs\/eGJvxuZObkXBs7MmL09yV8yyF\/g0xt\/vlf+ksH3hoFvo3+v1d1jWpG\/zED+wjt9Zm\/N+5Fqa8b3OctfZiB\/4X1Gfb83IqMdPfO393umZ609rR77qc+X5C8839Hf782W1Y4e+\/lbc7d39spf4Aki++botmRouZ9vc3fPDP0dNUtb5S+wupp7llGy29BiP4\/k7lfg8zOZqa3yF1jVldcMR7Yr0539PJq7X8FjZjFbW5+ev7IXnqWUt5\/7Web7nJ9Q0bFYwYxtvTouK2S17IVnqMmIXvtszb3g6tWqP2Yxa1ufmr+yF9ZXmxEzZO\/Ic2aZuW1bK7X1zCr5K3thXbPdk8nen83ctq2V2lqyQv7KXljPnczdPkaPds30e614p9nzV\/bCWu5m7t5jtZJx3wtHst8T0OI9A0CuHuu21+PdPQZayc5X2Qtr6rVes\/YU+86aan8+bMbXeWchf2FuvdZo7+fzvt\/7LFd\/Llv+nrMWYC69nxcf3adu\/\/7CnrNjerQ5uu\/3\/NuINb9XpOfzlsx21Yxtj+dyTyV\/Id+I16J6nqP1437vua0yoaeR2Vbj829YjWyb\/C379eO\/M8xheKMR6693VrV87NX22ln3z98PXr8oibwG0vIxjo59av7OOFfgTUbdu428p75rxT32adk7k6fl74zzBN5i5Oulo\/P9jlX31ple\/\/70hOz94Un5O9scgbcYuUdnZfyV7+etvKfO9v3nb0\/J3h9afw85u4AxRq+7zPPdyeAVzbq3Pil7f8jOS\/kLnMlY32fvrdn73JPyd9Z99WnZe+Tue8MiX1+Tny3eqwasY7a9P+IJ98GyF+CdZtv3r1oxh2fM3R9kL0A\/s+35rcyaw6t8D0\/2ArQ3657fQ\/b7YlbJ20+yF6Ct2ff9nrKzdpV+l70Abay2\/\/dU+37S3sfPRvYC3CdzqSF7Ae6Ru9SSvQDXeI2Zq2QvQD2Zyx2yFyDOve47\/dG4ZC9AjMwFgHHkLgAAAAAAAAAAAAAAAAAAAAAAAG\/yZ7AAgGuiWSuDgW\/2h\/Xd3fuNfT19DFxhn1hb77w1\/v+kb+Fnref+XwPbnsGesabMvH3r2OtT+FnLef7Xpp48\/+0Va8jO07fOg+z+e1Jf8iyt5\/dR7j5x\/ts35pW9z795DmT305P68onePKa113SUo0fH\/fXx7yf011aLeRLpmyf12SjZe\/qImkl2X4zuyyeMWYZS\/9zZD1fo5yvXUrqPPTrmbl\/2vKaM8332S4t5xs9azYOVarTs683sy+3xe+s4urafrrbvr\/bj7H18p\/1Hmbr9\/7Nj3l5HfdSr3iZ7fLOrt+zry+7Tvc9v1\/Gdtf0ktdd+9PxllbVx5G679zIjen8re8dn7qzzsJfs8Z2xWsm+jlkruh+2Xu8zu9uPZ\/27Wv\/1nl\/R+9zsrMmqs36arVaU3Wfbsc5uQ8uxzW5zqzFpPS5n67nV\/e+I8e2hZiyO7tvO9sqW\/dlLr\/l19TnezPtSj2qRuVk5vYrMcZ1hnFR8rFqNz9k9RuZz7B5aj0Pp3iyaLb36NrOPSnMoes8bfczSY81YkedkV64p+jUj+2lGM4z79mPZc3KFGjVvz\/atVo99dK7W56upMzON+1nflO7lVsmIVv101n9H2dCiHdl90aJvauda6fqz5txMMsd+b7xnGaOZqvZ5ec\/ztTxn6XGfnA0txqTmnqK0x559ffa13+2nSJ\/sPUbpHFc+Fm37iL7Za+ed3I1cxyxzKlPvuR8Zx5q9I3usRlZpv\/zzq0+f7K2hvY+3vsZoH7y1ruyDd\/p1tT4\/2m\/Orjeyxs76tfQ1M+Tu2bwp9dPZPLmyp0f7dXSNNnoNlObA0RittP5brpGaed7j\/C3Oc\/Vra8799PkRyZC9\/ij1y9W1OVtF5utZ5kbm21m\/bB937\/Fr2j9q7lzN0rN5EnnsszZm1kij18HRei6tkewx6bUWjvqspj9HjdndutqWu8dkj\/e2vXfny91+OWtTzznWqz+jeRD92qNjImNR23et+\/rqWiz1Renao\/vX3uPNNMd6670eonO0NPdm2wPunD+yviP9ObIvIu3atm3v3zV9F90Hr+wvWXPmTnvO+jk6XpFjIzmTXVfnQc08iszvmj6NXsfRWEfn1NU1cWU9XT2u9PFZqqWR66I0b0rzdda6s3fe2RtmmqultpeOiT52bd9dmXe9+mZvzhx9\/Eq\/R8995\/FnnWu1c6JmTrZec0dfF8msq19\/pS+25yq1rTRPjvaFVnN1VB3Jbldk3mW3ofX1ROZMZM3vHVuzTjKvvfYatuuvtJdEzl3qp+y+ubLvR85R+7kr7Y+e78pauDrHSn0duZboY9de45Ux2+ub6PyIrIera7SmXZE1eHfez1Jb2e15Y0X3wDtrYfv5P0\/OOep6a6+jdI1H1xnpn9Lxvcc7umcdXceVNowe371z7l1bdB5Ezn2lzXv9dHXuXOmTVuMWOWd0jZWO3WtbqX9K1xRdD6vWVnZ73lg1ayT6dWdrZIXrjH4ucs01+8v2cyOuPbonRvvxzt7e+lq3Hz\/7d7Tvz\/rjalu3j3v2eHv9Xbrus7Eetc7O5la0jbXrNvI4pXG5O8az1lZ2e95YpX3matZkX1f0OvaOq3mcUj9G9pge\/RYdp9LHI\/0YmUujxvioLdFrq+3XVm2vnX97\/z5q38i1Gc3dK2MTXbORbI2MR828WK22stuj\/q4r63TW+RnJici1tsjJ0X1U2pfv5GfP5w29xr91f2a2r3bOju7rvewvHV97rT2ua6bnkz1rT3ab1PMrep+xap3dIxxdd22WPrXvVqia+\/ORbYreZ9c8JzDH2teR7HapZ9fs92n6RLUa01Hnid4nmmdz1JnstqlnlnWvVJuqWUsyd56Kym6nUkqpf9Zs32tW53VVdruVUkqVS+bOVS1lX4tSSql\/lsydo0bIvkallHp7ydz8AuAdvjMXAICY\/wIjLy3y",
          "encoding":"base64",
          "height":159,
+         "id":2,
          "name":"front",
          "opacity":1,
          "type":"tilelayer",
@@ -31,6 +41,7 @@
         {
          "color":"#5555ff",
          "draworder":"topdown",
+         "id":3,
          "name":"mods",
          "objects":[],
          "opacity":1,
@@ -42,10 +53,11 @@
         {
          "color":"#ff0000",
          "draworder":"topdown",
+         "id":4,
          "name":"objects",
          "objects":[
                 {
-                 "gid":5781,
+                 "gid":5895,
                  "height":96,
                  "id":1251,
                  "name":"",
@@ -57,7 +69,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4353,
+                 "gid":4444,
                  "height":44,
                  "id":1257,
                  "name":"",
@@ -69,7 +81,7 @@
                  "y":552
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1258,
                  "name":"",
@@ -81,7 +93,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1259,
                  "name":"",
@@ -93,7 +105,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1260,
                  "name":"",
@@ -105,7 +117,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1261,
                  "name":"",
@@ -117,7 +129,7 @@
                  "y":432
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1262,
                  "name":"",
@@ -129,7 +141,7 @@
                  "y":432
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1263,
                  "name":"",
@@ -141,7 +153,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1264,
                  "name":"",
@@ -153,7 +165,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1265,
                  "name":"",
@@ -165,7 +177,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1266,
                  "name":"",
@@ -177,7 +189,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1267,
                  "name":"",
@@ -189,7 +201,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1268,
                  "name":"",
@@ -201,18 +213,16 @@
                  "y":648
                 }, 
                 {
-                 "gid":5996,
+                 "gid":6115,
                  "height":64,
                  "id":1278,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -221,47 +231,43 @@
                  "y":848
                 }, 
                 {
-                 "gid":5995,
+                 "gid":6114,
                  "height":32,
                  "id":1280,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":64,
-                 "x":1648,
+                 "x":1640,
                  "y":848
                 }, 
                 {
-                 "gid":5995,
+                 "gid":6114,
                  "height":32,
                  "id":1281,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\",\"basicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":64,
-                 "x":1648,
+                 "x":1640,
                  "y":816
                 }, 
                 {
-                 "gid":5949,
+                 "gid":6068,
                  "height":24,
                  "id":1284,
                  "name":"",
@@ -273,7 +279,7 @@
                  "y":728
                 }, 
                 {
-                 "gid":5938,
+                 "gid":6057,
                  "height":18,
                  "id":1286,
                  "name":"",
@@ -285,7 +291,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":5938,
+                 "gid":6057,
                  "height":18,
                  "id":1287,
                  "name":"",
@@ -297,7 +303,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":5938,
+                 "gid":6057,
                  "height":18,
                  "id":1288,
                  "name":"",
@@ -309,7 +315,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":5938,
+                 "gid":6057,
                  "height":18,
                  "id":1289,
                  "name":"",
@@ -321,7 +327,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":5938,
+                 "gid":6057,
                  "height":18,
                  "id":1292,
                  "name":"",
@@ -333,7 +339,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":5938,
+                 "gid":6057,
                  "height":18,
                  "id":1293,
                  "name":"",
@@ -345,18 +351,16 @@
                  "y":648
                 }, 
                 {
-                 "gid":6656,
+                 "gid":6786,
                  "height":40,
                  "id":1294,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -365,7 +369,7 @@
                  "y":600
                 }, 
                 {
-                 "gid":6698,
+                 "gid":6828,
                  "height":48,
                  "id":1298,
                  "name":"",
@@ -377,7 +381,7 @@
                  "y":600
                 }, 
                 {
-                 "gid":6712,
+                 "gid":6842,
                  "height":40,
                  "id":1300,
                  "name":"",
@@ -389,7 +393,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":6753,
+                 "gid":6883,
                  "height":40,
                  "id":1306,
                  "name":"",
@@ -401,7 +405,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":6804,
+                 "gid":6934,
                  "height":16,
                  "id":1308,
                  "name":"",
@@ -413,7 +417,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":2147490489,
+                 "gid":2147490619,
                  "height":16,
                  "id":1316,
                  "name":"",
@@ -425,7 +429,7 @@
                  "y":728
                 }, 
                 {
-                 "gid":2147490518,
+                 "gid":2147490648,
                  "height":32,
                  "id":1317,
                  "name":"",
@@ -437,7 +441,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":2147490518,
+                 "gid":2147490648,
                  "height":32,
                  "id":1318,
                  "name":"",
@@ -449,7 +453,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":2147490518,
+                 "gid":2147490648,
                  "height":32,
                  "id":1321,
                  "name":"",
@@ -461,7 +465,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":2147490518,
+                 "gid":2147490648,
                  "height":32,
                  "id":1322,
                  "name":"",
@@ -473,7 +477,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":2147490518,
+                 "gid":2147490648,
                  "height":32,
                  "id":1323,
                  "name":"",
@@ -485,7 +489,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":7013,
+                 "gid":7143,
                  "height":32,
                  "id":1327,
                  "name":"",
@@ -497,7 +501,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":2147490676,
+                 "gid":2147490806,
                  "height":32,
                  "id":1328,
                  "name":"",
@@ -509,7 +513,7 @@
                  "y":728
                 }, 
                 {
-                 "gid":2147490676,
+                 "gid":2147490806,
                  "height":32,
                  "id":1329,
                  "name":"",
@@ -521,7 +525,7 @@
                  "y":728
                 }, 
                 {
-                 "gid":7027,
+                 "gid":7157,
                  "height":18,
                  "id":1331,
                  "name":"",
@@ -533,7 +537,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":7031,
+                 "gid":7161,
                  "height":16,
                  "id":1336,
                  "name":"",
@@ -545,7 +549,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":7044,
+                 "gid":7174,
                  "height":16,
                  "id":1337,
                  "name":"",
@@ -553,11 +557,11 @@
                  "type":"",
                  "visible":true,
                  "width":16,
-                 "x":2856,
-                 "y":696
+                 "x":2824,
+                 "y":648
                 }, 
                 {
-                 "gid":7043,
+                 "gid":7173,
                  "height":16,
                  "id":1338,
                  "name":"",
@@ -569,7 +573,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":2147490702,
+                 "gid":2147490832,
                  "height":40,
                  "id":1339,
                  "name":"",
@@ -581,7 +585,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":2147490702,
+                 "gid":2147490832,
                  "height":40,
                  "id":1340,
                  "name":"",
@@ -593,7 +597,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":7058,
+                 "gid":7188,
                  "height":8,
                  "id":1342,
                  "name":"",
@@ -605,7 +609,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":7058,
+                 "gid":7188,
                  "height":8,
                  "id":1344,
                  "name":"",
@@ -617,7 +621,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1364,
                  "name":"",
@@ -629,7 +633,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1365,
                  "name":"",
@@ -641,7 +645,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1367,
                  "name":"",
@@ -653,7 +657,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1368,
                  "name":"",
@@ -665,7 +669,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1369,
                  "name":"",
@@ -677,7 +681,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1370,
                  "name":"",
@@ -689,7 +693,7 @@
                  "y":792
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1371,
                  "name":"",
@@ -701,7 +705,7 @@
                  "y":792
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1376,
                  "name":"",
@@ -713,7 +717,7 @@
                  "y":456
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1377,
                  "name":"",
@@ -725,7 +729,7 @@
                  "y":512
                 }, 
                 {
-                 "gid":7089,
+                 "gid":7219,
                  "height":40,
                  "id":1389,
                  "name":"",
@@ -737,7 +741,7 @@
                  "y":584
                 }, 
                 {
-                 "gid":7098,
+                 "gid":7228,
                  "height":40,
                  "id":1391,
                  "name":"",
@@ -749,7 +753,7 @@
                  "y":656
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1394,
                  "name":"",
@@ -761,7 +765,7 @@
                  "y":560
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1395,
                  "name":"",
@@ -773,7 +777,7 @@
                  "y":560
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1396,
                  "name":"",
@@ -785,7 +789,7 @@
                  "y":472
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1397,
                  "name":"",
@@ -793,11 +797,11 @@
                  "type":"",
                  "visible":true,
                  "width":24,
-                 "x":1352,
+                 "x":1440,
                  "y":400
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1398,
                  "name":"",
@@ -809,7 +813,7 @@
                  "y":360
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1399,
                  "name":"",
@@ -821,7 +825,7 @@
                  "y":472
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1400,
                  "name":"",
@@ -833,7 +837,7 @@
                  "y":424
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1401,
                  "name":"",
@@ -845,7 +849,7 @@
                  "y":424
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1402,
                  "name":"",
@@ -857,7 +861,7 @@
                  "y":568
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1403,
                  "name":"",
@@ -869,7 +873,7 @@
                  "y":560
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1404,
                  "name":"",
@@ -881,7 +885,7 @@
                  "y":568
                 }, 
                 {
-                 "gid":7104,
+                 "gid":7234,
                  "height":24,
                  "id":1406,
                  "name":"",
@@ -893,7 +897,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":7119,
+                 "gid":7249,
                  "height":16,
                  "id":1424,
                  "name":"",
@@ -905,7 +909,7 @@
                  "y":632
                 }, 
                 {
-                 "gid":7119,
+                 "gid":7249,
                  "height":16,
                  "id":1425,
                  "name":"",
@@ -917,7 +921,7 @@
                  "y":632
                 }, 
                 {
-                 "gid":7119,
+                 "gid":7249,
                  "height":16,
                  "id":1428,
                  "name":"",
@@ -929,7 +933,7 @@
                  "y":632
                 }, 
                 {
-                 "gid":7114,
+                 "gid":7244,
                  "height":32,
                  "id":1432,
                  "name":"",
@@ -941,7 +945,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":7137,
+                 "gid":7267,
                  "height":24,
                  "id":1435,
                  "name":"",
@@ -953,7 +957,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":7164,
+                 "gid":7294,
                  "height":64,
                  "id":1439,
                  "name":"",
@@ -965,7 +969,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":7163,
+                 "gid":7293,
                  "height":32,
                  "id":1440,
                  "name":"",
@@ -977,7 +981,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":2147490806,
+                 "gid":2147490936,
                  "height":24,
                  "id":1441,
                  "name":"",
@@ -989,18 +993,16 @@
                  "y":760
                 }, 
                 {
-                 "gid":7162,
+                 "gid":7292,
                  "height":16,
                  "id":1443,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1009,18 +1011,16 @@
                  "y":840
                 }, 
                 {
-                 "gid":7162,
+                 "gid":7292,
                  "height":16,
                  "id":1444,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1029,18 +1029,16 @@
                  "y":824
                 }, 
                 {
-                 "gid":7162,
+                 "gid":7292,
                  "height":16,
                  "id":1445,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1049,18 +1047,16 @@
                  "y":848
                 }, 
                 {
-                 "gid":7162,
+                 "gid":7292,
                  "height":16,
                  "id":1446,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1069,7 +1065,7 @@
                  "y":832
                 }, 
                 {
-                 "gid":7146,
+                 "gid":7276,
                  "height":24,
                  "id":1452,
                  "name":"",
@@ -1081,7 +1077,7 @@
                  "y":640
                 }, 
                 {
-                 "gid":7146,
+                 "gid":7276,
                  "height":24,
                  "id":1453,
                  "name":"",
@@ -1093,7 +1089,7 @@
                  "y":616
                 }, 
                 {
-                 "gid":2147486491,
+                 "gid":2147486557,
                  "height":15,
                  "id":1454,
                  "name":"",
@@ -1105,7 +1101,7 @@
                  "y":432
                 }, 
                 {
-                 "gid":2830,
+                 "gid":2896,
                  "height":16,
                  "id":1458,
                  "name":"",
@@ -1117,7 +1113,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":2830,
+                 "gid":2896,
                  "height":16,
                  "id":1459,
                  "name":"",
@@ -1129,7 +1125,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":2830,
+                 "gid":2896,
                  "height":16,
                  "id":1460,
                  "name":"",
@@ -1141,7 +1137,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":2147486524,
+                 "gid":2147486590,
                  "height":24,
                  "id":1462,
                  "name":"",
@@ -1153,7 +1149,7 @@
                  "y":560
                 }, 
                 {
-                 "gid":2942,
+                 "gid":3008,
                  "height":56,
                  "id":1469,
                  "name":"",
@@ -1165,7 +1161,7 @@
                  "y":384
                 }, 
                 {
-                 "gid":3046,
+                 "gid":3112,
                  "height":24,
                  "id":1471,
                  "name":"",
@@ -1177,7 +1173,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":2147486694,
+                 "gid":2147486760,
                  "height":24,
                  "id":1472,
                  "name":"",
@@ -1189,7 +1185,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":2147486694,
+                 "gid":2147486760,
                  "height":24,
                  "id":1473,
                  "name":"",
@@ -1201,7 +1197,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":3041,
+                 "gid":3107,
                  "height":48,
                  "id":1477,
                  "name":"",
@@ -1213,7 +1209,7 @@
                  "y":624
                 }, 
                 {
-                 "gid":3155,
+                 "gid":3221,
                  "height":24,
                  "id":1480,
                  "name":"",
@@ -1225,7 +1221,7 @@
                  "y":680
                 }, 
                 {
-                 "gid":3180,
+                 "gid":3246,
                  "height":32,
                  "id":1483,
                  "name":"",
@@ -1237,7 +1233,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":3169,
+                 "gid":3235,
                  "height":40,
                  "id":1485,
                  "name":"",
@@ -1249,7 +1245,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":3169,
+                 "gid":3235,
                  "height":40,
                  "id":1486,
                  "name":"",
@@ -1261,7 +1257,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":3169,
+                 "gid":3235,
                  "height":40,
                  "id":1487,
                  "name":"",
@@ -1273,7 +1269,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":3273,
+                 "gid":3339,
                  "height":16,
                  "id":1494,
                  "name":"",
@@ -1285,7 +1281,7 @@
                  "y":632
                 }, 
                 {
-                 "gid":3273,
+                 "gid":3339,
                  "height":16,
                  "id":1498,
                  "name":"",
@@ -1297,7 +1293,7 @@
                  "y":616
                 }, 
                 {
-                 "gid":3273,
+                 "gid":3339,
                  "height":16,
                  "id":1499,
                  "name":"",
@@ -1309,7 +1305,7 @@
                  "y":616
                 }, 
                 {
-                 "gid":7489,
+                 "gid":7626,
                  "height":24,
                  "id":1509,
                  "name":"",
@@ -1321,7 +1317,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":7489,
+                 "gid":7626,
                  "height":24,
                  "id":1510,
                  "name":"",
@@ -1333,7 +1329,7 @@
                  "y":496
                 }, 
                 {
-                 "gid":7489,
+                 "gid":7626,
                  "height":24,
                  "id":1511,
                  "name":"",
@@ -1341,11 +1337,11 @@
                  "type":"",
                  "visible":true,
                  "width":56,
-                 "x":1376,
+                 "x":1368,
                  "y":432
                 }, 
                 {
-                 "gid":7489,
+                 "gid":7626,
                  "height":24,
                  "id":1512,
                  "name":"",
@@ -1353,35 +1349,11 @@
                  "type":"",
                  "visible":true,
                  "width":56,
-                 "x":1376,
+                 "x":1368,
                  "y":408
                 }, 
                 {
-                 "gid":7489,
-                 "height":24,
-                 "id":1513,
-                 "name":"",
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":56,
-                 "x":1424,
-                 "y":432
-                }, 
-                {
-                 "gid":7489,
-                 "height":24,
-                 "id":1514,
-                 "name":"",
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":56,
-                 "x":1424,
-                 "y":408
-                }, 
-                {
-                 "gid":7489,
+                 "gid":7626,
                  "height":24,
                  "id":1516,
                  "name":"",
@@ -1393,7 +1365,7 @@
                  "y":432
                 }, 
                 {
-                 "gid":7499,
+                 "gid":7636,
                  "height":40,
                  "id":1519,
                  "name":"",
@@ -1405,7 +1377,7 @@
                  "y":432
                 }, 
                 {
-                 "gid":7499,
+                 "gid":7636,
                  "height":40,
                  "id":1520,
                  "name":"",
@@ -1417,7 +1389,7 @@
                  "y":432
                 }, 
                 {
-                 "gid":7499,
+                 "gid":7636,
                  "height":40,
                  "id":1521,
                  "name":"",
@@ -1429,7 +1401,7 @@
                  "y":432
                 }, 
                 {
-                 "gid":2147487068,
+                 "gid":2147487134,
                  "height":24,
                  "id":1526,
                  "name":"",
@@ -1441,7 +1413,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":3516,
+                 "gid":3582,
                  "height":16,
                  "id":1528,
                  "name":"",
@@ -1453,7 +1425,7 @@
                  "y":472
                 }, 
                 {
-                 "gid":2147490454,
+                 "gid":2147490584,
                  "height":64,
                  "id":1541,
                  "name":"",
@@ -1465,7 +1437,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":5957,
+                 "gid":6076,
                  "height":40,
                  "id":1558,
                  "name":"",
@@ -1477,7 +1449,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":5953,
+                 "gid":6072,
                  "height":16,
                  "id":1559,
                  "name":"",
@@ -1489,7 +1461,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":5962,
+                 "gid":6081,
                  "height":24,
                  "id":1561,
                  "name":"",
@@ -1497,11 +1469,11 @@
                  "type":"",
                  "visible":true,
                  "width":48,
-                 "x":1568,
+                 "x":1560,
                  "y":520
                 }, 
                 {
-                 "gid":5968,
+                 "gid":6087,
                  "height":24,
                  "id":1563,
                  "name":"",
@@ -1513,7 +1485,7 @@
                  "y":480
                 }, 
                 {
-                 "gid":5964,
+                 "gid":6083,
                  "height":16,
                  "id":1565,
                  "name":"",
@@ -1525,7 +1497,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":5963,
+                 "gid":6082,
                  "height":16,
                  "id":1566,
                  "name":"",
@@ -1537,7 +1509,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":5963,
+                 "gid":6082,
                  "height":16,
                  "id":1567,
                  "name":"",
@@ -1549,7 +1521,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":5965,
+                 "gid":6084,
                  "height":16,
                  "id":1569,
                  "name":"",
@@ -1561,7 +1533,7 @@
                  "y":504
                 }, 
                 {
-                 "gid":2147489615,
+                 "gid":2147489734,
                  "height":40,
                  "id":1573,
                  "name":"",
@@ -1573,7 +1545,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":5967,
+                 "gid":6086,
                  "height":40,
                  "id":1575,
                  "name":"",
@@ -1585,7 +1557,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":5937,
+                 "gid":6056,
                  "height":40,
                  "id":1578,
                  "name":"",
@@ -1597,7 +1569,7 @@
                  "y":464
                 }, 
                 {
-                 "gid":6030,
+                 "gid":6149,
                  "height":40,
                  "id":1583,
                  "name":"",
@@ -1609,7 +1581,7 @@
                  "y":464
                 }, 
                 {
-                 "gid":6006,
+                 "gid":6125,
                  "height":16,
                  "id":1586,
                  "name":"",
@@ -1621,7 +1593,7 @@
                  "y":704
                 }, 
                 {
-                 "gid":6005,
+                 "gid":6124,
                  "height":16,
                  "id":1587,
                  "name":"",
@@ -1633,7 +1605,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":5938,
+                 "gid":6057,
                  "height":18,
                  "id":1588,
                  "name":"",
@@ -1645,7 +1617,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":2147489586,
+                 "gid":2147489705,
                  "height":18,
                  "id":1589,
                  "name":"",
@@ -1657,7 +1629,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":5951,
+                 "gid":6070,
                  "height":24,
                  "id":1592,
                  "name":"",
@@ -1669,7 +1641,7 @@
                  "y":480
                 }, 
                 {
-                 "gid":5962,
+                 "gid":6081,
                  "height":24,
                  "id":1593,
                  "name":"",
@@ -1681,7 +1653,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":7709,
+                 "gid":7855,
                  "height":56,
                  "id":1596,
                  "name":"",
@@ -1693,7 +1665,7 @@
                  "y":464
                 }, 
                 {
-                 "gid":7739,
+                 "gid":7885,
                  "height":16,
                  "id":1598,
                  "name":"",
@@ -1705,7 +1677,7 @@
                  "y":416
                 }, 
                 {
-                 "gid":7739,
+                 "gid":7885,
                  "height":16,
                  "id":1600,
                  "name":"",
@@ -1717,7 +1689,7 @@
                  "y":440
                 }, 
                 {
-                 "gid":7764,
+                 "gid":7910,
                  "height":40,
                  "id":1602,
                  "name":"",
@@ -1729,7 +1701,7 @@
                  "y":464
                 }, 
                 {
-                 "gid":7760,
+                 "gid":7906,
                  "height":40,
                  "id":1603,
                  "name":"",
@@ -1741,7 +1713,7 @@
                  "y":464
                 }, 
                 {
-                 "gid":7793,
+                 "gid":7939,
                  "height":40,
                  "id":1607,
                  "name":"",
@@ -1753,7 +1725,7 @@
                  "y":592
                 }, 
                 {
-                 "gid":7793,
+                 "gid":7939,
                  "height":40,
                  "id":1609,
                  "name":"",
@@ -1765,7 +1737,7 @@
                  "y":592
                 }, 
                 {
-                 "gid":7806,
+                 "gid":7952,
                  "height":32,
                  "id":1612,
                  "name":"",
@@ -1777,7 +1749,7 @@
                  "y":488
                 }, 
                 {
-                 "gid":2147487673,
+                 "gid":2147487739,
                  "height":56,
                  "id":1629,
                  "name":"",
@@ -1789,7 +1761,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":4023,
+                 "gid":4089,
                  "height":80,
                  "id":1637,
                  "name":"",
@@ -1801,18 +1773,16 @@
                  "y":760
                 }, 
                 {
-                 "gid":7162,
+                 "gid":7292,
                  "height":16,
                  "id":1639,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1821,18 +1791,16 @@
                  "y":904
                 }, 
                 {
-                 "gid":7162,
+                 "gid":7292,
                  "height":16,
                  "id":1641,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1841,7 +1809,7 @@
                  "y":904
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1646,
                  "name":"",
@@ -1853,7 +1821,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1647,
                  "name":"",
@@ -1865,7 +1833,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1648,
                  "name":"",
@@ -1877,7 +1845,7 @@
                  "y":904
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1650,
                  "name":"",
@@ -1889,7 +1857,7 @@
                  "y":904
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1651,
                  "name":"",
@@ -1901,7 +1869,7 @@
                  "y":904
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1652,
                  "name":"",
@@ -1913,7 +1881,7 @@
                  "y":816
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1653,
                  "name":"",
@@ -1925,7 +1893,7 @@
                  "y":816
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1654,
                  "name":"",
@@ -1937,7 +1905,7 @@
                  "y":816
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1655,
                  "name":"",
@@ -1949,7 +1917,7 @@
                  "y":856
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1656,
                  "name":"",
@@ -1961,7 +1929,7 @@
                  "y":856
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1657,
                  "name":"",
@@ -1973,7 +1941,7 @@
                  "y":856
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1658,
                  "name":"",
@@ -1985,7 +1953,7 @@
                  "y":856
                 }, 
                 {
-                 "gid":4460,
+                 "gid":4555,
                  "height":30,
                  "id":1659,
                  "name":"",
@@ -1997,7 +1965,7 @@
                  "y":856
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1660,
                  "name":"",
@@ -2009,7 +1977,7 @@
                  "y":400
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1661,
                  "name":"",
@@ -2021,7 +1989,7 @@
                  "y":576
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1662,
                  "name":"",
@@ -2033,7 +2001,7 @@
                  "y":656
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1663,
                  "name":"",
@@ -2045,7 +2013,7 @@
                  "y":616
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1664,
                  "name":"",
@@ -2057,7 +2025,7 @@
                  "y":488
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1665,
                  "name":"",
@@ -2069,7 +2037,7 @@
                  "y":488
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1666,
                  "name":"",
@@ -2081,7 +2049,7 @@
                  "y":584
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1670,
                  "name":"",
@@ -2093,7 +2061,7 @@
                  "y":640
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1671,
                  "name":"",
@@ -2105,7 +2073,7 @@
                  "y":640
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1672,
                  "name":"",
@@ -2117,7 +2085,7 @@
                  "y":640
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1676,
                  "name":"",
@@ -2129,7 +2097,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1679,
                  "name":"",
@@ -2141,7 +2109,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1681,
                  "name":"",
@@ -2153,7 +2121,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1682,
                  "name":"",
@@ -2165,7 +2133,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1683,
                  "name":"",
@@ -2177,7 +2145,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1685,
                  "name":"",
@@ -2189,7 +2157,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1686,
                  "name":"",
@@ -2201,7 +2169,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1692,
                  "name":"",
@@ -2213,7 +2181,7 @@
                  "y":720
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1693,
                  "name":"",
@@ -2225,7 +2193,7 @@
                  "y":720
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1694,
                  "name":"",
@@ -2237,7 +2205,7 @@
                  "y":720
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1695,
                  "name":"",
@@ -2249,7 +2217,7 @@
                  "y":720
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1696,
                  "name":"",
@@ -2261,7 +2229,7 @@
                  "y":720
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1697,
                  "name":"",
@@ -2273,7 +2241,7 @@
                  "y":720
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1698,
                  "name":"",
@@ -2285,7 +2253,7 @@
                  "y":752
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1699,
                  "name":"",
@@ -2297,7 +2265,7 @@
                  "y":752
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1700,
                  "name":"",
@@ -2309,7 +2277,7 @@
                  "y":752
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1701,
                  "name":"",
@@ -2321,7 +2289,7 @@
                  "y":776
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1705,
                  "name":"",
@@ -2333,7 +2301,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1706,
                  "name":"",
@@ -2345,7 +2313,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1707,
                  "name":"",
@@ -2357,7 +2325,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1708,
                  "name":"",
@@ -2369,7 +2337,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1709,
                  "name":"",
@@ -2381,7 +2349,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1710,
                  "name":"",
@@ -2393,7 +2361,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1711,
                  "name":"",
@@ -2405,7 +2373,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1712,
                  "name":"",
@@ -2417,7 +2385,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1713,
                  "name":"",
@@ -2429,7 +2397,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1714,
                  "name":"",
@@ -2441,7 +2409,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1715,
                  "name":"",
@@ -2453,7 +2421,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1716,
                  "name":"",
@@ -2465,7 +2433,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1717,
                  "name":"",
@@ -2477,7 +2445,7 @@
                  "y":784
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1719,
                  "name":"",
@@ -2489,7 +2457,7 @@
                  "y":624
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1720,
                  "name":"",
@@ -2501,7 +2469,7 @@
                  "y":600
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1721,
                  "name":"",
@@ -2513,7 +2481,7 @@
                  "y":576
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1724,
                  "name":"",
@@ -2525,7 +2493,7 @@
                  "y":576
                 }, 
                 {
-                 "gid":4553,
+                 "gid":4648,
                  "height":32,
                  "id":1725,
                  "name":"",
@@ -2537,7 +2505,7 @@
                  "y":640
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1730,
                  "name":"",
@@ -2549,7 +2517,7 @@
                  "y":552
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1732,
                  "name":"",
@@ -2561,7 +2529,7 @@
                  "y":552
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1733,
                  "name":"",
@@ -2573,7 +2541,7 @@
                  "y":552
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1735,
                  "name":"",
@@ -2585,7 +2553,7 @@
                  "y":552
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1736,
                  "name":"",
@@ -2597,7 +2565,7 @@
                  "y":568
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1737,
                  "name":"",
@@ -2609,7 +2577,7 @@
                  "y":568
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1738,
                  "name":"",
@@ -2621,7 +2589,7 @@
                  "y":552
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1739,
                  "name":"",
@@ -2633,7 +2601,7 @@
                  "y":712
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1741,
                  "name":"",
@@ -2645,7 +2613,7 @@
                  "y":672
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1744,
                  "name":"",
@@ -2657,7 +2625,7 @@
                  "y":672
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1747,
                  "name":"",
@@ -2669,7 +2637,7 @@
                  "y":680
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1748,
                  "name":"",
@@ -2681,7 +2649,7 @@
                  "y":680
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1749,
                  "name":"",
@@ -2693,7 +2661,7 @@
                  "y":680
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1751,
                  "name":"",
@@ -2708,18 +2676,22 @@
                  "height":8,
                  "id":1753,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"greg"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"greg"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2731,18 +2703,22 @@
                  "height":8,
                  "id":1754,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2754,18 +2730,22 @@
                  "height":8,
                  "id":1755,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2777,18 +2757,22 @@
                  "height":8,
                  "id":1756,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2800,18 +2784,22 @@
                  "height":8,
                  "id":1757,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2823,18 +2811,22 @@
                  "height":8,
                  "id":1758,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2846,18 +2838,22 @@
                  "height":8,
                  "id":1759,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2869,18 +2865,22 @@
                  "height":8,
                  "id":1762,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"bunkerguard"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"bunkerguard"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2892,18 +2892,22 @@
                  "height":8,
                  "id":1763,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"bunkerguard"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"bunkerguard"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2912,7 +2916,7 @@
                  "y":776
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1765,
                  "name":"",
@@ -2924,7 +2928,7 @@
                  "y":576
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1766,
                  "name":"",
@@ -2936,7 +2940,7 @@
                  "y":584
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1767,
                  "name":"",
@@ -2948,7 +2952,7 @@
                  "y":592
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1768,
                  "name":"",
@@ -2960,7 +2964,7 @@
                  "y":600
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1769,
                  "name":"",
@@ -2972,7 +2976,7 @@
                  "y":608
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1770,
                  "name":"",
@@ -2984,7 +2988,7 @@
                  "y":616
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":1771,
                  "name":"",
@@ -2996,7 +3000,7 @@
                  "y":624
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1772,
                  "name":"",
@@ -3008,7 +3012,7 @@
                  "y":512
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1773,
                  "name":"",
@@ -3020,7 +3024,7 @@
                  "y":456
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1775,
                  "name":"",
@@ -3032,7 +3036,7 @@
                  "y":400
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1776,
                  "name":"",
@@ -3044,7 +3048,7 @@
                  "y":400
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1777,
                  "name":"",
@@ -3056,7 +3060,7 @@
                  "y":456
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1778,
                  "name":"",
@@ -3068,7 +3072,7 @@
                  "y":512
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1779,
                  "name":"",
@@ -3080,7 +3084,7 @@
                  "y":576
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1781,
                  "name":"",
@@ -3092,7 +3096,7 @@
                  "y":576
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1782,
                  "name":"",
@@ -3104,7 +3108,7 @@
                  "y":656
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1783,
                  "name":"",
@@ -3116,7 +3120,7 @@
                  "y":616
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1784,
                  "name":"",
@@ -3128,7 +3132,7 @@
                  "y":616
                 }, 
                 {
-                 "gid":7071,
+                 "gid":7201,
                  "height":40,
                  "id":1785,
                  "name":"",
@@ -3140,7 +3144,7 @@
                  "y":656
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1786,
                  "name":"",
@@ -3152,7 +3156,7 @@
                  "y":1016
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1787,
                  "name":"",
@@ -3164,7 +3168,7 @@
                  "y":1016
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1788,
                  "name":"",
@@ -3176,7 +3180,7 @@
                  "y":1016
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1789,
                  "name":"",
@@ -3188,7 +3192,7 @@
                  "y":1040
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1790,
                  "name":"",
@@ -3200,7 +3204,7 @@
                  "y":1160
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1791,
                  "name":"",
@@ -3212,7 +3216,7 @@
                  "y":1096
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1793,
                  "name":"",
@@ -3224,7 +3228,7 @@
                  "y":1064
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1794,
                  "name":"",
@@ -3236,7 +3240,7 @@
                  "y":1032
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1795,
                  "name":"",
@@ -3248,7 +3252,7 @@
                  "y":1000
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1799,
                  "name":"",
@@ -3260,7 +3264,7 @@
                  "y":1064
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1800,
                  "name":"",
@@ -3272,7 +3276,7 @@
                  "y":1056
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1801,
                  "name":"",
@@ -3284,7 +3288,7 @@
                  "y":1056
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1802,
                  "name":"",
@@ -3296,7 +3300,7 @@
                  "y":1056
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1803,
                  "name":"",
@@ -3308,7 +3312,7 @@
                  "y":1064
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1804,
                  "name":"",
@@ -3320,7 +3324,7 @@
                  "y":1008
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1807,
                  "name":"",
@@ -3332,7 +3336,7 @@
                  "y":1064
                 }, 
                 {
-                 "gid":239,
+                 "gid":242,
                  "height":8,
                  "id":1808,
                  "name":"",
@@ -3344,7 +3348,7 @@
                  "y":1080
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1809,
                  "name":"",
@@ -3356,7 +3360,7 @@
                  "y":1088
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1810,
                  "name":"",
@@ -3368,7 +3372,7 @@
                  "y":1048
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1811,
                  "name":"",
@@ -3380,7 +3384,7 @@
                  "y":1040
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1812,
                  "name":"",
@@ -3392,7 +3396,7 @@
                  "y":1024
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1813,
                  "name":"",
@@ -3404,7 +3408,7 @@
                  "y":1016
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1814,
                  "name":"",
@@ -3416,7 +3420,7 @@
                  "y":1008
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1815,
                  "name":"",
@@ -3428,7 +3432,7 @@
                  "y":1064
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1816,
                  "name":"",
@@ -3440,7 +3444,7 @@
                  "y":1048
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1817,
                  "name":"",
@@ -3452,7 +3456,7 @@
                  "y":1056
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1818,
                  "name":"",
@@ -3464,7 +3468,7 @@
                  "y":1056
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1819,
                  "name":"",
@@ -3476,7 +3480,7 @@
                  "y":1064
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1821,
                  "name":"",
@@ -3488,7 +3492,7 @@
                  "y":1024
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1822,
                  "name":"",
@@ -3500,7 +3504,7 @@
                  "y":1024
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1823,
                  "name":"",
@@ -3512,7 +3516,7 @@
                  "y":1024
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1824,
                  "name":"",
@@ -3524,7 +3528,7 @@
                  "y":1032
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1825,
                  "name":"",
@@ -3536,7 +3540,7 @@
                  "y":1104
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1827,
                  "name":"",
@@ -3548,7 +3552,7 @@
                  "y":1104
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1828,
                  "name":"",
@@ -3560,7 +3564,7 @@
                  "y":1096
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1831,
                  "name":"",
@@ -3572,7 +3576,7 @@
                  "y":1048
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1832,
                  "name":"",
@@ -3584,7 +3588,7 @@
                  "y":1048
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1833,
                  "name":"",
@@ -3596,7 +3600,7 @@
                  "y":1096
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1834,
                  "name":"",
@@ -3608,7 +3612,7 @@
                  "y":1104
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1835,
                  "name":"",
@@ -3620,7 +3624,7 @@
                  "y":1080
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1836,
                  "name":"",
@@ -3632,7 +3636,7 @@
                  "y":1056
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1838,
                  "name":"",
@@ -3644,7 +3648,7 @@
                  "y":1080
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1839,
                  "name":"",
@@ -3656,7 +3660,7 @@
                  "y":1072
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1840,
                  "name":"",
@@ -3668,7 +3672,7 @@
                  "y":1000
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1841,
                  "name":"",
@@ -3680,7 +3684,7 @@
                  "y":1000
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1842,
                  "name":"",
@@ -3692,7 +3696,7 @@
                  "y":1008
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1843,
                  "name":"",
@@ -3704,7 +3708,7 @@
                  "y":1040
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1844,
                  "name":"",
@@ -3716,7 +3720,7 @@
                  "y":1096
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1845,
                  "name":"",
@@ -3728,7 +3732,7 @@
                  "y":1048
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1846,
                  "name":"",
@@ -3740,7 +3744,7 @@
                  "y":1016
                 }, 
                 {
-                 "gid":238,
+                 "gid":241,
                  "height":8,
                  "id":1847,
                  "name":"",
@@ -3752,7 +3756,7 @@
                  "y":1104
                 }, 
                 {
-                 "gid":5645,
+                 "gid":5759,
                  "height":16,
                  "id":1856,
                  "name":"",
@@ -3764,7 +3768,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":2876,
+                 "gid":2942,
                  "height":24,
                  "id":1869,
                  "name":"",
@@ -3776,7 +3780,7 @@
                  "y":728
                 }, 
                 {
-                 "gid":5781,
+                 "gid":5895,
                  "height":96,
                  "id":1870,
                  "name":"",
@@ -3788,7 +3792,7 @@
                  "y":648
                 }, 
                 {
-                 "gid":2147489318,
+                 "gid":2147489432,
                  "height":16,
                  "id":1871,
                  "name":"",
@@ -3800,7 +3804,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":2147489318,
+                 "gid":2147489432,
                  "height":16,
                  "id":1874,
                  "name":"",
@@ -3812,7 +3816,7 @@
                  "y":632
                 }, 
                 {
-                 "gid":5670,
+                 "gid":5784,
                  "height":16,
                  "id":1875,
                  "name":"",
@@ -3824,7 +3828,7 @@
                  "y":632
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1876,
                  "name":"",
@@ -3836,7 +3840,7 @@
                  "y":528
                 }, 
                 {
-                 "gid":5670,
+                 "gid":5784,
                  "height":16,
                  "id":1877,
                  "name":"",
@@ -3848,7 +3852,7 @@
                  "y":520
                 }, 
                 {
-                 "gid":5686,
+                 "gid":5800,
                  "height":16,
                  "id":1882,
                  "name":"",
@@ -3860,7 +3864,7 @@
                  "y":640
                 }, 
                 {
-                 "gid":5686,
+                 "gid":5800,
                  "height":16,
                  "id":1883,
                  "name":"",
@@ -3872,7 +3876,7 @@
                  "y":736
                 }, 
                 {
-                 "gid":5686,
+                 "gid":5800,
                  "height":16,
                  "id":1884,
                  "name":"",
@@ -3884,7 +3888,7 @@
                  "y":544
                 }, 
                 {
-                 "gid":5643,
+                 "gid":5757,
                  "height":8,
                  "id":1903,
                  "name":"",
@@ -3896,7 +3900,7 @@
                  "y":776
                 }, 
                 {
-                 "gid":5643,
+                 "gid":5757,
                  "height":8,
                  "id":1904,
                  "name":"",
@@ -3908,7 +3912,7 @@
                  "y":776
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":1914,
                  "name":"",
@@ -3920,7 +3924,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":5938,
+                 "gid":6057,
                  "height":18,
                  "id":1918,
                  "name":"",
@@ -3932,7 +3936,7 @@
                  "y":728
                 }, 
                 {
-                 "gid":5938,
+                 "gid":6057,
                  "height":18,
                  "id":1919,
                  "name":"",
@@ -3944,7 +3948,7 @@
                  "y":728
                 }, 
                 {
-                 "gid":5692,
+                 "gid":5806,
                  "height":32,
                  "id":1920,
                  "name":"",
@@ -3956,7 +3960,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1981,
                  "name":"",
@@ -3964,11 +3968,11 @@
                  "type":"",
                  "visible":true,
                  "width":8,
-                 "x":1368,
-                 "y":416
+                 "x":1360,
+                 "y":400
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1982,
                  "name":"",
@@ -3976,11 +3980,11 @@
                  "type":"",
                  "visible":true,
                  "width":8,
-                 "x":1512,
-                 "y":392
+                 "x":1472,
+                 "y":400
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1983,
                  "name":"",
@@ -3988,11 +3992,11 @@
                  "type":"",
                  "visible":true,
                  "width":8,
-                 "x":1480,
-                 "y":392
+                 "x":1424,
+                 "y":400
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1984,
                  "name":"",
@@ -4004,7 +4008,7 @@
                  "y":392
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1985,
                  "name":"",
@@ -4016,7 +4020,7 @@
                  "y":456
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1986,
                  "name":"",
@@ -4028,7 +4032,7 @@
                  "y":456
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1987,
                  "name":"",
@@ -4040,7 +4044,7 @@
                  "y":376
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1988,
                  "name":"",
@@ -4052,7 +4056,7 @@
                  "y":376
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1989,
                  "name":"",
@@ -4064,7 +4068,7 @@
                  "y":376
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1990,
                  "name":"",
@@ -4076,7 +4080,7 @@
                  "y":472
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":1991,
                  "name":"",
@@ -4088,7 +4092,7 @@
                  "y":472
                 }, 
                 {
-                 "gid":2147489318,
+                 "gid":2147489432,
                  "height":16,
                  "id":2040,
                  "name":"",
@@ -4100,7 +4104,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":2147489318,
+                 "gid":2147489432,
                  "height":16,
                  "id":2044,
                  "name":"",
@@ -4112,7 +4116,7 @@
                  "y":744
                 }, 
                 {
-                 "gid":4023,
+                 "gid":4089,
                  "height":80,
                  "id":2047,
                  "name":"",
@@ -4124,7 +4128,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":4023,
+                 "gid":4089,
                  "height":80,
                  "id":2048,
                  "name":"",
@@ -4136,7 +4140,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":2147487629,
+                 "gid":2147487695,
                  "height":61,
                  "id":2049,
                  "name":"",
@@ -4148,7 +4152,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":2147487628,
+                 "gid":2147487694,
                  "height":61,
                  "id":2050,
                  "name":"",
@@ -4160,7 +4164,7 @@
                  "y":760
                 }, 
                 {
-                 "gid":5691,
+                 "gid":5805,
                  "height":16,
                  "id":2057,
                  "name":"",
@@ -4172,7 +4176,7 @@
                  "y":800
                 }, 
                 {
-                 "gid":3273,
+                 "gid":3339,
                  "height":16,
                  "id":2058,
                  "name":"",
@@ -4184,7 +4188,7 @@
                  "y":776
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2063,
                  "name":"",
@@ -4196,7 +4200,7 @@
                  "y":512
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2064,
                  "name":"",
@@ -4208,7 +4212,7 @@
                  "y":512
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2065,
                  "name":"",
@@ -4220,7 +4224,7 @@
                  "y":512
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2066,
                  "name":"",
@@ -4232,7 +4236,7 @@
                  "y":512
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2067,
                  "name":"",
@@ -4244,7 +4248,7 @@
                  "y":512
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2069,
                  "name":"",
@@ -4256,7 +4260,7 @@
                  "y":440
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2070,
                  "name":"",
@@ -4268,7 +4272,7 @@
                  "y":440
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2071,
                  "name":"",
@@ -4280,7 +4284,7 @@
                  "y":440
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2072,
                  "name":"",
@@ -4292,7 +4296,7 @@
                  "y":440
                 }, 
                 {
-                 "gid":5643,
+                 "gid":5757,
                  "height":8,
                  "id":2076,
                  "name":"",
@@ -4304,7 +4308,7 @@
                  "y":504
                 }, 
                 {
-                 "gid":5643,
+                 "gid":5757,
                  "height":8,
                  "id":2077,
                  "name":"",
@@ -4316,7 +4320,7 @@
                  "y":416
                 }, 
                 {
-                 "gid":5643,
+                 "gid":5757,
                  "height":8,
                  "id":2083,
                  "name":"",
@@ -4328,7 +4332,7 @@
                  "y":416
                 }, 
                 {
-                 "gid":5643,
+                 "gid":5757,
                  "height":8,
                  "id":2084,
                  "name":"",
@@ -4340,7 +4344,7 @@
                  "y":504
                 }, 
                 {
-                 "gid":2147489584,
+                 "gid":2147489703,
                  "height":48,
                  "id":2087,
                  "name":"",
@@ -4352,7 +4356,7 @@
                  "y":688
                 }, 
                 {
-                 "gid":5945,
+                 "gid":6064,
                  "height":24,
                  "id":2088,
                  "name":"",
@@ -4364,7 +4368,7 @@
                  "y":504
                 }, 
                 {
-                 "gid":4317,
+                 "gid":4408,
                  "height":40,
                  "id":2107,
                  "name":"",
@@ -4376,27 +4380,25 @@
                  "y":800
                 }, 
                 {
-                 "gid":2147491500,
+                 "gid":2147491652,
                  "height":53,
                  "id":2108,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{ \"startingUpgradeStage\" : 3 }"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{ \"startingUpgradeStage\" : 3 }"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":80,
-                 "x":1616,
+                 "x":1664,
                  "y":600
                 }, 
                 {
-                 "gid":2147491519,
+                 "gid":2147491671,
                  "height":45,
                  "id":2109,
                  "name":"",
@@ -4404,11 +4406,11 @@
                  "type":"",
                  "visible":true,
                  "width":48,
-                 "x":1568,
+                 "x":1592,
                  "y":600
                 }, 
                 {
-                 "gid":7873,
+                 "gid":8025,
                  "height":16,
                  "id":2110,
                  "name":"",
@@ -4420,7 +4422,7 @@
                  "y":672
                 }, 
                 {
-                 "gid":2147491508,
+                 "gid":2147491660,
                  "height":24,
                  "id":2111,
                  "name":"",
@@ -4432,27 +4434,25 @@
                  "y":688
                 }, 
                 {
-                 "gid":2147491511,
+                 "gid":2147491663,
                  "height":56,
                  "id":2112,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{ \"startingUpgradeStage\" : 3 }"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{ \"startingUpgradeStage\" : 3 }"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":56,
-                 "x":1512,
+                 "x":1520,
                  "y":600
                 }, 
                 {
-                 "gid":4468,
+                 "gid":4563,
                  "height":12,
                  "id":2113,
                  "name":"",
@@ -4464,7 +4464,7 @@
                  "y":584
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":2114,
                  "name":"",
@@ -4476,7 +4476,7 @@
                  "y":544
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":2115,
                  "name":"",
@@ -4488,7 +4488,7 @@
                  "y":544
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":2116,
                  "name":"",
@@ -4500,7 +4500,7 @@
                  "y":544
                 }, 
                 {
-                 "gid":4580,
+                 "gid":4675,
                  "height":8,
                  "id":2117,
                  "name":"",
@@ -4512,7 +4512,7 @@
                  "y":544
                 }, 
                 {
-                 "gid":5697,
+                 "gid":5811,
                  "height":16,
                  "id":2120,
                  "name":"",
@@ -4527,24 +4527,154 @@
                  "height":8,
                  "id":2166,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"wrexornar"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"wrexornar"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
                  "width":8,
                  "x":2648,
                  "y":656
+                }, 
+                {
+                 "gid":7626,
+                 "height":24,
+                 "id":2174,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":56,
+                 "x":1480,
+                 "y":408
+                }, 
+                {
+                 "gid":2147489705,
+                 "height":22,
+                 "id":2178,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":16,
+                 "x":1464,
+                 "y":432
+                }, 
+                {
+                 "gid":6063,
+                 "height":16,
+                 "id":2179,
+                 "name":"",
+                 "properties":[
+                        {
+                         "name":"imagePositionX",
+                         "type":"string",
+                         "value":"-24"
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":40,
+                 "x":1424,
+                 "y":432
+                }, 
+                {
+                 "gid":6058,
+                 "height":15,
+                 "id":2180,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":19,
+                 "x":1432,
+                 "y":416
+                }, 
+                {
+                 "gid":7292,
+                 "height":16,
+                 "id":1859,
+                 "name":"",
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":24,
+                 "x":1920,
+                 "y":904
+                }, 
+                {
+                 "gid":7292,
+                 "height":16,
+                 "id":1860,
+                 "name":"",
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":24,
+                 "x":1920,
+                 "y":888
+                }, 
+                {
+                 "gid":7292,
+                 "height":16,
+                 "id":1861,
+                 "name":"",
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":24,
+                 "x":2008,
+                 "y":904
+                }, 
+                {
+                 "gid":7292,
+                 "height":16,
+                 "id":1862,
+                 "name":"",
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":24,
+                 "x":1984,
+                 "y":888
                 }],
          "opacity":0.910000026226044,
          "type":"objectgroup",
@@ -4555,6 +4685,7 @@
         {
          "color":"#ffff00",
          "draworder":"topdown",
+         "id":5,
          "name":"wiring - lights & guns",
          "objects":[
                 {
@@ -4616,86 +4747,6 @@
                  "width":0,
                  "x":1984,
                  "y":736
-                }, 
-                {
-                 "gid":7162,
-                 "height":16,
-                 "id":1859,
-                 "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":24,
-                 "x":1920,
-                 "y":904
-                }, 
-                {
-                 "gid":7162,
-                 "height":16,
-                 "id":1860,
-                 "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":24,
-                 "x":1920,
-                 "y":888
-                }, 
-                {
-                 "gid":7162,
-                 "height":16,
-                 "id":1861,
-                 "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":24,
-                 "x":2008,
-                 "y":904
-                }, 
-                {
-                 "gid":7162,
-                 "height":16,
-                 "id":1862,
-                 "name":"",
-                 "properties":
-                    {
-                     "parameters":"{\"treasurePools\":[\"ffbasicTreasure\"]}"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":24,
-                 "x":1984,
-                 "y":888
                 }, 
                 {
                  "height":0,
@@ -5098,26 +5149,6 @@
                  "y":792
                 }, 
                 {
-                 "gid":7849,
-                 "height":49,
-                 "id":2106,
-                 "name":"",
-                 "properties":
-                    {
-                     "parameters":"{ \"startingUpgradeStage\" : 3 }"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string"
-                    },
-                 "rotation":0,
-                 "type":"",
-                 "visible":true,
-                 "width":56,
-                 "x":1696,
-                 "y":600
-                }, 
-                {
                  "height":0,
                  "id":2121,
                  "name":"",
@@ -5343,7 +5374,7 @@
                  "name":"",
                  "polyline":[
                         {
-                         "x":0,
+                         "x":-8,
                          "y":0
                         }, 
                         {
@@ -5407,8 +5438,8 @@
                          "y":0
                         }, 
                         {
-                         "x":16,
-                         "y":-40
+                         "x":-16,
+                         "y":-88
                         }],
                  "rotation":0,
                  "type":"",
@@ -5427,7 +5458,7 @@
                          "y":0
                         }, 
                         {
-                         "x":-96,
+                         "x":-88,
                          "y":-48
                         }],
                  "rotation":0,
@@ -5447,7 +5478,7 @@
                          "y":0
                         }, 
                         {
-                         "x":-160,
+                         "x":-152,
                          "y":-48
                         }],
                  "rotation":0,
@@ -5467,7 +5498,7 @@
                          "y":0
                         }, 
                         {
-                         "x":-96,
+                         "x":-88,
                          "y":-16
                         }],
                  "rotation":0,
@@ -5487,7 +5518,7 @@
                          "y":0
                         }, 
                         {
-                         "x":-160,
+                         "x":-152,
                          "y":-16
                         }],
                  "rotation":0,
@@ -5527,7 +5558,7 @@
                          "y":0
                         }, 
                         {
-                         "x":40,
+                         "x":48,
                          "y":-24
                         }],
                  "rotation":0,
@@ -5547,7 +5578,7 @@
                          "y":0
                         }, 
                         {
-                         "x":80,
+                         "x":88,
                          "y":-24
                         }],
                  "rotation":0,
@@ -5556,6 +5587,186 @@
                  "width":0,
                  "x":2680,
                  "y":792
+                }, 
+                {
+                 "height":0,
+                 "id":2171,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":-8,
+                         "y":0
+                        }, 
+                        {
+                         "x":-264,
+                         "y":-112
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":2856,
+                 "y":720
+                }, 
+                {
+                 "height":0,
+                 "id":2172,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":-8,
+                         "y":0
+                        }, 
+                        {
+                         "x":-312,
+                         "y":-112
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":2856,
+                 "y":720
+                }, 
+                {
+                 "height":0,
+                 "id":2183,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-1040,
+                         "y":-96
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":2848,
+                 "y":720
+                }, 
+                {
+                 "height":0,
+                 "id":2184,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-1104,
+                         "y":-208
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":2848,
+                 "y":720
+                }, 
+                {
+                 "height":0,
+                 "id":2185,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-112,
+                         "y":0
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":1760,
+                 "y":632
+                }, 
+                {
+                 "height":0,
+                 "id":2186,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-296,
+                         "y":-72
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":1760,
+                 "y":632
+                }, 
+                {
+                 "height":0,
+                 "id":2187,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-72,
+                         "y":48
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":1760,
+                 "y":632
+                }, 
+                {
+                 "height":0,
+                 "id":2188,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-112,
+                         "y":0
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":1760,
+                 "y":632
+                }, 
+                {
+                 "height":0,
+                 "id":2189,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":688,
+                         "y":200
+                        }, 
+                        {
+                         "x":-336,
+                         "y":-56
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":2160,
+                 "y":520
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -5566,24 +5777,29 @@
         {
          "color":"#ff0000",
          "draworder":"topdown",
+         "id":6,
          "name":"monsters & npcs",
          "objects":[
                 {
                  "height":8,
                  "id":1894,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5595,18 +5811,22 @@
                  "height":8,
                  "id":1895,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5618,18 +5838,22 @@
                  "height":8,
                  "id":1896,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5641,18 +5865,22 @@
                  "height":8,
                  "id":1897,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5664,18 +5892,22 @@
                  "height":8,
                  "id":1898,
                  "name":"",
-                 "properties":
-                    {
-                     "npc":"human",
-                     "seed":"stable",
-                     "typeName":"fubandit1"
-                    },
-                 "propertytypes":
-                    {
-                     "npc":"string",
-                     "seed":"string",
-                     "typeName":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"npc",
+                         "type":"string",
+                         "value":"human"
+                        }, 
+                        {
+                         "name":"seed",
+                         "type":"string",
+                         "value":"stable"
+                        }, 
+                        {
+                         "name":"typeName",
+                         "type":"string",
+                         "value":"fubandit1"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5685,13 +5917,14 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }, 
         {
          "color":"#00ffff",
          "draworder":"topdown",
+         "id":7,
          "name":"wiring - locked door",
          "objects":[
                 {
@@ -5782,6 +6015,7 @@
         }, 
         {
          "draworder":"topdown",
+         "id":8,
          "name":"outside the map",
          "objects":[],
          "opacity":1,
@@ -5792,10 +6026,11 @@
         }, 
         {
          "draworder":"topdown",
+         "id":9,
          "name":"anchors etc",
          "objects":[
                 {
-                 "gid":249,
+                 "gid":252,
                  "height":8,
                  "id":748,
                  "name":"",
@@ -5807,7 +6042,7 @@
                  "y":1176
                 }, 
                 {
-                 "gid":237,
+                 "gid":240,
                  "height":8,
                  "id":749,
                  "name":"",
@@ -5819,7 +6054,7 @@
                  "y":1176
                 }, 
                 {
-                 "gid":248,
+                 "gid":251,
                  "height":8,
                  "id":750,
                  "name":"",
@@ -5831,7 +6066,7 @@
                  "y":1160
                 }, 
                 {
-                 "gid":236,
+                 "gid":239,
                  "height":8,
                  "id":751,
                  "name":"",
@@ -5843,7 +6078,7 @@
                  "y":1160
                 }, 
                 {
-                 "gid":248,
+                 "gid":251,
                  "height":8,
                  "id":949,
                  "name":"",
@@ -5855,7 +6090,7 @@
                  "y":1160
                 }, 
                 {
-                 "gid":236,
+                 "gid":239,
                  "height":8,
                  "id":950,
                  "name":"",
@@ -5867,7 +6102,7 @@
                  "y":1160
                 }, 
                 {
-                 "gid":249,
+                 "gid":252,
                  "height":8,
                  "id":951,
                  "name":"",
@@ -5879,7 +6114,7 @@
                  "y":1176
                 }, 
                 {
-                 "gid":237,
+                 "gid":240,
                  "height":8,
                  "id":952,
                  "name":"",
@@ -5894,16 +6129,17 @@
                  "height":152,
                  "id":2138,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{ \"radioMessages\" : [\"wrexornar\"] }",
-                     "stagehand":"radiomessage"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string",
-                     "stagehand":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{ \"radioMessages\" : [\"wrexornar\"] }"
+                        }, 
+                        {
+                         "name":"stagehand",
+                         "type":"string",
+                         "value":"radiomessage"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5915,16 +6151,17 @@
                  "height":168,
                  "id":2139,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{ \"radioMessages\" : [\"wrexornar\"] }",
-                     "stagehand":"radiomessage"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string",
-                     "stagehand":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{ \"radioMessages\" : [\"wrexornar\"] }"
+                        }, 
+                        {
+                         "name":"stagehand",
+                         "type":"string",
+                         "value":"radiomessage"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5936,16 +6173,17 @@
                  "height":152,
                  "id":2140,
                  "name":"",
-                 "properties":
-                    {
-                     "parameters":"{ \"radioMessages\" : [\"wrexornar\"] }",
-                     "stagehand":"radiomessage"
-                    },
-                 "propertytypes":
-                    {
-                     "parameters":"string",
-                     "stagehand":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"parameters",
+                         "type":"string",
+                         "value":"{ \"radioMessages\" : [\"wrexornar\"] }"
+                        }, 
+                        {
+                         "name":"stagehand",
+                         "type":"string",
+                         "value":"radiomessage"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5957,14 +6195,12 @@
                  "height":48,
                  "id":2141,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5976,14 +6212,12 @@
                  "height":16,
                  "id":2142,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5995,14 +6229,12 @@
                  "height":16,
                  "id":2143,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6014,14 +6246,12 @@
                  "height":16,
                  "id":2144,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6033,14 +6263,12 @@
                  "height":16,
                  "id":2145,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6052,14 +6280,12 @@
                  "height":8,
                  "id":2146,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6071,14 +6297,12 @@
                  "height":16,
                  "id":2147,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6090,14 +6314,12 @@
                  "height":16,
                  "id":2148,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6109,14 +6331,12 @@
                  "height":16,
                  "id":2149,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6128,14 +6348,12 @@
                  "height":16,
                  "id":2150,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6147,14 +6365,12 @@
                  "height":16,
                  "id":2151,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6166,14 +6382,12 @@
                  "height":32,
                  "id":2152,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6185,14 +6399,12 @@
                  "height":16,
                  "id":2153,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6204,14 +6416,12 @@
                  "height":16,
                  "id":2154,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6223,14 +6433,12 @@
                  "height":16,
                  "id":2155,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6242,14 +6450,12 @@
                  "height":16,
                  "id":2156,
                  "name":"",
-                 "properties":
-                    {
-                     "dungeonid":"none"
-                    },
-                 "propertytypes":
-                    {
-                     "dungeonid":"string"
-                    },
+                 "properties":[
+                        {
+                         "name":"dungeonid",
+                         "type":"string",
+                         "value":"none"
+                        }],
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6265,6 +6471,7 @@
         }, 
         {
          "draworder":"topdown",
+         "id":10,
          "name":"items",
          "objects":[],
          "opacity":1,
@@ -6273,11 +6480,11 @@
          "x":0,
          "y":0
         }],
- "nextobjectid":2167,
+ "nextlayerid":11,
+ "nextobjectid":2190,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "templategroups":[],
- "tiledversion":"2017.09.08",
+ "tiledversion":"1.4.2",
  "tileheight":8,
  "tilesets":[
         {
@@ -6285,135 +6492,135 @@
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/materials.json"
         }, 
         {
-         "firstgid":196,
+         "firstgid":198,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/supports.json"
         }, 
         {
-         "firstgid":232,
+         "firstgid":235,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/miscellaneous.json"
         }, 
         {
-         "firstgid":254,
+         "firstgid":259,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/liquids.json"
         }, 
         {
-         "firstgid":282,
+         "firstgid":287,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-race\/generic.json"
         }, 
         {
-         "firstgid":2207,
+         "firstgid":2271,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-race\/hylotl.json"
         }, 
         {
-         "firstgid":2439,
+         "firstgid":2503,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/breakable.json"
         }, 
         {
-         "firstgid":2747,
+         "firstgid":2813,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/crafting.json"
         }, 
         {
-         "firstgid":2827,
+         "firstgid":2893,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/decorative.json"
         }, 
         {
-         "firstgid":4243,
+         "firstgid":4334,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/door.json"
         }, 
         {
-         "firstgid":4371,
+         "firstgid":4466,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/light.json"
         }, 
         {
-         "firstgid":4813,
+         "firstgid":4924,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/pot.json"
         }, 
         {
-         "firstgid":5110,
+         "firstgid":5221,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/railpoint.json"
         }, 
         {
-         "firstgid":5115,
+         "firstgid":5226,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/seed.json"
         }, 
         {
-         "firstgid":5191,
+         "firstgid":5302,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/storage.json"
         }, 
         {
-         "firstgid":5422,
+         "firstgid":5536,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/teleportmarker.json"
         }, 
         {
-         "firstgid":5436,
+         "firstgid":5550,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/trap.json"
         }, 
         {
-         "firstgid":5640,
+         "firstgid":5754,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/wire.json"
         }, 
         {
-         "firstgid":5857,
+         "firstgid":5976,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/hylotlvillage.json"
         }, 
         {
-         "firstgid":5916,
+         "firstgid":6035,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fu_labmaterials.json"
         }, 
         {
-         "firstgid":5936,
+         "firstgid":6055,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fu_labgear.json"
         }, 
         {
-         "firstgid":6079,
+         "firstgid":6206,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fu_liquids.json"
         }, 
         {
-         "firstgid":6101,
+         "firstgid":6228,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fumaterials2.json"
         }, 
         {
-         "firstgid":6222,
+         "firstgid":6352,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fuplatforms.json"
         }, 
         {
-         "firstgid":6237,
+         "firstgid":6367,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/apex.json"
         }, 
         {
-         "firstgid":6604,
+         "firstgid":6734,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-race\/apex.json"
         }, 
         {
-         "firstgid":6975,
+         "firstgid":7105,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-race\/human.json"
         }, 
         {
-         "firstgid":7256,
+         "firstgid":7393,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-race\/protectorate.json"
         }, 
         {
-         "firstgid":7354,
+         "firstgid":7491,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/furniture.json"
         }, 
         {
-         "firstgid":7700,
+         "firstgid":7845,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/generic.json"
         }, 
         {
-         "firstgid":7701,
+         "firstgid":7847,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/electronic.json"
         }, 
         {
-         "firstgid":7828,
+         "firstgid":7979,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-type\/physics.json"
         }, 
         {
-         "firstgid":7844,
+         "firstgid":7996,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fu_stations.json"
         }],
  "tilewidth":8,
  "type":"map",
- "version":1,
+ "version":1.4,
  "width":479
 }

--- a/objects/generic/fu_craftinfo/fu_craftinfo.object
+++ b/objects/generic/fu_craftinfo/fu_craftinfo.object
@@ -2,7 +2,7 @@
 	"objectName" : "fu_craftinfo",
 	"colonyTags" : ["electronic"],
 	"rarity" : "Common",
-	"description" : "This panel shows which materials produce results with your various lab stations. Must place near Extractor or Xenolab.",
+	"description" : "This panel shows which materials produce results with your various lab stations. Must place near an Extractor or other processing station.",
 	"shortdescription" : "^yellow;Lab Directory^reset;",
 	"race" : "generic",
 	"printable" : false,
@@ -14,7 +14,7 @@
 	"flickerStrength" : 0.05,
 	"flickerTiming" : 4,
 
-        "pickupQuestTemplates" : [ "fuquest_craftinfo" ],
+    "pickupQuestTemplates" : [ "fuquest_craftinfo" ],
 
 	"ponexDescription" : "Please, someone end my eternal torment. My pain is ceaseless.",
 

--- a/quests/fu_questlines/deprecated/fuquest_craftinfo.questtemplate
+++ b/quests/fu_questlines/deprecated/fuquest_craftinfo.questtemplate
@@ -1,7 +1,7 @@
 {
   "id" : "fuquest_craftinfo",
   "title" : "New Directions",
-  "text" : "A ^orange;Lab Directory^reset; does only one thing: ^green;Telling you what makes what^reset; in your production stations. Try making one now in your ^orange;Auto-Assembler^reset;. Show me it when you're done.",
+  "text" : "A ^orange;Lab Directory^reset; does only one thing: ^green;Telling you what makes what^reset; in your production stations. Try making one now in your ^orange;Machining Table^reset;.",
   "completionText" : "Now take that to your base and place it next to an extractor, centrifuge or other production station. Access it, and you'll soon see just how amazing a device it truly is.",
   "rewards" : [
     [ [ "glass", 2] ]
@@ -16,7 +16,7 @@
       "questComplete" : "questGiver"
     },
     "canBeAbandoned" : true,
-    "requireTurnIn" : true,
+    "requireTurnIn" : false,
 
     "turnInDescription" : "Bring the ^orange;Lab Directory^reset; to the scientist at the ^orange;Science Outpost^reset;",
 

--- a/quests/fu_questlines/science/genetics/create_regengene.questtemplate
+++ b/quests/fu_questlines/science/genetics/create_regengene.questtemplate
@@ -2,10 +2,10 @@
 	"id": "create_regengene",
 	"prerequisites": ["create_fertilizer"],
 	"title": "Gene Splicing 101",
-	"text": "My ^orange;Xeno Lab^reset; is on the fritz! and I need 3 ^orange;Beetle Sprout^reset; seeds for a client or I don't eat this month! Can you help me out?",
+	"text": "My ^orange;Xeno Lab^reset; is on the fritz, and I need 3 ^orange;Thornitox^reset; seeds for a client or I don't eat this month! Can you help me out?",
 	"completionText": "Thanks so much. It's not much, but take this data I uncovered by scanning ^orange;Technology of the Ancients^reset;. Maybe you can make use of it.",
 	"moneyRange": [320, 440],
-	"rewards" : [ [ [ "fuscienceresource",200 ] ] ],
+	"rewards" : [ [ [ "fuprecursorresource", 2 ] ] ],
 	"speaker": "questGiver",
 
 	"updateDelta": 10,
@@ -20,11 +20,11 @@
 		"canBeAbandoned": true,
 		"requireTurnIn": true,
 
-		"turnInDescription": "Bring ^orange;3 Beetlesprout Seeds^reset; to the yellow Avian at the ^orange;Science Outpost^reset;",
+		"turnInDescription": "Bring ^orange;3 Thornitox Seeds^reset; to the yellow Avian at the ^orange;Science Outpost^reset;",
 		"giveBlueprints": ["isn_flintlock"],
 		"conditions": [{
 			"type": "gatherItem",
-			"itemName": "beetlesproutseed",
+			"itemName": "thornitoxseed",
 			"count": 3,
 			"consume": true
 		}]

--- a/quests/other/transponder.questtemplate.patch
+++ b/quests/other/transponder.questtemplate.patch
@@ -40,7 +40,7 @@
     "value": {
       "type": "gatherItem",
       "itemName": "money",
-      "count": 20000,
+      "count": 6000,
       "consume": true
     }
   }

--- a/recipes/designlab/combatplants4/porphisplantseed.recipe
+++ b/recipes/designlab/combatplants4/porphisplantseed.recipe
@@ -6,8 +6,7 @@
     { "item" : "pussplum", "count" : 18 },
     { "item" : "fleshstrand", "count" : 30 },
     { "item" : "phosphorus", "count" : 14 },
-    { "item" : "ff_silicon", "count" : 16 },
-    { "item" : "cell_viral", "count" : 2 }
+    { "item" : "ff_silicon", "count" : 16 }
   ],
   "output" : {
     "item" : "porphisplantseed",

--- a/recipes/designlab/explorationplants1/diodiahybridseed.recipe
+++ b/recipes/designlab/explorationplants1/diodiahybridseed.recipe
@@ -5,7 +5,6 @@
     { "item" : "cellmateria", "count" : 1 },
     { "item" : "diodiaseed", "count" : 3 },
     { "item" : "currentcornseed", "count" : 1 },
-    { "item" : "cellmateria", "count" : 1 },
     { "item" : "staticcell", "count" : 1 }
   ],
   "output" : {

--- a/recipes/prototyper/labs/tools/fu_craftinfo.recipe
+++ b/recipes/prototyper/labs/tools/fu_craftinfo.recipe
@@ -1,12 +1,11 @@
 {
   "input" : [
-    { "item" : "siliconboard", "count" : 1 },
+    { "item" : "ironbar", "count" : 4 },
+    { "item" : "siliconboard", "count" : 2 },
     { "item" : "wire", "count" : 3 },
-    { "item" : "glass", "count" : 1 },
-    { "item" : "ff_plastic", "count" : 2 },
-    { "item" : "titaniumbar", "count" : 2 }
+    { "item" : "glass", "count" : 3 }
   ],
   "output" : { "item" : "fu_craftinfo", "count" : 1 },
-  "groups" : [ "prototyper2", "genetics", "all" ],
+  "groups" : [ "prototyper1", "genetics", "all" ],
   "duration" : 6
 }

--- a/stats/effects/nofallinvis/nofallinvis.lua
+++ b/stats/effects/nofallinvis/nofallinvis.lua
@@ -1,0 +1,3 @@
+function init()
+  effect.addStatModifierGroup({{stat = "fallDamageMultiplier", effectiveMultiplier = 0}})
+end

--- a/stats/effects/nofallinvis/nofallinvis.statuseffect
+++ b/stats/effects/nofallinvis/nofallinvis.statuseffect
@@ -1,0 +1,9 @@
+{
+  "name" : "nofallinvis",
+  "effectConfig" : {},
+  "defaultDuration" : 1.0,
+
+  "scripts" : [
+    "nofallinvis.lua"
+  ]
+}

--- a/treasure/smashable.treasurepools.patch
+++ b/treasure/smashable.treasurepools.patch
@@ -1,63 +1,78 @@
 [
+  {
+    "op": "add",
+    "path": "/deadglitchloot",
+    "value": [[0,
       {
-        "op": "add",
-        "path": "/deadglitchloot",
-        "value": [
-            [
-                0,
-                {
-                    "pool": [
-                        {"weight" : 0.1, "pool" : "ffbasicTreasure"},
-        		{"weight" : 0.1, "pool" : "chestMoney"},
-                        {"weight": 0.4,"item": ["rustyblock",1]},
-                        {"weight": 0.35,"item": ["rustyblock",2]},
-                        {"weight": 0.3,"item": ["rustyblock",3]},
-                        {"weight": 0.4,"item": ["junk",4]},
-                        {"weight": 0.3,"item": ["junk",5]},
-                        {"weight": 0.3,"item": ["junktech",1]},
-			{"weight": 0.23,"item": "stickofram" },
-                        {"weight": 0.2,"item": ["junktech",8]},
-                        {"weight": 0.3,"item": ["liquidoil",1]},
-                        {"weight": 0.1,"item": ["liquidoil",5]},
-                        {"weight": 0.0001,"item": "glitchskullhead" },
-                        {"weight": 0.0005,"item": "glitchfossil1" },
-                        {"weight": 0.0005,"item": "glitchfossil2" },
-                        {"weight": 0.0005,"item": "glitchfossil3" }
-                    ]
-                }
-            ]
+        "pool": [
+          {"weight" : 0.1, "pool" : "ffbasicTreasure"},
+          {"weight" : 0.1, "pool" : "chestMoney"},
+          {"weight": 0.4,"item": ["rustyblock",1]},
+          {"weight": 0.35,"item": ["rustyblock",2]},
+          {"weight": 0.3,"item": ["rustyblock",3]},
+          {"weight": 0.4,"item": ["junk",4]},
+          {"weight": 0.3,"item": ["junk",5]},
+          {"weight": 0.3,"item": ["junktech",1]},
+          {"weight": 0.23,"item": "stickofram" },
+          {"weight": 0.2,"item": ["junktech",8]},
+          {"weight": 0.3,"item": ["liquidoil",1]},
+          {"weight": 0.1,"item": ["liquidoil",5]},
+          {"weight": 0.0001,"item": "glitchskullhead" },
+          {"weight": 0.0005,"item": "glitchfossil1" },
+          {"weight": 0.0005,"item": "glitchfossil2" },
+          {"weight": 0.0005,"item": "glitchfossil3" }
         ]
-    },
+      }
+    ]]
+  },
+  {
+    "op": "add",
+    "path": "/deadloot",
+    "value": [[0,
       {
-        "op": "add",
-        "path": "/deadloot",
-        "value": [
-            [
-                0,
-                {
-                    "pool": [
-                        {"weight" : 0.1, "pool" : "ffbasicTreasure"},
-        		{"weight" : 0.1, "pool" : "chestMoney"},
-                        {"weight": 0.4,"item": ["alienmeat",1]},
-                        {"weight": 0.35,"item": ["rawribmeat",2]},
-                        {"weight": 0.3,"item": ["rawbacon",3]},
-                        {"weight": 0.4,"item": ["junk",4]},
-                        {"weight": 0.3,"item": ["junk",5]},
-			{"weight": 0.2,"item": ["faceskin",1]},
-			{"weight": 0.2,"item": ["fupest",1]},
-			{"weight": 0.2,"item": ["severedheadplatter",1]},
-			{"weight": 0.1,"item": ["tearnutbutter",1]},
-			{"weight": 0.1,"item": ["toxicsludge",1]},
-			{"weight": 0.2,"item": ["blam",1]},
-                        {"weight": 0.2,"item": ["bone",8]},
-                        {"weight": 0.2,"item": ["bone",16]},
-                        {"weight": 0.1,"item": ["wrappedbody",1]},
-                        {"weight": 0.3,"item": ["wrappedbodyputrid",1]}
-                    ]
-                }
-            ]
+        "pool": [
+          {"weight" : 0.1, "pool" : "ffbasicTreasure"},
+          {"weight" : 0.1, "pool" : "chestMoney"},
+          {"weight": 0.4,"item": ["alienmeat",1]},
+          {"weight": 0.35,"item": ["rawribmeat",2]},
+          {"weight": 0.3,"item": ["rawbacon",3]},
+          {"weight": 0.4,"item": ["junk",4]},
+          {"weight": 0.3,"item": ["junk",5]},
+          {"weight": 0.2,"item": ["faceskin",1]},
+          {"weight": 0.2,"item": ["fupest",1]},
+          {"weight": 0.2,"item": ["severedheadplatter",1]},
+          {"weight": 0.1,"item": ["tearnutbutter",1]},
+          {"weight": 0.1,"item": ["toxicsludge",1]},
+          {"weight": 0.2,"item": ["blam",1]},
+          {"weight": 0.2,"item": ["bone",8]},
+          {"weight": 0.2,"item": ["bone",16]},
+          {"weight": 0.1,"item": ["wrappedbody",1]},
+          {"weight": 0.3,"item": ["wrappedbodyputrid",1]}
         ]
-    },
+      }
+    ]]
+  },
+  {
+    "op": "add",
+    "path": "/capsulesmall",
+    "value": [[0,
+      {"pool": [{"weight" : 1.0, "pool" : "capsule"}]}
+    ]]
+  },
+  {
+    "op": "add",
+    "path": "/capsulemed",
+    "value": [[0,
+      {"pool": [{"weight" : 1.0, "pool" : "capsule"}]}
+    ]]
+  },
+  {
+    "op": "add",
+    "path": "/capsulebig",
+    "value": [[0,
+      {"pool": [{"weight" : 1.0, "pool" : "capsule"}]}
+    ]]
+  },
   {
     "op": "replace",
     "path": "/capsule/0/1/pool/0/item/1",

--- a/zb/researchTree/fu_engineering.config
+++ b/zb/researchTree/fu_engineering.config
@@ -13,7 +13,7 @@
 				"position" : [0, 0],
 				"children" : [ "goldcircuitry", "extraction1", "robotics1", "tinkering1", "spacebasic", "sciencestuff" ],
 				"price" : [["fuscienceresource", 150], ["ironbar", 1], ["copperbar", 1]],
-				"unlocks" : [ "prototyper", "beeexaminer", "stickynotepadfu", "paper", "wire", "electromagnet", "siliconboard", "laserdiode", "researchvoxelsmall","researchvoxel","researchvoxellarge"]
+				"unlocks" : [ "prototyper", "fu_craftinfo", "beeexaminer", "stickynotepadfu", "paper", "wire", "electromagnet", "siliconboard", "laserdiode", "researchvoxelsmall","researchvoxel","researchvoxellarge"]
 			},
 			"techs1" : {
 				"icon" : "/tech/distortionsphere2.png",
@@ -463,7 +463,7 @@
 				"position" : [40, 0],
 				"children" : [ ],
 				"price" : [["fuscienceresource", 500], ["tungstenbar", 1], ["ff_plastic", 1]],
-				"unlocks" : [ "genestorage","genecabinet", "fuwallsafe","gravgen", "antigravgen", "fu_upgradetable","miningbench", "nanostove", "checkpoint", "fu_craftinfo" ]
+				"unlocks" : [ "genestorage","genecabinet", "fuwallsafe","gravgen", "antigravgen", "fu_upgradetable","miningbench", "nanostove", "checkpoint" ]
 			},										
 			"vehicles1" : {
 				"icon" : "/items/active/vehiclecontroller/hazardsubcontroller.png:full",
@@ -709,7 +709,7 @@
 	},
 
 	"versions":{
-	  "fu_engineering" : "0.133"
+	  "fu_engineering" : "0.134"
 	},	
 	"initiallyResearched" : {
 		"fu_engineering" : [ "BASICTRAINING" ]

--- a/zb/researchTree/fu_engineering.config
+++ b/zb/researchTree/fu_engineering.config
@@ -459,7 +459,7 @@
 				"unlocks" : [ "fu_fuelpurifiert3","fu_fuelpurifiert4",  "fu_ftldrivemk3a", "fu_ftldrivemk3b", "fu_ftldrivemk3c", "fu_ftl_humanUpgrade","fu_booster_tiny6", "fu_booster_small6", "fu_booster_medium6","fu_booster_large6", "fu_booster_tiny7", "fu_booster_small7", "fu_booster_medium7","fu_booster_large7","fu_booster_tiny8", "fu_booster_small8", "fu_booster_medium8","fu_booster_large8"]
 			},				
 			"sciencestuff" : {
-				"icon" : "/objects/generic/fu_craftinfo/icon.png",
+				"icon" : "/objects/generic/storage4/fuwallsafeicon.png",
 				"position" : [40, 0],
 				"children" : [ ],
 				"price" : [["fuscienceresource", 500], ["tungstenbar", 1], ["ff_plastic", 1]],


### PR DESCRIPTION
- Fixed duplicate cell ingredients in Porphis and Diodia-Hybrid seeds
- Altered the Lab Directory's recipe to be craftable at T1, and moved it to the first Engineering node to make it available earlier.
- Disabled fall damage in the Outpost, Science Outpost, and player-owned space stations.
- Increased the world size of player space stations (will only apply to those created after this update).
- Rebalanced the pixels required for the vanilla Station Transponder quest.
- Fixed misplaced items in the Wrexor Nar pirate dungeon.
- Changed the Beetle Sprout tutorial quest to instead require Thornitox, and tweaked the rewards.
- Fixed many biome smashable treasure pools referring to loot pools not present in the game.