### PR TITLE
Updated treasure pools to account for T2 encounters

### DIFF
--- a/treasure/space.treasurepools.patch
+++ b/treasure/space.treasurepools.patch
@@ -14,7 +14,7 @@
     "path": "/commonSpaceItem/0/1/pool/2"
   },
   
-  //Re-tiering space treasurepools to start giving the 'this is a real space encouncounter, not friendly' loot at T2
+  //Re-tiering space treasurepools to start giving the 'this is a real space encounter, not friendly' loot at T2
   {
     "op": "replace",
     "path": "/spaceRock/1/0",

--- a/treasure/space.treasurepools.patch
+++ b/treasure/space.treasurepools.patch
@@ -12,5 +12,37 @@
   {
     "op": "remove",
     "path": "/commonSpaceItem/0/1/pool/2"
+  },
+  
+  //Re-tiering space treasurepools to start giving the 'this is a real space encouncounter, not friendly' loot at T2
+  {
+    "op": "replace",
+    "path": "/spaceRock/1/0",
+    "value": 1.9
+  },
+  {
+    "op": "replace",
+    "path": "/spaceRobot/1/0",
+    "value": 1.9
+  },
+  {
+    "op": "replace",
+    "path": "/spaceRobotPassive/1/0",
+    "value": 0.9
+  },
+  {
+    "op": "replace",
+    "path": "/rareSpaceItem/1/0",
+    "value": 1.9
+  },
+  {
+    "op": "replace",
+    "path": "/mechPartBlueprint/1/0",
+    "value": 1.9
+  },
+  {
+    "op": "replace",
+    "path": "/salvageComponent/1/0",
+    "value": 1.9
   }
 ]


### PR DESCRIPTION
Re-tiering space treasurepools to start giving the 'this is a real space encounter, not friendly' loot at T2. Won't be player-facing, is preparation for when you change gentle star encounters to T2