### PR TITLE
Cute Lamp Post alignment fix

### DIFF
--- a/objects/vanity/cute/cutelamppost/cutelamppost.object
+++ b/objects/vanity/cute/cutelamppost/cutelamppost.object
@@ -14,24 +14,24 @@
   "orientations" : [
     {
       "image" : "cutelamppost.png:<color>.<frame>",
-      "imagePosition" : [-7, 0],
+      "imagePosition" : [-8, 0],
       "frames" : 1,
       "animationCycle" : 0.3,
       "direction" : "left",
       "flipImages" : true,
       "lightPosition" : [0, 3],
-      "animationPosition" : [-7, 0],
+      "animationPosition" : [-8, 0],
       "spaceScan" : 0.1,
       "anchors" : [ "bottom" ]
     },
     {
       "image" : "cutelamppost.png:<color>.<frame>",
-      "imagePosition" : [-7, 0],
+      "imagePosition" : [-8, 0],
       "frames" : 1,
       "animationCycle" : 0.3,
       "direction" : "right",
       "lightPosition" : [0, 3],
-      "animationPosition" : [-7, 0],
+      "animationPosition" : [-8, 0],
       "spaceScan" : 0.1,
       "anchors" : [ "bottom" ]
     }


### PR DESCRIPTION
Cute Lamp Post object was positioned a few pixels too far to the right from center of placement. Now properly centered.