### PR TITLE
Fix incorrect name/description of "herocowl" item

### DIFF
--- a/items/armors/costumes/herocowl/herocowl.head
+++ b/items/armors/costumes/herocowl/herocowl.head
@@ -4,8 +4,8 @@
   "dropCollision" : [-4.0, -3.0, 4.0, 3.0],
   "maxStack" : 1,
   "rarity" : "rare",
-  "description" : "Laugh it up.",
-  "shortdescription" : "Joke Glasses",
+  "description" : "Hides your secret identity.",
+  "shortdescription" : "Hero Cowl",
   "category" : "headarmour",
   "tooltipKind" : "armor",
 


### PR DESCRIPTION
Previous name ("Joke Glasses") is an accidental copy-paste from `items/armors/costumes/jokeglasses/jokeglasses.head`

"herocowl" doesn't look like glasses, so this name doesn't fit it.