### PR TITLE
Fix remaining item name collision with Tungsten Magnum

### DIFF
--- a/items/active/weapons/ranged/unique/irradiumrifle.activeitem
+++ b/items/active/weapons/ranged/unique/irradiumrifle.activeitem
@@ -6,7 +6,7 @@
   "rarity" : "rare",
   "description" : "Even if you graze 'em, the radiation burn is deadly
 ^yellow;Inflicts radiation burn^reset;",
-    "shortdescription" : "Irradium Rifle",
+    "shortdescription" : "Irradium Energy Rifle",
   "category" : "sniperRifle",
   "level" : 4,
   "tooltipKind" : "gun2",

--- a/items/active/weapons/ranged/unique/pistoltungstenfu.activeitem
+++ b/items/active/weapons/ranged/unique/pistoltungstenfu.activeitem
@@ -6,7 +6,7 @@
   "rarity" : "common",
   "description" : "Fires high-caliber rounds.
 ^yellow;High damage rounds.^reset;",
-  "shortdescription" : "Tungsten Magnum",
+  "shortdescription" : "Tungsten Revolver",
   "level" : 2,
   "category" : "pistol",
   "itemTags" : ["weapon","ranged","pistol","upgradeableWeapon"],

--- a/recipes/emptyhands/stonemace.recipe
+++ b/recipes/emptyhands/stonemace.recipe
@@ -5,7 +5,7 @@
     { "item" : "plantfibre", "count" : 2 }
   ],
   "output" : {
-    "item" : "stonemace2",
+    "item" : "stonemace",
     "count" : 1
   },
   "groups" : [ "plain", "primitive"  ]


### PR DESCRIPTION
Renaming Tungsten Revolver was a mistake (vanilla already has Magnum, so Tungsten Revolver wasn't a duplicate name), so we revert it.

Renaming of "Durasteel Revolver" was correct and is not reverted.