### PR TITLE
neuropod_correction

### DIFF
--- a/items/generic/produce/neuropod.consumable
+++ b/items/generic/produce/neuropod.consumable
@@ -17,7 +17,7 @@
 			},				
 			{
 				"effect": "percentarmorboostneg5",
-				"duration": 150
+				"duration": 300
 			}
 		]
 	]

--- a/items/generic/produce/neuropod.consumable
+++ b/items/generic/produce/neuropod.consumable
@@ -6,7 +6,7 @@
 	"price": 95,
 
 	"tooltipKind": "food",
-	"description": "Ingesting this 'fruit' alters your brain chemistry for a short time at the expense of defense. \n^yellow;^reset;^cyan;Research Bonus^reset;: ^cyan;+5 ^reset;,^yellow;^reset;^cyan;-50%^reset;, ^cyan;Protection^reset;, 300s",
+	"description": "Ingesting this 'fruit' alters your brain chemistry for a short time at the expense of defense. \n^yellow;^reset;^cyan;Research Bonus^reset;: ^cyan;+5 ^reset;,^yellow;^reset;^cyan;-50% Protection^reset;: 300s",
 	"shortdescription": "Neuropod Bulb",
 
 	"effects": [


### PR DESCRIPTION
The description for the Neuropod Buld had an extra comma that made things look off. Also, the duration of the defense penalty didn't match the description.