### PR TITLE
clamp

### DIFF
--- a/scripts/FRHelper.lua
+++ b/scripts/FRHelper.lua
@@ -4,10 +4,10 @@ FRHelper = {}
 DynamicScripts = {}
 
 function FRHelper:new(species,gender)
-    local frHelper = {}
-    frHelper.frconfig = root.assetJson("/frackinraces.config")
+	local frHelper = {}
+	frHelper.frconfig = root.assetJson("/frackinraces.config")
 
-    frHelper.species = species
+	frHelper.species = species
 	local success
 	if species then
 		success, frHelper.speciesConfig = pcall(
@@ -19,37 +19,40 @@ function FRHelper:new(species,gender)
 	if not success then frHelper.speciesConfig = root.assetJson("/species/_default.raceeffect") end
 
 	if frHelper.speciesConfig.gender and frHelper.speciesConfig.gender[gender] then
-	  frHelper.speciesConfig = util.mergeTable(frHelper.speciesConfig,frHelper.speciesConfig.gender[gender])
+		frHelper.speciesConfig = util.mergeTable(frHelper.speciesConfig,frHelper.speciesConfig.gender[gender])
 	end
 	frHelper.speciesConfig.gender = nil
 
-    frHelper.stats = frHelper.speciesConfig.stats                          -- status modifiers
-    frHelper.controlModifiers = frHelper.speciesConfig.controlModifiers    -- control modifiers
-    frHelper.controlParameters = frHelper.speciesConfig.controlParameters  -- control parameters
-    --frHelper.envEffects = frHelper.speciesConfig.envEffects              -- environmental effects
-    --frHelper.weaponEffects = frHelper.speciesConfig.weaponEffects        -- weapon effects
-    frHelper.special = frHelper.speciesConfig.special                      -- status effects applied
+	frHelper.stats = frHelper.speciesConfig.stats													-- status modifiers
+	frHelper.controlModifiers = frHelper.speciesConfig.controlModifiers		-- control modifiers
+	frHelper.controlParameters = frHelper.speciesConfig.controlParameters	-- control parameters
+	--frHelper.envEffects = frHelper.speciesConfig.envEffects							-- environmental effects
+	--frHelper.weaponEffects = frHelper.speciesConfig.weaponEffects				-- weapon effects
+	frHelper.special = frHelper.speciesConfig.special											-- status effects applied
 
-    --frHelper.scripts = frHelper.speciesConfig.weaponScripts              -- Scripts
-    frHelper.scriptCalls = {}                                              -- Stores the loaded script calls
+	--frHelper.scripts = frHelper.speciesConfig.weaponScripts							-- Scripts
+	frHelper.scriptCalls = {}																							-- Stores the loaded script calls
 
-    frHelper.persistentEffects = {}
+	frHelper.persistentEffects = {}
 
-    setmetatable(frHelper, extend(self))
-    return frHelper
+	setmetatable(frHelper, extend(self))
+	return frHelper
 end
 
 -- Applies the given status parameters (name is required for setting persistent effects)
 -- Is a combination of applying persistent effects, control modifiers, and scripts all in one
 -- Extra arguments are sent to any scripts run
 function FRHelper:applyStats(stats, name, ...)
-    if name then self:applyPersistent(stats.stats, name) end
-    self:applyControlModifiers(stats.controlModifiers, stats.controlParameters)
-    if stats.scripts then
-        for _,script in ipairs(stats.scripts) do
-            self:runScript(script, ...)
-        end
-    end
+	--sb.logInfo("aS: %s,%s,%s",stats,name,{...})
+	if name then
+		self:applyPersistent(stats.stats, name)
+	end
+	self:applyControlModifiers(stats.controlModifiers, stats.controlParameters)
+	if stats.scripts then
+		for _,script in ipairs(stats.scripts) do
+				self:runScript(script, ...)
+		end
+	end
 end
 
 local function split(str, pat)
@@ -91,7 +94,7 @@ end
 -- Checks if the items match the given combo
 function FRHelper:validCombo(item1, item2, combo)
 	combo=splitCombo(combo)
-    if #combo == 2 and item1 and item2 then  -- two-weapon combos
+	if #combo == 2 and item1 and item2 then	-- two-weapon combos
 		if ((combo[1].tag == "nothing") and (combo[1].condition=="is")) or ((combo[2].tag == "nothing") and (combo[2].condition=="is")) then
 			return false
 		else
@@ -110,7 +113,7 @@ function FRHelper:validCombo(item1, item2, combo)
 			--sb.logInfo("%s::%s",combo,{combo1item1,combo1item2,combo2item1,combo2item2,(combo1item1 and combo2item2),(combo1item2 and combo2item1)})
 			return (combo1item1 and combo2item2) or (combo1item2 and combo2item1)
 		end
-    elseif ((item1 and not item2) or (item2 and not item1)) then  -- single-weapon combos
+	elseif ((item1 and not item2) or (item2 and not item1)) then	-- single-weapon combos
 		if (#combo == 1) then
 			local test=root.itemHasTag(item1 or item2, combo[1].tag)
 			if combo[1].condition=="not" then
@@ -140,17 +143,18 @@ function FRHelper:validCombo(item1, item2, combo)
 		elseif #combo==1 then
 			if ((combo[1].tag == "nothing") and (combo[1].condition=="is")) then return true end
 		end
-    end
-    return false
+	end
+	return false
 end
 
 -- Checks for if the given persistent effect is currently applied
 function FRHelper:checkStatusApplied(name)
-    return #status.getPersistentEffects(name) > 0 and true or false
+	return #status.getPersistentEffects(name) > 0 and true or false
 end
 
 -- Apply the given persistent effect with the given name
 function FRHelper:applyPersistent(stats, name)
+	--sb.logInfo("aP: %s,%s",stats,name)
 	-- Don't reapply an identical persistent effect
 	if not compare(stats or {},self.persistentEffects[name]) then
 		status.setPersistentEffects(name, stats or {})
@@ -161,110 +165,110 @@ end
 -- Function for clearing applied persistent effects added through applyStats()
 -- With name, it clears the effect with the matching name. Otherwise, clears all.
 function FRHelper:clearPersistent(name)
-    if name then
-        status.clearPersistentEffects(name)
-        self.persistentEffects[name] = nil
-    else
-        for thing,_ in pairs(self.persistentEffects) do
-            status.clearPersistentEffects(thing)
-            self.persistentEffects[thing] = nil
-        end
-    end
+	if name then
+		status.clearPersistentEffects(name)
+		self.persistentEffects[name] = nil
+	else
+		for thing,_ in pairs(self.persistentEffects) do
+			status.clearPersistentEffects(thing)
+			self.persistentEffects[thing] = nil
+		end
+	end
 end
 
 -- For weaponabilities
 function clearPersistent(name)
-    if not self.helper then return end
-    self.helper:clearPersistent(name)
+	if not self.helper then return end
+	self.helper:clearPersistent(name)
 end
 
 -- Applies the set control modifiers/parameters. Missing arguments are replaced with default.
 function FRHelper:applyControlModifiers(cM, cP)
-    mcontroller.controlModifiers(cM or self.controlModifiers or {})
-    mcontroller.controlParameters(cP or self.controlParameters or {})
+	mcontroller.controlModifiers(cM or self.controlModifiers or {})
+	mcontroller.controlParameters(cP or self.controlParameters or {})
 end
 
 -- Load the given script (scripts without context are added to "racialscript" instead)
 function FRHelper:loadScript(script)
-    local contexts = script.contexts
-    local path = script.script
-    local args = script.args
-    if type(contexts) == "string" then contexts = {contexts} end
-    if not contexts then contexts = {"racialscript"} end
-    for _,context in ipairs(contexts) do
-        self.scriptCalls[context] = self.scriptCalls[context] or {}
-        self.scriptCalls[context][args or path] = path
-        if not scriptLoaded(script.script) then
-            self.call = nil
-            require(script.script)
-            DynamicScripts[path] = self.call   -- Add to loaded script list
-            self.call = nil
-        end
-    end
+	local contexts = script.contexts
+	local path = script.script
+	local args = script.args
+	if type(contexts) == "string" then contexts = {contexts} end
+	if not contexts then contexts = {"racialscript"} end
+	for _,context in ipairs(contexts) do
+		self.scriptCalls[context] = self.scriptCalls[context] or {}
+		self.scriptCalls[context][args or path] = path
+		if not scriptLoaded(script.script) then
+			self.call = nil
+			require(script.script)
+			DynamicScripts[path] = self.call	 -- Add to loaded script list
+			self.call = nil
+		end
+	end
 end
 
 -- Loads weapon scripts (important)
 function FRHelper:loadWeaponScripts(contexts)
-    if type(contexts) == "string" then contexts = {contexts} end
-    -- For each script setting
-    for _,thing in ipairs(self.speciesConfig.weaponScripts or {}) do
-        -- Check if it matches any of the contexts
-        for _,context in ipairs(contexts or {}) do
-            -- If it matches, load the script and add the call and args to the list
-            if contains(thing.contexts, context) then
-                -- If there's a weapon type restriction, check it
-                if thing.weapons then
-                    local doLoad = false
-                    for _,weap in ipairs(thing.weapons) do
-                        if root.itemHasTag(world.entityHandItem(activeItem.ownerEntityId(), activeItem.hand()), weap) then
-                            doLoad = true
-                            break
-                        end
-                    end
-                    -- If blacklisting, don't load weapons that matched, but load those that didn't
-                    if thing.blacklist then doLoad = not doLoad end
-                    if doLoad then self:loadScript(thing) end
-                else
-                    self:loadScript(thing)
-                end
-            end
-        end
-    end
+	if type(contexts) == "string" then contexts = {contexts} end
+	-- For each script setting
+	for _,thing in ipairs(self.speciesConfig.weaponScripts or {}) do
+		-- Check if it matches any of the contexts
+		for _,context in ipairs(contexts or {}) do
+			-- If it matches, load the script and add the call and args to the list
+			if contains(thing.contexts, context) then
+				-- If there's a weapon type restriction, check it
+				if thing.weapons then
+					local doLoad = false
+					for _,weap in ipairs(thing.weapons) do
+						if root.itemHasTag(world.entityHandItem(activeItem.ownerEntityId(), activeItem.hand()), weap) then
+							doLoad = true
+							break
+						end
+					end
+					-- If blacklisting, don't load weapons that matched, but load those that didn't
+					if thing.blacklist then doLoad = not doLoad end
+					if doLoad then self:loadScript(thing) end
+				else
+					self:loadScript(thing)
+				end
+			end
+		end
+	end
 end
 
 -- Runs all of the loaded scripts of the given context(s)
 -- Params is extra things that can be sent (typically parameters from the parent function)
 -- NOTE: For extra parameters, the standard is self, method args, then anything extra!
 function FRHelper:runScripts(contexts, ...)
-    if type(contexts) == "string" then contexts = {contexts} end
-    for _,context in ipairs(contexts or {}) do
-        for args,path in pairs(self.scriptCalls[context] or {}) do
-            if DynamicScripts[path] then
-                self.call = DynamicScripts[path]
-                self:call(args, ...)
-                self.call = nil
-            end
-        end
-    end
+	if type(contexts) == "string" then contexts = {contexts} end
+	for _,context in ipairs(contexts or {}) do
+		for args,path in pairs(self.scriptCalls[context] or {}) do
+			if DynamicScripts[path] then
+				self.call = DynamicScripts[path]
+				self:call(args, ...)
+				self.call = nil
+			end
+		end
+	end
 end
 
 -- For running one specific script, loads if necessary.
 function FRHelper:runScript(script, ...)
-    local path = script.script
-    local args = script.args
-    if not scriptLoaded(path) then
-        self:loadScript(script)
-    end
-    if DynamicScripts[path] then
-        self.call = DynamicScripts[path]
-        self:call(args, ...)
-        self.call = nil
-    end
+	local path = script.script
+	local args = script.args
+	if not scriptLoaded(path) then
+		self:loadScript(script)
+	end
+	if DynamicScripts[path] then
+		self.call = DynamicScripts[path]
+		self:call(args, ...)
+		self.call = nil
+	end
 end
 
 -- Returns whether the given script is loaded
 function scriptLoaded(script)
-    return _SBLOADED[script] or false
+	return _SBLOADED[script] or false
 end
 
 -- Function for setting up a FRHelper instance with the given weapon scripts.

--- a/scripts/fr_raceEffects.lua
+++ b/scripts/fr_raceEffects.lua
@@ -58,6 +58,31 @@ function update(dt)
 		end
 
 		-- Apply the persistent effect
+		local derp=copy(self.helper.speciesConfig.stats or {})
+		--sb.logInfo("FR_racialStats pre: %s",derp)
+		for _,statSet in pairs(derp) do
+			if (statSet.stat=="maxEnergy") or (statSet.stat=="maxHealth") then
+				if statSet.amount then statSet.amount=util.clamp(statSet.amount,-50,50)
+				elseif statSet.effectiveMultiplier then statSet.effectiveMultiplier=util.clamp(statSet.effectiveMultiplier,0.5,1.5)
+				elseif statSet.baseMultiplier then statSet.baseMultiplier=util.clamp(statSet.baseMultiplier,0.5,1.5)
+				end
+			elseif (statSet.stat=="powerMultiplier") then
+				if statSet.amount then statSet.amount=util.clamp(statSet.amount,-0.5,0.5)--they should be using basemult or effectivemult.
+				elseif statSet.effectiveMultiplier then statSet.effectiveMultiplier=util.clamp(statSet.effectiveMultiplier,0.7,1.3)
+				elseif statSet.baseMultiplier then statSet.baseMultiplier=util.clamp(statSet.baseMultiplier,0.5,1.5)
+				end
+			elseif (statSet.stat=="protection") then
+				if statSet.amount then statSet.amount=util.clamp(statSet.amount,-25,25)
+				elseif statSet.effectiveMultiplier then statSet.effectiveMultiplier=util.clamp(statSet.effectiveMultiplier,0.7,1.3)
+				--elseif statSet.baseMultiplier then statSet.baseMultiplier=util.clamp(statSet.baseMultiplier,0.5,1.5)--has no effect. base is 0.
+				end
+			elseif string.find(statSet.stat,"Resistance") then
+				if statSet.amount then statSet.amount=util.clamp(statSet.amount,-1.0,1.0)
+				elseif statSet.effectiveMultiplier then statSet.effectiveMultiplier=util.clamp(statSet.effectiveMultiplier,0.0,2.0)
+				end
+			end
+		end
+		--sb.logInfo("FR_racialStats post: %s",derp)
 		status.setPersistentEffects("FR_racialStats", self.helper.speciesConfig.stats or {})
 
 		-- Add any other special effects

--- a/stats/effects/fu_effects/fu_nooxygen/fu_nooxygen.lua
+++ b/stats/effects/fu_effects/fu_nooxygen/fu_nooxygen.lua
@@ -1,13 +1,14 @@
-function init()
+--[[function init()
 	--world.sendEntityMessage(entity.id(), "queueRadioMessage", "biomeairless", 5.0)
-	script.setUpdateDelta(config.getParameter("scriptDelta"))
-	status.addPersistentEffect("nooxygen", {stat = "breathRegenerationRate", effectiveMultiplier = 0})
-end
+	--script.setUpdateDelta(config.getParameter("scriptDelta"))
+	--status.addPersistentEffect("nooxygen", {stat = "breathRegenerationRate", effectiveMultiplier = 0})
+end]]
 
 function update(dt)
-	status.setResource("breath", status.resource("breath") - (dt * status.stat("breathDepletionRate")))
+	status.modifyResource("breath",-1*(dt * status.stat("breathDepletionRate")))
 end
-
+--[[
 function uninit()
 	status.clearPersistentEffects("nooxygen")
 end
+]]

--- a/stats/effects/fu_effects/fu_nooxygen/fu_nooxygen.statuseffect
+++ b/stats/effects/fu_effects/fu_nooxygen/fu_nooxygen.statuseffect
@@ -1,13 +1,10 @@
 {
-  "name" : "fu_nooxygen",
-  "blockingStat" : "breathProtection",
+	"name" : "fu_nooxygen",
+	"blockingStat" : "breathProtection",
 
-  "effectConfig" : {
-    "scriptDelta" : 20
-  },
-  "defaultDuration" : 3,
+ 	"effectConfig": {"stats": [{"stat": "breathRegenerationRate","effectiveMultiplier": 0.0}]},
+	"defaultDuration" : 3,
+	"scriptDelta" : 20,
 
-  "scripts" : [
-    "fu_nooxygen.lua"
-  ]
+	"scripts" : ["fu_nooxygen.lua","/stats/effects/fu_genericStatApplier.lua"]
 }


### PR DESCRIPTION
passive stat values for raceeffects are now clamped to ranges as follows:
resistances: amount (-1.0 to 1.0), effectiveMultiplier (0.0 to 2.0)
max energy and max health: amount(-50 to 50), baseMultiplier(-50% to +50%), effectiveMultiplier(0.7x to 1.5x)
protection (Defense): amount(-25 to 25), effectiveMultiplier(0.7x to 1.3x)
power (Damage): amount(-0.5 to 0.5), baseMultiplier(-50% to +50%), effectiveMultiplier(0.7x to 1.3x)
this is primarily to address irresponsible mod authors giving their races excessive values (IE: kitsune patch giving +150% max energy, which is normally +150)

fixed a recursion issue with fu_nooxygen