### PR TITLE
Fix misc. biome-related errors

### DIFF
--- a/biomes/surface/astral.biome
+++ b/biomes/surface/astral.biome
@@ -1,6 +1,7 @@
 {
 	"name": "astral",
 	"friendlyName": "Aetheric",
+	"statusEffects" : [ "aetherweathernew"  ],
 
 	"spawnProfile": {
 		"groups": [{

--- a/terrestrial_worlds.config.patch
+++ b/terrestrial_worlds.config.patch
@@ -8990,7 +8990,7 @@
 			"caveLiquid": ["water", "poison"],
 			"caveLiquidChanceRange": [35, 85],
 			"biome": [
-				[0, ["ffvolcanic"]]
+				[0, ["ffzen"]]
 			]
 		}
 	},

--- a/terrestrial_worlds.config.patch
+++ b/terrestrial_worlds.config.patch
@@ -3200,7 +3200,7 @@
 					"primaryRegion": ["clouds"]
 				},
 				"surface": {
-					"primaryRegion": ["arboreal2"],
+					"primaryRegion": ["arborealdark"],
 					"secondaryRegions": ["futentacle", "wartfield", "wastelandmini", "steamspring", "corruptedforest", "hellhive", "goreforest", "cactiplace", "crystalswamp", "birchforest", "alienforest", "swamp", "hellhive", "elder", "corruptedforest", "flowerforest", "deadwood", "giantflowers"],
 					"dungeons": [
 						[1.0, "ship1"],


### PR DESCRIPTION
- Add missing "Aetheric Atmosphere" hazard to land-based Aether Worlds.
- Fix typo that caused Dark Primeval planets to use Volcanic Primeval as main biome.
- Fix typo that caused "ffvolcanic" biome to be used instead of "ffzen".