### PR TITLE
Cute Sconce alignment fix

### DIFF
--- a/objects/vanity/cute/cutesconce/cutesconce.object
+++ b/objects/vanity/cute/cutesconce/cutesconce.object
@@ -46,13 +46,13 @@
 
     {
       "image" : "cutesconce_back.png:<color>.<frame>",
-      "imagePosition" : [1, 0],
+      "imagePosition" : [-4, 0],
 
       "animationParts" : {
         "bg" : "cutesconce_back.png",
         "fg" : "cutesconce_backlit.png"
       },
-      "animationPosition" : [1, 0],
+      "animationPosition" : [-4, 0],
 
       "spaces" : [ [0, 0], [0, 1] ],
       "bgAnchors" : [ [0, 0] ],


### PR DESCRIPTION
Cute Sconce object was positioned too far to the right of where it was placed. Now properly centered on a wall block.