### PR TITLE
cake

### DIFF
--- a/items/active/weapons/ranged/unique/corerifle.activeitem
+++ b/items/active/weapons/ranged/unique/corerifle.activeitem
@@ -166,7 +166,7 @@
     "overheatLevel" : 100,        //Overheat at this value        
       "projectileType" : "corerifleshot",
       "projectileParameters" : { 
-		"statusEffect" : [ "burning" ],
+		"statusEffects" : [ "burning" ],
         "speed" : 82,
         "knockback" : 4
       }
@@ -203,7 +203,7 @@
         "speed" : 92,
         "knockback" : 6,
 		"damageKind" : "hellfire",		
-        "statusEffect" : [ "burningnapalm" ]
+        "statusEffects" : [ "burningnapalm" ]
       }
     }
   }    

--- a/items/active/weapons/staff/abilities/transdimensional.lua
+++ b/items/active/weapons/staff/abilities/transdimensional.lua
@@ -48,7 +48,7 @@ function Controlledteleport:charge()
 
   local chargeTimer = self.stances.charge.duration
   while chargeTimer > 0 and self.fireMode == (self.activatingFireMode or self.abilitySlot) do
-    chargeTimer = chargeTimer - self.dt
+    chargeTimer = chargeTimer - (self.dt*(((status.statPositive("admin") or player.isAdmin()) and 10) or 1))
 
     mcontroller.controlModifiers({runningSuppressed=true})
 

--- a/items/generic/drinks/ciders/miracleambrosia.consumable
+++ b/items/generic/drinks/ciders/miracleambrosia.consumable
@@ -23,8 +23,13 @@
 			{
 				"effect" : "booze",
 				"duration" : 60
+			},		
+			{
+				"effect" : "miracleambrosiacooldown",
+				"duration" : 60
 			}
 		]
 	],
-  "emitters" : [ "drinking" ]
+	"emitters" : [ "drinking" ],
+	"blockingEffects":["miracleambrosiacooldown"]
 }

--- a/projectiles/guns/corerifleshot/corerifleshot.projectile
+++ b/projectiles/guns/corerifleshot/corerifleshot.projectile
@@ -13,7 +13,7 @@
   "speed" : 72,
   "power" : 1,
 
-  "statusEffect" : [ "burning" ],
+  "statusEffects" : [ "burning" ],
       "actionOnReap" : [
         {
           "action" : "config",

--- a/stats/effects/fu_effects/fu_dummyeffects/miracleambrosiacooldown/miracleambrosiacooldown.statuseffect
+++ b/stats/effects/fu_effects/fu_dummyeffects/miracleambrosiacooldown/miracleambrosiacooldown.statuseffect
@@ -1,0 +1,6 @@
+{
+	"name" : "miracleambrosiacooldown",
+	"defaultDuration" : 30,
+	"label" : "Cannot use Miracle Ambrosia",
+	"icon" : "/interface/statuses/healingpenalty.png"
+}

--- a/stats/monster_primary.lua
+++ b/stats/monster_primary.lua
@@ -93,22 +93,24 @@ function applyDamageRequest(damageRequest)
 
 	if not status.resourcePositive("health") then
 		hitType = "kill"
-	--sb.logInfo("%s",damageRequest)
-	--this sadly doesnt actually cause drops to be hunting drops.
-	--there is ZERO way to interact with monster drop pools from scripts. period. stop trying.
-	--[[
-	if string.find(damageRequest.damageSourceKind,"bow") then
-		damageRequest.damageSourceKind="bow"
-	end]]
-	--instead, we take a smarter workaround that functions, albeit annoyingly
-	if string.find(damageRequest.damageSourceKind,"bow") and not (damageRequest.damageSourceKind=="bow") and status then
-		status.setResource("health",1)
-		--set resistances to nil so at least the damage number is represented properly
-		status.addEphemeralEffect("vulnerability",1,damageRequest.sourceEntityId)
-		--then spawn a projectile and gib 'em.
-		world.spawnProjectile("fuinvisibleprojectiletiny", entity.position(), damageRequest.sourceEntityId,nil,nil,{damageType="IgnoresDef",damageKind="bow",damageTeam={type="friendly"},power=damage})
-		return {}
-	end
+		--sb.logInfo("%s",damageRequest)
+		--this sadly doesnt actually cause drops to be hunting drops.
+		--there is ZERO way to interact with monster drop pools from scripts. period. stop trying.
+		--[[
+		if string.find(damageRequest.damageSourceKind,"bow") then
+			damageRequest.damageSourceKind="bow"
+		end]]
+		--instead, we take a smarter workaround that functions, albeit annoyingly
+		if string.find(damageRequest.damageSourceKind,"bow") and not (damageRequest.damageSourceKind=="bow") then
+			if damage>=1 then
+				status.setResource("health",1)
+				--set resistances to nil so at least the damage number is represented properly
+				status.addEphemeralEffect("vulnerability",1,damageRequest.sourceEntityId)
+				--then spawn a projectile and gib 'em.
+				world.spawnProjectile("fuinvisibleprojectiletiny", entity.position(), damageRequest.sourceEntityId,nil,nil,{damageType="IgnoresDef",damageKind="bow",damageTeam={type="friendly"},power=damage})
+				return {}
+			end
+		end
 	end
 	return {{
 		sourceEntityId = damageRequest.sourceEntityId,


### PR DESCRIPTION
void warp locus now charges near instantly for admins, to make testing instance-dependent content less a migraine.

miracle ambrosia cooldown refactored. it is now a 1 minute cooldown with a status effect indicator

fixed a bug with the hunting damage override, which caused 0 damage 'bow' damage projectiles (such as the core rifle's explosion) to break certain encounters such as asra nox