### PR TITLE
Fixing a typo for Redwood Bark

### DIFF
--- a/items/materials/redwoodbark.matitem
+++ b/items/materials/redwoodbark.matitem
@@ -3,7 +3,7 @@
   "category" : "block",
   "rarity" : "common",
   "inventoryIcon" : "redwoodicon.png",
-  "description" : "Redwork bark. Peeled from the logs of large trees.",
+  "description" : "Redwood bark. Peeled from the logs of large trees.",
   "shortdescription" : "Redwood Bark",
   "glitchDescription" : "Unimpressed. This bark covering is not sturdy.",
   "floranDescription" : "Floran likess rough bark covering. Feelss like home.",

--- a/tiles/materials/redwoodbark.material
+++ b/tiles/materials/redwoodbark.material
@@ -5,7 +5,7 @@
   "itemDrop" : "redwoodbark",
 
   "shortdescription" : "Redwood Bark",
-  "description" : "Redwork bark. Peeled from the logs of large trees",
+  "description" : "Redwood bark. Peeled from the logs of large trees",
   "glitchDescription" : "Unimpressed. This bark covering is not sturdy.",
   "floranDescription" : "Floran likess rough bark covering. Feelss like home.",
   "novakidDescription" : "Nice lookin' bark straight off a tree.",


### PR DESCRIPTION
Enough said honestly. I just went into the .matitem / .material files to turn 'Redwork' -> 'Redwood'.

P.S. This is my first time forking a repository on my own, so if I made a mistake feel free to point that out.