### PR TITLE
Cute Lamp alignment fix

### DIFF
--- a/objects/vanity/cute/cutelamp/cutelamp.object
+++ b/objects/vanity/cute/cutelamp/cutelamp.object
@@ -14,24 +14,24 @@
   "orientations" : [
     {
       "image" : "cutelamp.png:<color>.<frame>",
-      "imagePosition" : [-7, 0],
+      "imagePosition" : [-8, 0],
       "frames" : 1,
       "animationCycle" : 0.3,
       "direction" : "left",
       "flipImages" : true,
       "lightPosition" : [0, 3],
-      "animationPosition" : [-7, 0],
+      "animationPosition" : [-8, 0],
       "spaceScan" : 0.1,
       "anchors" : [ "bottom" ]
     },
     {
       "image" : "cutelamp.png:<color>.<frame>",
-      "imagePosition" : [-7, 0],
+      "imagePosition" : [-8, 0],
       "frames" : 1,
       "animationCycle" : 0.3,
       "direction" : "right",
       "lightPosition" : [0, 3],
-      "animationPosition" : [-7, 0],
+      "animationPosition" : [-8, 0],
       "spaceScan" : 0.1,
       "anchors" : [ "bottom" ]
     }


### PR DESCRIPTION
Cute Lamp object was displayed a few pixels too far to the right of the center of two blocks. Now properly centered.