### PR TITLE
Ship

### DIFF
--- a/dialog/converse.config.patch
+++ b/dialog/converse.config.patch
@@ -984,14 +984,14 @@
 				"Begone.", 
 				"Excuse me.", 
 				"Trouble me with conversation.",
-				"Piss off."
+				"Begone."
 			],
 
 			"fukirhos": [
 				"Evil is done everywhere under yon suns. That is why we Nightar lurk in shadow, where peril finds us not.",
 				"My ears deign not to listen to thine Kirhosi mewling. Goodbye.",
 				"Spare us a futile parley, and make yourself scarce, <entityname>.",
-				"We've heard of you, <entityname>, and none of it was good. Piss off.",
+				"We've heard of you, <entityname>, and none of it was good. Begone.",
 				"Begone, Kirhos, and do not test us.",
 				"We Nightar have naught to do with your kind.",
 				"You waste your time on this errand, Kirhos. Begone.",

--- a/dialog/converse.config.patch
+++ b/dialog/converse.config.patch
@@ -983,8 +983,7 @@
 				"I have no desire for conversation, Lightdweller.",
 				"Begone.", 
 				"Excuse me.", 
-				"Trouble me with conversation.",
-				"Begone."
+				"Trouble me not with conversation."
 			],
 
 			"fukirhos": [
@@ -1031,7 +1030,7 @@
 				"The Protectorate? but why would you have anything to do with them?",
 				"These Humans, what are they like? Smelly, stupid and unable to fight, I am certain.",
 				"Tarry a while, friend, and savour this moment together.",
-				"By the black eyes of the Matriarch, a Lightdweller among our kind?!?!",
+				"By the black eyes of the Matriarch, a Lightdweller among our kind?!",
 				"Need anything, fellow Shadow-walker?"
 			]
 		}

--- a/npcs/crew/crewmemberLoveliusSmythe.npctype
+++ b/npcs/crew/crewmemberLoveliusSmythe.npctype
@@ -73,17 +73,13 @@
       }      
     },
 
-    "questGenerator" : {
-      "enableParticipation" : false
-    },
-
     "dialog" : {
           "crewmember" : {         
             "offer" : {
               "default" : {
                 "default" : [
 				  "I'M FREE! AT LONG LAST! Sire, I would travel with you as thanks!",
-				  "Glorious, wonderful oxygen. Do yourself a favor: Don't be friends with Avians. That sucked ass. I'll follow you now, if you'll have me.",
+				  "Glorious, wonderful oxygen. Do yourself a favor: Don't be friends with Avians. That sucked. I'll follow you now, if you'll have me.",
 				  "Let us unravel secrets together, now that you've so graciously freed me.",
 				  "I suppose they meant it literally when they said they intended to keep me forever. Avian hospitality is rather poor."
                 ]
@@ -102,21 +98,15 @@
               "default" : {
                 "default" : [
                   "I'm back? Again? What madness is this?",
-                  "I am positive I just died. Did I?",
-                  "I'm back! And alive!",
-                  "I'm back and in one piece!",
-                  "I'm alive again! That's good.",
-                  "I don't think I respawned properly...",
-                  "My head hurts.",
-                  "What was I doing just before I died?" 
+                  "I am positive I just died. Did I?"
                 ]
               }
             },
             "combatBenefit" : {
               "default" : {
                 "default" : [
-				  "To battle, <playerName>!",
-				  "<playerName>! Let us vanquish these cursed foes!",
+				  "To battle, <entityname>!",
+				  "<entityname>! Let us vanquish these cursed foes!",
 				  "Like a squallid hellhound, I engage Beast Mode!"
                 ]
               }
@@ -124,23 +114,18 @@
             "unfollow" : {
               "default" : {
                 "default" : [
-				  "I'll just wait here.",
-				  "I'll stay here. Come back when you need me, <playerName>!",
-				  "I'll stay here for now, <playerName>.",
-				  "Do you need me to stay here?",
-				  "I'll stay here for now, then.",
-				  "I'll stay here."	
+				  "I'll stay here. Come back when you need me, <entityname>!",
+				  "I'll stay here for now, <entityname>.",
+				  "Do you need me to stay here, <entityname>?"
                 ]
               }
             },
             "follow" : {
               "default" : {
                 "default" : [
-				  "Yes, <playerName>!",
-				  "Good idea <playerName>!",
-				  "Let's get going!",
-				  "Let's go, <playerName>!",
-				  "Are we going somewhere?"
+				  "Good idea <entityname>!",
+				  "Let's get going, <entityname>!",
+				  "Let's go, <entityname>!"
                 ]
               }
             },

--- a/objects/avaligeneric/kitchen/avalikitchenfridge.object
+++ b/objects/avaligeneric/kitchen/avalikitchenfridge.object
@@ -1,11 +1,11 @@
 {
   "objectName" : "avalikitchenfridge",
-  "colonyTags" : [ "avali", "avalicamp", "storage" ], 
+  "colonyTags" : [ "avali", "avalicamp", "cooking", "storage" ], 
   "printable" : false,
   "rarity" : "Common",
   "objectType" : "container",
 
-  "category" : "storage",
+  "category" : "fridgeStorage",
   "price" : 120,
   "retainObjectParametersInItem" : true, 
   "description" : "What does an ice-bound race keep in a fridge?",

--- a/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_apex.object
+++ b/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_apex.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["apex", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Apex ship bunk bed. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Apex Ship Bunk Bed",
+  "shortdescription" : "Apex Crew Bunk Bed",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_avian.object
+++ b/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_avian.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["avian", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Avian ship bunk bed. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Avian Ship Bunk Bed",
+  "shortdescription" : "Avian Crew Bunk Bed",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_floran.object
+++ b/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_floran.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["floran", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Floran ship bunk bed. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Floran Ship Bunk Bed",
+  "shortdescription" : "Floran Crew Bunk Bed",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_glitch.object
+++ b/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_glitch.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["glitch", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Glitch ship bunk bed. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Glitch Ship Bunk Bed",
+  "shortdescription" : "Glitch Crew Bunk Bed",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_human.object
+++ b/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_human.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["human", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Human ship bunk bed. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Human Ship Bunk Bed",
+  "shortdescription" : "Human Crew Bunk Bed",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_hylotl.object
+++ b/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_hylotl.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["hylotl", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Hylotl ship bunk bed. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Hylotl Ship Bunk Bed",
+  "shortdescription" : "Hylotl Crew Bunk Bed",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_novakid.object
+++ b/objects/ship/fu_crewbedracialbunk/fu_crewbedracialbunk_novakid.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["novakid", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Novakid ship bunk bed. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Novakid Ship Bunk Bed",
+  "shortdescription" : "Novakid Crew Bunk Bed",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_apex.object
+++ b/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_apex.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["apex", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Apex ship wall bunk. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Apex Ship Wall Bunk",
+  "shortdescription" : "Apex Crew Wall Bunk",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_avian.object
+++ b/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_avian.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["avian", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Avian ship wall bunk. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Avian Ship Wall Bunk",
+  "shortdescription" : "Avian Crew Wall Bunk",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_floran.object
+++ b/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_floran.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["floran", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Floran ship wall bunk. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Floran Ship Wall Bunk",
+  "shortdescription" : "Floran Crew Wall Bunk",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_glitch.object
+++ b/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_glitch.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["glitch", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Glitch ship wall bunk. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Glitch Ship Wall Bunk",
+  "shortdescription" : "Glitch Crew Wall Bunk",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_human.object
+++ b/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_human.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["human", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Human ship wall bunk. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Human Ship Wall Bunk",
+  "shortdescription" : "Human Crew Wall Bunk",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_hylotl.object
+++ b/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_hylotl.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["hylotl", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Hylotl ship wall bunk. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Hylotl Ship Wall Bunk",
+  "shortdescription" : "Hylotl Crew Wall Bunk",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_novakid.object
+++ b/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_novakid.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["novakid", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Novakid ship wall bunk. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "Novakid Ship Wall Bunk",
+  "shortdescription" : "Novakid Crew Wall Bunk",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_protectorate.object
+++ b/objects/ship/fu_crewbedracialwall/fu_crewbedracialwall_protectorate.object
@@ -4,7 +4,7 @@
   "colonyTags" : ["protectorate", "bed"],
   "rarity" : "Legendary",
   "description" : "A standard Protectorate ship wall bunk. ^yellow;Crew +1^reset;. Counts as a deed. ^red;BYOS Only^reset;. Extract to return Crew Bunk.",
-  "shortdescription" : "P. Ship Wall Bunk",
+  "shortdescription" : "P. Crew Wall Bunk",
   "race" : "generic",
   "category" : "furniture",
   "price" : 0,

--- a/recipes/armory/melee/dagger/carbondagger.recipe
+++ b/recipes/armory/melee/dagger/carbondagger.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "carbonplate", "count" : 1 },
-    { "item" : "zerchesiumbar", "count" : 1 }
+    { "item" : "titaniumbar", "count" : 1 }
   ],
   "output" : { "item" : "fucarbondagger", "count" : 1 },
   "groups" : [ "armory2", "melee", "all" ]

--- a/recipes/armory/melee/hammer/carbonhammer.recipe
+++ b/recipes/armory/melee/hammer/carbonhammer.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "carbonplate", "count" : 2 },
-    { "item" : "zerchesiumbar", "count" : 3 }
+    { "item" : "titaniumbar", "count" : 3 }
   ],
   "output" : { "item" : "fucarbonhammer", "count" : 1 },
   "groups" : [ "armory2", "melee2", "all" ]

--- a/recipes/armory/melee/longsword/carbonlongsword.recipe
+++ b/recipes/armory/melee/longsword/carbonlongsword.recipe
@@ -3,9 +3,6 @@
     { "item" : "carbonplate", "count" : 4 },
     { "item" : "tungstenbar", "count" : 4 }
   ],
-  "output" : {
-    "item" : "carbonlongsword",
-    "count" : 1
-  },
+  "output" : { "item" : "carbonlongsword", "count" : 1 },
   "groups" : [ "armory2", "melee", "all" ]
 }

--- a/recipes/armory/melee/quarterstaff/carbonquarterstaff.recipe
+++ b/recipes/armory/melee/quarterstaff/carbonquarterstaff.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "carbonplate", "count" : 6 },
-    { "item" : "durasteelbar", "count" : 4 }
+    { "item" : "titaniumbar", "count" : 4 }
   ],
   "output" : { "item" : "carbonquarterstaff", "count" : 1 },
   "groups" : [ "armory2", "melee2", "all" ]

--- a/recipes/armory/melee/shortsword/carbonblade.recipe
+++ b/recipes/armory/melee/shortsword/carbonblade.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "carbonplate", "count" : 5 },
-    { "item" : "zerchesiumbar", "count" : 4 }
+    { "item" : "titaniumbar", "count" : 4 }
   ],
   "output" : { "item" : "carbonblade", "count" : 1 },
   "groups" : [ "armory2", "melee", "all" ]

--- a/recipes/armory/melee/spear/carbonspear.recipe
+++ b/recipes/armory/melee/spear/carbonspear.recipe
@@ -1,7 +1,7 @@
 {
   "input" : [
     { "item" : "carbonplate", "count" : 3 },
-    { "item" : "zerchesiumbar", "count" : 5 }
+    { "item" : "titaniumbar", "count" : 5 }
   ],
   "output" : { "item" : "carbonspear", "count" : 1 },
   "groups" : [ "armory2", "melee2", "all" ]

--- a/recipes/armory/melee/veluu/veluulongsword.recipe
+++ b/recipes/armory/melee/veluu/veluulongsword.recipe
@@ -4,5 +4,5 @@
     { "item" : "duskiline", "count" : 2 }
   ],
   "output" : { "item" : "veluulongsword", "count" : 1 },
-  "groups" : [ "armory1", "melee1", "all" ]
+  "groups" : [ "armory1", "melee", "all" ]
 }

--- a/recipes/armory/ranged/guns/2h/carbonshotgun.recipe
+++ b/recipes/armory/ranged/guns/2h/carbonshotgun.recipe
@@ -3,9 +3,6 @@
    { "item" : "carbonplate", "count" : 4 },
    { "item" : "titaniumbar", "count" : 4 }
   ],
-  "output" : {
-    "item" : "carbonshotgun",
-    "count" : 1
-  },
+  "output" : { "item" : "carbonshotgun", "count" : 1 },
   "groups" : [ "armory2", "ranged2", "all" ]
 }

--- a/recipes/chemlab/compounds/metallichydrogen.recipe
+++ b/recipes/chemlab/compounds/metallichydrogen.recipe
@@ -8,6 +8,6 @@
     "item" : "fu_hydrogenmetallic",
     "count" : 1
   },
-  "groups" : [ "chemlab3", "reagents", "all" ],
+  "groups" : [ "chemlab3", "compounds", "all" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/alienjuice.recipe
+++ b/recipes/chemlab/liquids/alienjuice.recipe
@@ -8,6 +8,6 @@
     "item" : "liquidalienjuice",
     "count" : 1
   },
-  "groups" : [ "chemlab2", "liquids", "all" ],
+  "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/bioooze.recipe
+++ b/recipes/chemlab/liquids/bioooze.recipe
@@ -6,7 +6,7 @@
   ],
   "output" : {
     "item" : "liquidbioooze",
-    "count" : 1
+    "count" : 3
   },
   "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25

--- a/recipes/chemlab/liquids/blacktar.recipe
+++ b/recipes/chemlab/liquids/blacktar.recipe
@@ -7,6 +7,6 @@
     "item" : "liquidblacktar",
     "count" : 1
   },
-  "groups" : [ "chemlab1", "liquids", "all" ],
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/blood.recipe
+++ b/recipes/chemlab/liquids/blood.recipe
@@ -7,6 +7,6 @@
     "item" : "liquidblood",
     "count" : 1
   },
-  "groups" : [ "chemlab1", "liquids", "all" ],
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/crystalliquid.recipe
+++ b/recipes/chemlab/liquids/crystalliquid.recipe
@@ -7,6 +7,6 @@
     "item" : "liquidcrystal",
     "count" : 5
   },
-  "groups" : [ "chemlab2", "liquids", "all" ],
+  "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/fusaltwater.recipe
+++ b/recipes/chemlab/liquids/fusaltwater.recipe
@@ -7,6 +7,6 @@
     "item" : "liquidwater",
     "count" : 10
   },
-  "groups" : [ "chemlab","chemlab1","chemlab2", "liquids", "all" ],
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.2
 }

--- a/recipes/chemlab/liquids/liquidiron.recipe
+++ b/recipes/chemlab/liquids/liquidiron.recipe
@@ -1,12 +1,12 @@
 {
   "input" : [
-    { "item" : "liquidwastewater", "count" : 1 },
+    { "item" : "liquidlava", "count" : 1 },
     { "item" : "ironore", "count" : 1 }
   ],
   "output" : {
     "item" : "liquidironfu",
-    "count" : 1
+    "count" : 3
   },
-  "groups" : [ "chemlab2", "liquids", "all" ],
+  "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/liquidirradium.recipe
+++ b/recipes/chemlab/liquids/liquidirradium.recipe
@@ -5,7 +5,7 @@
   ],
   "output" : {
     "item" : "liquidirradium",
-    "count" : 1
+    "count" : 2
   },
   "groups" : [ "chemlab3", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25

--- a/recipes/chemlab/liquids/liquidnitrogen.recipe
+++ b/recipes/chemlab/liquids/liquidnitrogen.recipe
@@ -5,8 +5,8 @@
   ],
   "output" : {
     "item" : "liquidnitrogenitem",
-    "count" : 1
+    "count" : 3
   },
-  "groups" : [ "chemlab2", "liquids", "all" ],
+  "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/liquidpoison.recipe
+++ b/recipes/chemlab/liquids/liquidpoison.recipe
@@ -7,6 +7,6 @@
     "item" : "liquidpoison",
     "count" : 3
   },
-  "groups" : [ "chemlab1", "liquids", "all" ],
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/liquidumechfuel.recipe
+++ b/recipes/chemlab/liquids/liquidumechfuel.recipe
@@ -7,6 +7,6 @@
     "item" : "liquidmechfuel",
     "count" : 5
   },
-  "groups" : [ "chemlab2", "liquids", "all"  ],
+  "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling"  ],
   "duration" : 0.01
 }

--- a/recipes/chemlab/liquids/liquidunrefinedmechfuel.recipe
+++ b/recipes/chemlab/liquids/liquidunrefinedmechfuel.recipe
@@ -7,6 +7,6 @@
     "item" : "unrefinedliquidmechfuel",
     "count" : 2
   },
-  "groups" : [ "chemlab2", "liquids", "all"  ],
+  "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling"  ],
   "duration" : 0.01
 }

--- a/recipes/chemlab/liquids/liquidwater.recipe
+++ b/recipes/chemlab/liquids/liquidwater.recipe
@@ -7,6 +7,6 @@
     "item" : "fusaltwater",
     "count" : 2
   },
-  "groups" : [ "chemlab","chemlab1", "liquids", "all" ],
+  "groups" : [ "chemlab","chemlab1", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/mercury.recipe
+++ b/recipes/chemlab/liquids/mercury.recipe
@@ -6,8 +6,8 @@
   ],
   "output" : {
     "item" : "ff_mercury",
-    "count" : 1
+    "count" : 3
   },
-  "groups" : [ "chemlab2", "liquids", "all" ],
+  "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/organicsoup.recipe
+++ b/recipes/chemlab/liquids/organicsoup.recipe
@@ -6,8 +6,8 @@
   ],
   "output" : {
     "item" : "liquidorganicsoup",
-    "count" : 1
+    "count" : 3
   },
-  "groups" : [ "chemlab2", "liquids", "all" ],
+  "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/purewater.recipe
+++ b/recipes/chemlab/liquids/purewater.recipe
@@ -6,8 +6,8 @@
   ],
   "output" : {
     "item" : "liquidwater",
-    "count" : 3
+    "count" : 5
   },
-  "groups" : [ "chemlab1", "liquids", "all" ],
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/pus.recipe
+++ b/recipes/chemlab/liquids/pus.recipe
@@ -7,6 +7,6 @@
     "item" : "liquidpus",
     "count" : 1
   },
-  "groups" : [ "chemlab1", "liquids", "all" ],
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/sulphuricacid.recipe
+++ b/recipes/chemlab/liquids/sulphuricacid.recipe
@@ -5,8 +5,8 @@
   ],
   "output" : {
     "item" : "liquidsulphuricacid",
-    "count" : 1
+    "count" : 5
   },
-  "groups" : [ "chemlab2", "liquids", "all" ],
+  "groups" : [ "chemlab2", "liquids", "all","nouncrafting","norecycling" ],
   "duration" : 0.25
 }

--- a/zb/researchTree/fu_warcraft.config
+++ b/zb/researchTree/fu_warcraft.config
@@ -111,7 +111,7 @@
 				"position" : [70, 85],
 				"children" : [  ],
 				"price" : [["fuscienceresource", 400],["duskiline", 5]],
-				"unlocks" : [ "magnorbveluu", "veluuclaws", "veluudagger", "veluulongsword", "fuveluushortsword", "armcannonveluu", "armcannonveluubullet", "armcannonveluufire", "armcannonveluuice", "armcannonveluupoison", "veluupistol", "veluurifle", "veluulongsword" ]
+				"unlocks" : [ "magnorbveluu", "veluuclaws", "veluudagger", "veluulongsword", "fuveluushortsword", "armcannonveluu", "armcannonveluubullet", "armcannonveluufire", "armcannonveluuice", "armcannonveluupoison", "veluupistol", "veluurifle" ]
 			},			
 			"tungstengear" : {
 				"icon" : "/items/generic/crafting/tungstenbar.png",


### PR DESCRIPTION
- Tweaked racial crew bed names, for the sake of the official wiki bot.
- Fixed the missing refrigerated storage group on the Avali kitchen fridge.
- Tweaked various liquid recipes to make underperforming recipes more worth using, and to fix incorrect recipe groups.
- Fixed metallic hydrogen being uncraftable.
- Altered carbon weapon recipes so that they are craftable by the time players gain access to titanium.
- Fixed the Vel'uuish longsword appearing twice in its research node, and having an incorrect crafting group.
- Fixed the Occult Researcher's dialogue.