### PR TITLE
Update isn_thermalgenerator.object

### DIFF
--- a/objects/power/isn_thermalgenerator/isn_thermalgenerator.object
+++ b/objects/power/isn_thermalgenerator/isn_thermalgenerator.object
@@ -51,9 +51,9 @@
 	"powertype" : "output",
 	"acceptablefuel" : {
 		//solids
-		"paper" : 2,
+		"paper" : 1,
 		"logblock" : 5,
-		"fullwood2" : 1,
+		"fullwood2" : 2,
 		"coalore" : 8,
 		"solidfuel" : 12,
 		"supermatter" : 25,

--- a/objects/power/isn_thermalgenerator/isn_thermalgenerator.object
+++ b/objects/power/isn_thermalgenerator/isn_thermalgenerator.object
@@ -53,7 +53,7 @@
 		//solids
 		"paper" : 4,
 		"logblock" : 5,
-		"fullwood2" : 5,
+		"fullwood2" : 3,
 		"coalore" : 8,
 		"solidfuel" : 12,
 		"supermatter" : 25,

--- a/objects/power/isn_thermalgenerator/isn_thermalgenerator.object
+++ b/objects/power/isn_thermalgenerator/isn_thermalgenerator.object
@@ -51,9 +51,9 @@
 	"powertype" : "output",
 	"acceptablefuel" : {
 		//solids
-		"paper" : 4,
+		"paper" : 2,
 		"logblock" : 5,
-		"fullwood2" : 3,
+		"fullwood2" : 1,
 		"coalore" : 8,
 		"solidfuel" : 12,
 		"supermatter" : 25,


### PR DESCRIPTION
Rebalanced the burn time of unrefined wood (fullwood2). It will still be beneficial to process the log into it, but a single log processed into 10 of these for a total of 50 seconds will no longer be the second best fuel in this machine.