### PR TITLE
hylotl breath

### DIFF
--- a/species/hylotl.raceeffect
+++ b/species/hylotl.raceeffect
@@ -112,7 +112,7 @@
 				{ "stat": "maxHealth", "effectiveMultiplier": 1.25 },
 				{ "stat": "physicalResistance", "amount": 0.2 },
 				{ "stat": "perfectBlockLimit", "amount": 2 },
-				{ "stat": "maxBreath", "amount": 1500 }
+				{ "stat": "breathDepletionRate", "effectiveMultiplier": 0.0625 }
 			]
 		}
 	]

--- a/species/hylotl.species.patch
+++ b/species/hylotl.species.patch
@@ -62,7 +62,7 @@
   ^green;Resist^reset;: +^green;20^reset;% Ice
 
 ^orange;Environment^reset;:
-  +^green;1500^reset; oxygen in water
+  (Salt, Healing, Swamp) Water, Sewage: Breath Depletion Rate x^green;0.0625^reset;
   On ^green;oceanic^reset; biomes: Health & Energy x^green;1.12^reset;, Defense x^green;1.15^reset;
   In water: +^green;20^reset;% Physical Resistance, Health x^green;1.25^reset;, ^green;Swim Boost^reset;
   Rain grants very slight regeneration.

--- a/stats/__STAT_LIST.TXT
+++ b/stats/__STAT_LIST.TXT
@@ -122,7 +122,7 @@ OTHER:
     noFood                          [amount]              [Boolean] - doesn't really do anything?
     foodDelta                       [baseMultiplier]      [X-Relative, Default: -0.0583] Results in -70 food over 20 minutes. Flat modifier to food per second.
     
-    maxBreath                       [amount]              [Static Number, Default: 100]
+    maxBreath                       [amount]              [Static Number, Default: 100] WARNING: Do not use in conditionals related to being in unbreathable locations. it will not function properly. modify breath depletion rate instead.
     breathDepletionRate             [baseMultiplier]      [X-Relative, Default: 4]
     breathRegenerationRate          [amount]              [Static Number, Unit unknown: Breath/sec? Default: 10]
 	


### PR DESCRIPTION
fixed hylotl water breath bonus: reduces breath depletion rate, rather than increasing max breath, since the latter doesnt work as was expected