### PR TITLE
cultist staff fix

### DIFF
--- a/items/active/weapons/staff/cultiststaff3/cultiststaff3.activeitem
+++ b/items/active/weapons/staff/cultiststaff3/cultiststaff3.activeitem
@@ -44,7 +44,7 @@
 
   "scripts" : ["/items/active/weapons/staff/staff.lua"],
 
-  "baseDamageFactor" : 1.5,
+  "baseDamageFactor" : 0.5,
 
   "stances" : {
     "idle" : {
@@ -100,13 +100,13 @@
     "scripts" : ["/items/active/weapons/staff/abilities/controlprojectile/controlprojectile.lua"],
     "class" : "ControlProjectile",
 
-    "energyCost" : 75,
+    "energyCost" : 100,
 
     "maxCastRange" : 50,
 
     "projectileType" : "elderportal",
     "projectileParameters" : {
-      "baseDamage" : 12
+      "baseDamage" : 6
     }
   },
 


### PR DESCRIPTION
brought the cultist staff's damage back down to earth, as it was doing absurd amounts with no investment. there's no way a tier 7 weapon with t6 warp miner should be spamming projectiles doing 300-400 damage every half a second.