### PR TITLE
Workaround for truncated description of Bone/Stone/Primitive hammers in Basic Crafting menu

### DIFF
--- a/items/active/weapons/melee/greataxe/stonegreataxe.activeitem
+++ b/items/active/weapons/melee/greataxe/stonegreataxe.activeitem
@@ -6,7 +6,7 @@
   "rarity" : "Common",
   "description" : "Great for early meat and hide gathering.",
   "shortdescription" : "Primitive Greataxe",
-  "tooltipKind" : "hammer",
+  "tooltipKind" : "sword",
   "category" : "greataxe",
   "twoHanded" : true,
   "itemTags" : ["weapon","melee","greataxe", "upgradeableWeapon","stone"],

--- a/items/active/weapons/melee/hammer/fubonehammer.activeitem
+++ b/items/active/weapons/melee/hammer/fubonehammer.activeitem
@@ -5,7 +5,7 @@
   "rarity" : "common",
   "description" : "Primitive murder in the palm of your hand.",
   "shortdescription" : "Bone Cudgel",
-  "tooltipKind" : "hammer",
+  "tooltipKind" : "sword",
   "category" : "hammer",
   "twoHanded" : true,
   "itemTags" : ["weapon","melee","hammer", "upgradeableWeapon","bone"],

--- a/items/active/weapons/melee/hammer/stonehammer.activeitem
+++ b/items/active/weapons/melee/hammer/stonehammer.activeitem
@@ -6,7 +6,7 @@
   "rarity" : "Common",
   "description" : "Great for early meat and hide gathering.",
   "shortdescription" : "Primitive Hammer",
-  "tooltipKind" : "hammer",
+  "tooltipKind" : "sword",
   "category" : "hammer",
   "twoHanded" : true,
   "itemTags" : ["weapon","melee","hammer", "upgradeableWeapon","stone"],

--- a/items/active/weapons/melee/mace/bonemace.activeitem
+++ b/items/active/weapons/melee/mace/bonemace.activeitem
@@ -6,7 +6,7 @@
   "rarity" : "common",
   "description" : "Simple, but effective. Design by Sacre.",
   "shortdescription" : "Bone Mace",
-  "tooltipKind" : "hammer",
+  "tooltipKind" : "sword",
   "category" : "mace",
   "twoHanded" : false,
   "itemTags" : ["weapon","melee","mace", "upgradeableWeapon","bone"],

--- a/items/active/weapons/melee/mace/stonemace.activeitem
+++ b/items/active/weapons/melee/mace/stonemace.activeitem
@@ -6,7 +6,7 @@
   "rarity" : "common",
   "description" : "Literally a rock tied to a stick. Design by Dagnez",
   "shortdescription" : "Stone Club",
-  "tooltipKind" : "hammer",
+  "tooltipKind" : "sword",
   "category" : "mace",
   "twoHanded" : false,
   "itemTags" : ["weapon","melee","mace", "upgradeableWeapon","stone"],

--- a/items/active/weapons/melee/mace/woodenmace.activeitem
+++ b/items/active/weapons/melee/mace/woodenmace.activeitem
@@ -6,7 +6,7 @@
   "rarity" : "common",
   "description" : "It's a piece of wood. You whack things with it.",
   "shortdescription" : "Wooden Club",
-  "tooltipKind" : "hammer",
+  "tooltipKind" : "sword",
   "category" : "mace",
   "twoHanded" : false,
   "itemTags" : ["weapon","melee","mace", "upgradeableWeapon","wood"],


### PR DESCRIPTION
"hammer" tooltip is too large for Crafting menu, but "sword" tooltip is shown correctly.

This is a crude workaround, as it doesn't show Stun Chance for hammers,
but Stun Chance wasn't visible anyway (due to being truncated).
