### PR TITLE
Update tungstenshield and ironshield groups

### DIFF
--- a/recipes/anvil1/weapons/tier1/ironshield.recipe
+++ b/recipes/anvil1/weapons/tier1/ironshield.recipe
@@ -7,5 +7,5 @@
     "item" : "ironshield",
     "count" : 1
   },
-  "groups" : [ "craftinganvil", "armours", "all","armory1","shield" ]
+  "groups" : [ "armory1", "shield", "craftinganvil", "weapons", "all" ]
 }

--- a/recipes/anvil1/weapons/tier2/tungstenshield.recipe
+++ b/recipes/anvil1/weapons/tier2/tungstenshield.recipe
@@ -7,5 +7,5 @@
     "item" : "tungstenshield",
     "count" : 1
   },
-  "groups" : [ "craftinganvil", "armours", "all","armory1","shield" ]
+  "groups" : [ "armory1", "shield", "craftinganvil", "all" ]
 }

--- a/recipes/anvil1/weapons/tier2/tungstenshield.recipe
+++ b/recipes/anvil1/weapons/tier2/tungstenshield.recipe
@@ -7,5 +7,5 @@
     "item" : "tungstenshield",
     "count" : 1
   },
-  "groups" : [ "armory1", "shield", "craftinganvil", "all" ]
+  "groups" : [ "armory1", "shield", "craftinganvil", "weapons", "all" ]
 }


### PR DESCRIPTION
I've noticed small bug. "Tungsten Shield" appearing in the armor group on "Assembly Line".
I've not familiar in Starbound modding, so not fully sure, is my PR fix this, but I've checked "Lunari Shield" as example and it has all groups except "craftinganvil" and "armours", so I thought that removing "armours" group should fix the issue.

```
// recipes/armory/shield/lunarishield.recipe
"groups" : [ "armory1", "shield", "all" ]
```

![03](https://user-images.githubusercontent.com/29846693/109099013-1194bb80-776e-11eb-9286-191c4e3688e8.png)