### PR TITLE
Cute Chandelier alignment fix

### DIFF
--- a/objects/vanity/cute/cutechandelier/cutechandelier.object
+++ b/objects/vanity/cute/cutechandelier/cutechandelier.object
@@ -14,24 +14,24 @@
   "orientations" : [
     {
       "image" : "cutechandelier.png:<color>.<frame>",
-      "imagePosition" : [-7, 0],
+      "imagePosition" : [-8, 0],
       "frames" : 1,
       "animationCycle" : 0.3,
       "direction" : "left",
       "flipImages" : true,
       "lightPosition" : [0, 3],
-      "animationPosition" : [-7, 0],
+      "animationPosition" : [-8, 0],
       "spaceScan" : 0.1,
       "anchors" : [ "top" ]
     },
     {
       "image" : "cutechandelier.png:<color>.<frame>",
-      "imagePosition" : [-7, 0],
+      "imagePosition" : [-8, 0],
       "frames" : 1,
       "animationCycle" : 0.3,
       "direction" : "right",
       "lightPosition" : [0, 3],
-      "animationPosition" : [-7, 0],
+      "animationPosition" : [-8, 0],
       "spaceScan" : 0.1,
       "anchors" : [ "top" ]
     }


### PR DESCRIPTION
Cute Chandelier object is displayed a couple pixels too far to the right from the center of two blocks. Now properly centered.