### PR TITLE
Prismatic Orb Launcher typo fix

### DIFF
--- a/items/active/weapons/ranged/unique/cuteorblauncher.activeitem
+++ b/items/active/weapons/ranged/unique/cuteorblauncher.activeitem
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "Fire destructive balls of energy.
-^yellow;Counts asa 'energy' for set bonuses^reset;",
+^yellow;Counts as 'Energy' for set bonuses^reset;",
   "shortdescription" : "Prismatic Orb Launcher",
   "category" : "shotgun",
   "level" : 4,


### PR DESCRIPTION
Changed "Counts asa 'energy' for set bonuses" to "Counts as 'Energy' for set bonuses" to fix the typo and make it in line with other energy weapons.