### PR TITLE
Researcher's Helm Fix

### DIFF
--- a/items/armors/tier3/tw_fieldresearch/tw_fieldresearch.head
+++ b/items/armors/tier3/tw_fieldresearch/tw_fieldresearch.head
@@ -27,7 +27,7 @@
     {
       "levelFunction" : "standardArmorLevelProtectionMultiplier",
       "stat" : "protection",
-      "amount" : 0.26
+      "amount" : 0.27
     },
     {
       "levelFunction" : "standardArmorLevelMaxEnergyMultiplier",


### PR DESCRIPTION
Just making the main Researcher's Helm have the same value as the alts because the minor difference irked me. Not sure whether this one or the alts are erroneous, changing this one because it's outnumbered.