### PR TITLE
aura name shift

### DIFF
--- a/items/active/weapons/melee/abilities/hammer/elementalaura/elementalaura.weaponability.patch
+++ b/items/active/weapons/melee/abilities/hammer/elementalaura/elementalaura.weaponability.patch
@@ -1,353 +1,358 @@
 [
-  {
-    "op": "add",
-    "path": "/animationCustom/particleEmitters/aetherCharge",
-    "value" : {
-      "active" : false,
-      "transformationGroups" : ["weapon"],
-      "emissionRate" : 25,
-      "offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
-      "particles" : [
-        { "particle" : "cosmicswoosh1"},
-        { "particle" : "cosmicswoosh2"},
-        { "particle" : "cosmicswoosh3"},
-        { "particle" : "cosmicaura"}
-      ]
-    }
-  },
-  {
-    "op": "add",
-    "path": "/ability/elementalConfig/aether",
-    "value" : {
-      "damageConfig" : { "statusEffects" : [ "defenseboostneg20" ] }
-    }
-  },  
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/aethercharge",
-    "value" : [ "/sfx/melee/shockwave_charge_electric.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/aetherfull",
-    "value" : [ "/sfx/melee/shockwave_full_electric.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/aetheractivate",
-    "value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/aetheractive",
-    "value" : [ "/sfx/melee/elemental_aura_electric.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/aetherdeactivate",
-    "value" : [ "/sfx/gun/impact_plasma.ogg" ]
-  },
-  
-  
-  {
-    "op": "add",
-    "path": "/animationCustom/particleEmitters/cosmicCharge",
-    "value" : {
-      "active" : false,
-      "transformationGroups" : ["weapon"],
-      "emissionRate" : 25,
-      "offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
-      "particles" : [
-        { "particle" : "cosmicswoosh1"},
-        { "particle" : "cosmicswoosh2"},
-        { "particle" : "cosmicswoosh3"},
-        { "particle" : "cosmicaura"}
-      ]
-    }
-  },
-  {
-    "op": "add",
-    "path": "/ability/elementalConfig/cosmic",
-    "value" : {
-      "damageConfig" : { "statusEffects" : [ "defenseboostneg20" ] }
-    }
-  },  
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/cosmiccharge",
-    "value" : [ "/sfx/melee/shockwave_charge_electric.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/cosmicfull",
-    "value" : [ "/sfx/melee/shockwave_full_electric.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/cosmicactivate",
-    "value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/cosmicactive",
-    "value" : [ "/sfx/melee/elemental_aura_electric.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/cosmicdeactivate",
-    "value" : [ "/sfx/gun/impact_plasma.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/shadowcharge",
-    "value" : [ "/sfx/melee/shockwave_charge_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/shadowfull",
-    "value" : [ "/sfx/melee/shockwave_full_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/shadowactivate",
-    "value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/shadowactive",
-    "value" : [ "/sfx/melee/elemental_aura_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/shadowdeactivate",
-    "value" : [ "/sfx/gun/impact_plasma.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/radioactivecharge",
-    "value" : [ "/sfx/melee/shockwave_charge_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/radioactivefull",
-    "value" : [ "/sfx/melee/shockwave_full_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/radioactiveactivate",
-    "value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/radioactiveactive",
-    "value" : [ "/sfx/melee/elemental_aura_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/radioactivedeactivate",
-    "value" : [ "/sfx/gun/impact_plasma.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/particleEmitters/shadowCharge",
-    "value" : {
-      "active" : false,
-      "transformationGroups" : ["weapon"],
-      "emissionRate" : 25,
-      "offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
-      "particles" : [
-        { "particle" : "shadowswoosh1"},
-        { "particle" : "shadowswoosh2"},
-        { "particle" : "shadowswoosh3"},
-        { "particle" : "shadowsmoke2"},
-        { "particle" : "shadowsmoke2"},
-        { "particle" : "shadowsmoke1"}
-      ]
-    }
-  },
-  {
-    "op": "add",
-    "path": "/ability/elementalConfig/shadow",
-    "value" : {
-      "damageConfig" : { "statusEffects" : [ "shadowgasfx" ] }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/particleEmitters/radioactiveCharge",
-    "value" : {
-      "active" : false,
-      "transformationGroups" : ["weapon"],
-      "emissionRate" : 25,
-      "offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
-      "particles" : [
-        { "particle" : "radioactiveswoosh1"},
-        { "particle" : "radioactiveswoosh2"},
-        { "particle" : "poisonswoosh2"},
-        { "particle" : "radioactiveswoosh1"},
-        { "particle" : "radioactiveswoosh2"},
-        { "particle" : "poisonswoosh2"},
-        { "particle" : "radioactiveaura"}
-      ]
-    }
-  },
-  {
-    "op": "add",
-    "path": "/ability/elementalConfig/radioactive",
-    "value" : {
-      "damageConfig" : { "statusEffects" : [ "radiationburn" ] }
-    }
-  },
+	{
+		"op": "add",
+		"path": "/animationCustom/particleEmitters/aetherCharge",
+		"value" : {
+			"active" : false,
+			"transformationGroups" : ["weapon"],
+			"emissionRate" : 25,
+			"offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
+			"particles" : [
+				{ "particle" : "cosmicswoosh1"},
+				{ "particle" : "cosmicswoosh2"},
+				{ "particle" : "cosmicswoosh3"},
+				{ "particle" : "cosmicaura"}
+			]
+		}
+	},
+	{
+		"op": "add",
+		"path": "/ability/elementalConfig/aether",
+		"value" : {
+			"damageConfig" : { "statusEffects" : [ "defenseboostneg20" ] }
+		}
+	},
+	{
+		"op": "replace",
+		"path": "/ability/name",
+		"value" : "<elementalType> aura"
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/aethercharge",
+		"value" : [ "/sfx/melee/shockwave_charge_electric.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/aetherfull",
+		"value" : [ "/sfx/melee/shockwave_full_electric.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/aetheractivate",
+		"value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/aetheractive",
+		"value" : [ "/sfx/melee/elemental_aura_electric.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/aetherdeactivate",
+		"value" : [ "/sfx/gun/impact_plasma.ogg" ]
+	},
 
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/bioweaponcharge",
-    "value" : [ "/sfx/melee/shockwave_charge_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/bioweaponfull",
-    "value" : [ "/sfx/melee/shockwave_full_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/bioweaponactivate",
-    "value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/bioweaponactive",
-    "value" : [ "/sfx/melee/elemental_aura_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/bioweapondeactivate",
-    "value" : [ "/sfx/gun/impact_plasma.ogg" ]
-  },  
-  {
-    "op": "add",
-    "path": "/animationCustom/particleEmitters/bioweaponCharge",
-    "value" : {
-      "active" : false,
-      "transformationGroups" : ["weapon"],
-      "emissionRate" : 25,
-      "offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
-      "particles" : [
-        { "particle" : "poisonswoosh1"},
-        { "particle" : "poisonswoosh2"},
-        { "particle" : "poisonswoosh3"},
-        { "particle" : "shadowsmoke2"},
-        { "particle" : "shadowsmoke2"},
-        { "particle" : "shadowsmoke1"}
-      ]
-    }
-  },
-  {
-    "op": "add",
-    "path": "/ability/elementalConfig/bioweapon",
-    "value" : {
-      "damageConfig" : { "statusEffects" : [ "weakpoison" ] }
-    }
-  },  
 
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/silverweaponcharge",
-    "value" : [ "/sfx/melee/shockwave_charge_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/silverweaponfull",
-    "value" : [ "/sfx/melee/shockwave_full_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/silverweaponactivate",
-    "value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/silverweaponactive",
-    "value" : [ "/sfx/melee/elemental_aura_poison.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/silverweapondeactivate",
-    "value" : [ "/sfx/gun/impact_plasma.ogg" ]
-  },  
-  {
-    "op": "add",
-    "path": "/animationCustom/particleEmitters/silverweaponCharge",
-    "value" : {
-      "active" : false,
-      "transformationGroups" : ["weapon"],
-      "emissionRate" : 25,
-      "offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
-      "particles" : [
-        { "particle" : "poisonswoosh1"},
-        { "particle" : "poisonswoosh2"},
-        { "particle" : "poisonswoosh3"},
-        { "particle" : "shadowsmoke2"},
-        { "particle" : "shadowsmoke2"},
-        { "particle" : "shadowsmoke1"}
-      ]
-    }
-  },
-  {
-    "op": "add",
-    "path": "/ability/elementalConfig/silverweapon",
-    "value" : {
-      "damageConfig" : { "statusEffects" : [  ] }
-    }
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/hellfirecharge",
-    "value" : [ "/sfx/melee/shockwave_charge_fire.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/hellfirefull",
-    "value" : [ "/sfx/melee/shockwave_full_fire.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/hellfireactivate",
-    "value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/hellfireactive",
-    "value" : [ "/sfx/melee/elemental_aura_fire.ogg" ]
-  },
-  {
-    "op": "add",
-    "path": "/animationCustom/sounds/hellfiredeactivate",
-    "value" : [ "/sfx/gun/impact_plasma.ogg" ]
-  },  
-  {
-    "op": "add",
-    "path": "/animationCustom/particleEmitters/hellfireCharge",
-    "value" : {
-      "active" : false,
-      "transformationGroups" : ["weapon"],
-      "emissionRate" : 25,
-      "offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
-      "particles" : [
-        { "particle" : "fireswoosh1"},
-        { "particle" : "fireswoosh2"},
-        { "particle" : "fireswoosh3"},
-        { "particle" : "shadowsmoke2"},
-        { "particle" : "shadowsmoke2"},
-        { "particle" : "shadowsmoke1"}
-      ]
-    }
-  },
-  {
-    "op": "add",
-    "path": "/ability/elementalConfig/hellfire",
-    "value" : {
-      "damageConfig" : { "statusEffects" : [ "burning" ] }
-    }
-  }    
+	{
+		"op": "add",
+		"path": "/animationCustom/particleEmitters/cosmicCharge",
+		"value" : {
+			"active" : false,
+			"transformationGroups" : ["weapon"],
+			"emissionRate" : 25,
+			"offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
+			"particles" : [
+				{ "particle" : "cosmicswoosh1"},
+				{ "particle" : "cosmicswoosh2"},
+				{ "particle" : "cosmicswoosh3"},
+				{ "particle" : "cosmicaura"}
+			]
+		}
+	},
+	{
+		"op": "add",
+		"path": "/ability/elementalConfig/cosmic",
+		"value" : {
+			"damageConfig" : { "statusEffects" : [ "defenseboostneg20" ] }
+		}
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/cosmiccharge",
+		"value" : [ "/sfx/melee/shockwave_charge_electric.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/cosmicfull",
+		"value" : [ "/sfx/melee/shockwave_full_electric.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/cosmicactivate",
+		"value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/cosmicactive",
+		"value" : [ "/sfx/melee/elemental_aura_electric.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/cosmicdeactivate",
+		"value" : [ "/sfx/gun/impact_plasma.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/shadowcharge",
+		"value" : [ "/sfx/melee/shockwave_charge_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/shadowfull",
+		"value" : [ "/sfx/melee/shockwave_full_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/shadowactivate",
+		"value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/shadowactive",
+		"value" : [ "/sfx/melee/elemental_aura_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/shadowdeactivate",
+		"value" : [ "/sfx/gun/impact_plasma.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/radioactivecharge",
+		"value" : [ "/sfx/melee/shockwave_charge_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/radioactivefull",
+		"value" : [ "/sfx/melee/shockwave_full_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/radioactiveactivate",
+		"value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/radioactiveactive",
+		"value" : [ "/sfx/melee/elemental_aura_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/radioactivedeactivate",
+		"value" : [ "/sfx/gun/impact_plasma.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/particleEmitters/shadowCharge",
+		"value" : {
+			"active" : false,
+			"transformationGroups" : ["weapon"],
+			"emissionRate" : 25,
+			"offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
+			"particles" : [
+				{ "particle" : "shadowswoosh1"},
+				{ "particle" : "shadowswoosh2"},
+				{ "particle" : "shadowswoosh3"},
+				{ "particle" : "shadowsmoke2"},
+				{ "particle" : "shadowsmoke2"},
+				{ "particle" : "shadowsmoke1"}
+			]
+		}
+	},
+	{
+		"op": "add",
+		"path": "/ability/elementalConfig/shadow",
+		"value" : {
+			"damageConfig" : { "statusEffects" : [ "shadowgasfx" ] }
+		}
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/particleEmitters/radioactiveCharge",
+		"value" : {
+			"active" : false,
+			"transformationGroups" : ["weapon"],
+			"emissionRate" : 25,
+			"offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
+			"particles" : [
+				{ "particle" : "radioactiveswoosh1"},
+				{ "particle" : "radioactiveswoosh2"},
+				{ "particle" : "poisonswoosh2"},
+				{ "particle" : "radioactiveswoosh1"},
+				{ "particle" : "radioactiveswoosh2"},
+				{ "particle" : "poisonswoosh2"},
+				{ "particle" : "radioactiveaura"}
+			]
+		}
+	},
+	{
+		"op": "add",
+		"path": "/ability/elementalConfig/radioactive",
+		"value" : {
+			"damageConfig" : { "statusEffects" : [ "radiationburn" ] }
+		}
+	},
+
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/bioweaponcharge",
+		"value" : [ "/sfx/melee/shockwave_charge_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/bioweaponfull",
+		"value" : [ "/sfx/melee/shockwave_full_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/bioweaponactivate",
+		"value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/bioweaponactive",
+		"value" : [ "/sfx/melee/elemental_aura_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/bioweapondeactivate",
+		"value" : [ "/sfx/gun/impact_plasma.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/particleEmitters/bioweaponCharge",
+		"value" : {
+			"active" : false,
+			"transformationGroups" : ["weapon"],
+			"emissionRate" : 25,
+			"offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
+			"particles" : [
+				{ "particle" : "poisonswoosh1"},
+				{ "particle" : "poisonswoosh2"},
+				{ "particle" : "poisonswoosh3"},
+				{ "particle" : "shadowsmoke2"},
+				{ "particle" : "shadowsmoke2"},
+				{ "particle" : "shadowsmoke1"}
+			]
+		}
+	},
+	{
+		"op": "add",
+		"path": "/ability/elementalConfig/bioweapon",
+		"value" : {
+			"damageConfig" : { "statusEffects" : [ "weakpoison" ] }
+		}
+	},
+
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/silverweaponcharge",
+		"value" : [ "/sfx/melee/shockwave_charge_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/silverweaponfull",
+		"value" : [ "/sfx/melee/shockwave_full_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/silverweaponactivate",
+		"value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/silverweaponactive",
+		"value" : [ "/sfx/melee/elemental_aura_poison.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/silverweapondeactivate",
+		"value" : [ "/sfx/gun/impact_plasma.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/particleEmitters/silverweaponCharge",
+		"value" : {
+			"active" : false,
+			"transformationGroups" : ["weapon"],
+			"emissionRate" : 25,
+			"offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
+			"particles" : [
+				{ "particle" : "poisonswoosh1"},
+				{ "particle" : "poisonswoosh2"},
+				{ "particle" : "poisonswoosh3"},
+				{ "particle" : "shadowsmoke2"},
+				{ "particle" : "shadowsmoke2"},
+				{ "particle" : "shadowsmoke1"}
+			]
+		}
+	},
+	{
+		"op": "add",
+		"path": "/ability/elementalConfig/silverweapon",
+		"value" : {
+			"damageConfig" : { "statusEffects" : [	] }
+		}
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/hellfirecharge",
+		"value" : [ "/sfx/melee/shockwave_charge_fire.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/hellfirefull",
+		"value" : [ "/sfx/melee/shockwave_full_fire.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/hellfireactivate",
+		"value" : [ "/sfx/melee/elemental_aura_activate.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/hellfireactive",
+		"value" : [ "/sfx/melee/elemental_aura_fire.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/sounds/hellfiredeactivate",
+		"value" : [ "/sfx/gun/impact_plasma.ogg" ]
+	},
+	{
+		"op": "add",
+		"path": "/animationCustom/particleEmitters/hellfireCharge",
+		"value" : {
+			"active" : false,
+			"transformationGroups" : ["weapon"],
+			"emissionRate" : 25,
+			"offsetRegion" : [-1.0, -2.5, 1.0, 1.5],
+			"particles" : [
+				{ "particle" : "fireswoosh1"},
+				{ "particle" : "fireswoosh2"},
+				{ "particle" : "fireswoosh3"},
+				{ "particle" : "shadowsmoke2"},
+				{ "particle" : "shadowsmoke2"},
+				{ "particle" : "shadowsmoke1"}
+			]
+		}
+	},
+	{
+		"op": "add",
+		"path": "/ability/elementalConfig/hellfire",
+		"value" : {
+			"damageConfig" : { "statusEffects" : [ "burning" ] }
+		}
+	}
 ]

--- a/items/active/weapons/melee/abilities/hammer/elementalaura/elementalaura.weaponability.patch
+++ b/items/active/weapons/melee/abilities/hammer/elementalaura/elementalaura.weaponability.patch
@@ -25,7 +25,7 @@
 	{
 		"op": "replace",
 		"path": "/ability/name",
-		"value" : "<elementalType> aura"
+		"value" : "<elementalName> Aura"
 	},
 	{
 		"op": "add",

--- a/items/buildscripts/buildboomerang.lua
+++ b/items/buildscripts/buildboomerang.lua
@@ -24,6 +24,7 @@ function build(directory, config, parameters, level, seed)
 	-- elemental type
 	local elementalType = parameters.elementalType or config.elementalType or "physical"
 	replacePatternInData(config, nil, "<elementalType>", elementalType)
+	replacePatternInData(config, nil, "<elementalName>", elementalType:gsub("^%l", string.upper))
 
 	-- calculate damage level multiplier
 	config.damageLevelMultiplier = root.evalFunction("weaponDamageLevelMultiplier", configParameter("level", 1))

--- a/items/buildscripts/buildbow.lua
+++ b/items/buildscripts/buildbow.lua
@@ -57,6 +57,7 @@ function build(directory, config, parameters, level, seed)
 	-- elemental type
 	local elementalType = parameters.elementalType or config.elementalType or "physical"
 	replacePatternInData(config, nil, "<elementalType>", elementalType)
+	replacePatternInData(config, nil, "<elementalName>", elementalType:gsub("^%l", string.upper))
 
 	local primaryAbility=configParameterDeep("primaryAbility")
 	local altAbility=configParameterDeep("altAbility")

--- a/items/buildscripts/buildfuoverheatweapon.lua
+++ b/items/buildscripts/buildfuoverheatweapon.lua
@@ -56,6 +56,7 @@ function build(directory, config, parameters, level, seed)
 	-- elemental type and config (for alt ability)
 	local elementalType = configParameter("elementalType", "physical")
 	replacePatternInData(config, nil, "<elementalType>", elementalType)
+	replacePatternInData(config, nil, "<elementalName>", elementalType:gsub("^%l", string.upper))
 	if config.altAbility and config.altAbility.elementalConfig then
 		--The difference is here, i added an if null-coalescing operation that checks if the alt ability has the elementalType in the elementalConfig list and replaces it with the physical type if it doesn't exist.
 		util.mergeTable(config.altAbility, config.altAbility.elementalConfig[elementalType] or config.altAbility.elementalConfig["physical"])

--- a/items/buildscripts/buildunrandweapon.lua
+++ b/items/buildscripts/buildunrandweapon.lua
@@ -55,6 +55,7 @@ function build(directory, config, parameters, level, seed)
 	-- elemental type and config (for alt ability)
 	local elementalType = configParameter("elementalType", "physical")
 	replacePatternInData(config, nil, "<elementalType>", elementalType)
+	replacePatternInData(config, nil, "<elementalName>", elementalType:gsub("^%l", string.upper))
 
 	if (type(config.altAbility)=="table") and (type(config.altAbility.elementalConfig)=="table") and (type(elementalType)=="string") and ((type(config.altAbility.elementalConfig[elementalType])=="table") or (type(config.altAbility.elementalConfig["physical"])=="table")) then
 		--The difference is here, i added an if null-coalescing operation that checks if the alt ability has the elementalType in the elementalConfig list and replaces it with the physical type if it doesn't exist.

--- a/items/buildscripts/fubuildchakram.lua
+++ b/items/buildscripts/fubuildchakram.lua
@@ -24,6 +24,7 @@ function build(directory, config, parameters, level, seed)
 	-- elemental type
 	local elementalType = parameters.elementalType or config.elementalType or "physical"
 	replacePatternInData(config, nil, "<elementalType>", elementalType)
+	replacePatternInData(config, nil, "<elementalName>", elementalType:gsub("^%l", string.upper))
 
 	-- calculate damage level multiplier
 	config.damageLevelMultiplier = root.evalFunction("weaponDamageLevelMultiplier", configParameter("level", 1))

--- a/items/buildscripts/fubuildmagnorb.lua
+++ b/items/buildscripts/fubuildmagnorb.lua
@@ -24,6 +24,7 @@ function build(directory, config, parameters, level, seed)
 	-- elemental type
 	local elementalType = parameters.elementalType or config.elementalType or "physical"
 	replacePatternInData(config, nil, "<elementalType>", elementalType)
+	replacePatternInData(config, nil, "<elementalName>", elementalType:gsub("^%l", string.upper))
 
 	-- calculate damage level multiplier
 	config.damageLevelMultiplier = root.evalFunction("weaponDamageLevelMultiplier", configParameter("level", 1))

--- a/items/buildscripts/neb-buildbow.lua
+++ b/items/buildscripts/neb-buildbow.lua
@@ -60,6 +60,7 @@ function build(directory, config, parameters, level, seed)
 	-- elemental type
 	local elementalType = parameters.elementalType or config.elementalType or "physical"
 	replacePatternInData(config, nil, "<elementalType>", elementalType)
+	replacePatternInData(config, nil, "<elementalName>", elementalType:gsub("^%l", string.upper))
 
 	-- calculate damage level multiplier
 	config.damageLevelMultiplier = root.evalFunction("weaponDamageLevelMultiplier", configParameter("level", 1))

--- a/items/generic/loot/healing/fuhoneysilkbandage.consumable
+++ b/items/generic/loot/healing/fuhoneysilkbandage.consumable
@@ -46,7 +46,7 @@
     "salveheal",
     "bandageheal",
     "medkitheal",
-    "mutaviskbandage",
+    "mutaviskheal",
     "nanowrapheal",
     "honeysilkheal"
   ]

--- a/items/generic/loot/healing/mutaviskbandage.consumable
+++ b/items/generic/loot/healing/mutaviskbandage.consumable
@@ -23,7 +23,7 @@
     "heal_long4",
     "bandageheal",
     "medkitheal",
-    "mutaviskbandage",
+    "mutaviskheal",
     "nanowrapheal",
     "honeysilkheal"
   ]

--- a/items/generic/other/bandage.consumable.patch
+++ b/items/generic/other/bandage.consumable.patch
@@ -10,6 +10,6 @@
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long2"},
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long3"},
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long4"},
-	{"op": "add","path": "/blockingEffects/-","value": "mutaviskbandage"},
+	{"op": "add","path": "/blockingEffects/-","value": "mutaviskheal"},
 	{"op": "add","path": "/blockingEffects/-","value": "honeysilkheal"}
 ]

--- a/items/generic/other/medkit.consumable.patch
+++ b/items/generic/other/medkit.consumable.patch
@@ -10,6 +10,6 @@
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long2"},
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long3"},
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long4"},
-	{"op": "add","path": "/blockingEffects/-","value": "mutaviskbandage"},
+	{"op": "add","path": "/blockingEffects/-","value": "mutaviskheal"},
 	{"op": "add","path": "/blockingEffects/-","value": "honeysilkheal"}
 ]

--- a/items/generic/other/medkit2.consumable
+++ b/items/generic/other/medkit2.consumable
@@ -43,7 +43,7 @@
     "heal_long4",
     "bandageheal",
     "medkitheal",
-    "mutaviskbandage",
+    "mutaviskheal",
     "nanowrapheal",
     "honeysilkheal"
   ]

--- a/items/generic/other/medkit3.consumable
+++ b/items/generic/other/medkit3.consumable
@@ -43,7 +43,7 @@
     "heal_long4",
     "bandageheal",
     "medkitheal",
-    "mutaviskbandage",
+    "mutaviskheal",
     "nanowrapheal",
     "honeysilkheal"
   ]

--- a/items/generic/other/medkit4.consumable
+++ b/items/generic/other/medkit4.consumable
@@ -43,7 +43,7 @@
     "heal_long4",
     "bandageheal",
     "medkitheal",
-    "mutaviskbandage",
+    "mutaviskheal",
     "nanowrapheal",
     "honeysilkheal"
   ]

--- a/items/generic/other/nanowrap.consumable.patch
+++ b/items/generic/other/nanowrap.consumable.patch
@@ -10,6 +10,6 @@
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long2"},
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long3"},
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long4"},
-	{"op": "add","path": "/blockingEffects/-","value": "mutaviskbandage"},
+	{"op": "add","path": "/blockingEffects/-","value": "mutaviskheal"},
 	{"op": "add","path": "/blockingEffects/-","value": "honeysilkheal"}
 ]

--- a/items/generic/other/perfectelygenericmedkit.consumable
+++ b/items/generic/other/perfectelygenericmedkit.consumable
@@ -43,7 +43,7 @@
     "heal_long4",
     "bandageheal",
     "medkitheal",
-    "mutaviskbandage",
+    "mutaviskheal",
     "nanowrapheal",
     "honeysilkheal"
   ]

--- a/items/generic/other/reactivegel.consumable
+++ b/items/generic/other/reactivegel.consumable
@@ -24,7 +24,7 @@
     "heal_long4",
     "bandageheal",
     "medkitheal",
-    "mutaviskbandage",
+    "mutaviskheal",
     "nanowrapheal",
     "honeysilkheal",
 	"radienheal",

--- a/items/generic/other/reactivegel2.consumable
+++ b/items/generic/other/reactivegel2.consumable
@@ -28,7 +28,7 @@
     "heal_long4",
     "bandageheal",
     "medkitheal",
-    "mutaviskbandage",
+    "mutaviskheal",
     "nanowrapheal",
     "honeysilkheal",
 	"radienheal",

--- a/items/generic/other/reactivegel3.consumable
+++ b/items/generic/other/reactivegel3.consumable
@@ -29,7 +29,7 @@
     "heal_long4",
     "bandageheal",
     "medkitheal",
-    "mutaviskbandage",
+    "mutaviskheal",
     "nanowrapheal",
     "honeysilkheal",
 	"radienheal",

--- a/items/generic/other/salve.consumable.patch
+++ b/items/generic/other/salve.consumable.patch
@@ -10,6 +10,6 @@
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long2"},
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long3"},
 	{"op": "add","path": "/blockingEffects/-","value": "heal_long4"},
-	{"op": "add","path": "/blockingEffects/-","value": "mutaviskbandage"},
+	{"op": "add","path": "/blockingEffects/-","value": "mutaviskheal"},
 	{"op": "add","path": "/blockingEffects/-","value": "honeysilkheal"}
 ]

--- a/scripts/companions/petspawner.lua
+++ b/scripts/companions/petspawner.lua
@@ -5,34 +5,34 @@ Pet = {}
 Pet.__index = Pet
 
 function Pet.new(...)
-  local self = setmetatable({}, Pet)
-  self:init(...)
-  return self
+	local self = setmetatable({}, Pet)
+	self:init(...)
+	return self
 end
 
 function Pet:init(podUuid, json)
-  self.podUuid = podUuid
-  self.name = json.name
-  self.rank = json.rank
-  self.description = json.description
-  self.portrait = json.portrait
-  self.spawnConfig = json.config
-  self.uniqueId = json.uniqueId
-  self.status = json.status
-  self.storage = json.storage
-  self.collar = json.collar
-  self.collisionPoly = json.collisionPoly
+	self.podUuid = podUuid
+	self.name = json.name
+	self.rank = json.rank
+	self.description = json.description
+	self.portrait = json.portrait
+	self.spawnConfig = json.config
+	self.uniqueId = json.uniqueId
+	self.status = json.status
+	self.storage = json.storage
+	self.collar = json.collar
+	self.collisionPoly = json.collisionPoly
 
-  self.persistent = json.persistent or false
-  self.spawner = petSpawner
-  self.dirtyOnStatusUpdate = true
-  self.returnMessage = "pet.returnToPod"
-  self.statusRequestMessage = "pet.status"
+	self.persistent = json.persistent or false
+	self.spawner = petSpawner
+	self.dirtyOnStatusUpdate = true
+	self.returnMessage = "pet.returnToPod"
+	self.statusRequestMessage = "pet.status"
 
-  if self.uniqueId then
-    self.statusTimer = config.getParameter("statusTimer", 2)
-  end
-  --[[
+	if self.uniqueId then
+		self.statusTimer = config.getParameter("statusTimer", 2)
+	end
+	--[[
 	local elementaltypes=root.assetJson("/damage/elementaltypes.config")
 	local buffer={}
 
@@ -42,130 +42,130 @@ function Pet:init(podUuid, json)
 			buffer[data.resistanceStat]=true
 		end
 	end
-  self.resistanceList=buffer]]
+	self.resistanceList=buffer]]
 end
 
 function Pet:store()
-  local result = self:toJson()
-  if not self.persistent then
-    result.uniqueId = nil
-  end
-  return result
+	local result = self:toJson()
+	if not self.persistent then
+		result.uniqueId = nil
+	end
+	return result
 end
 
 function Pet:toJson()
-  return {
-      podUuid = self.podUuid,
-      name = self.name,
-      rank = self.rank,
-      description = self.description,
-      portrait = self.portrait,
-      config = self.spawnConfig,
-      status = self.status,
-      storage = self.storage,
-      collar = self.collar,
-      uniqueId = self.uniqueId,
-      collisionPoly = self.collisionPoly,
-      persistent = self.persistent
-    }
+	return {
+			podUuid = self.podUuid,
+			name = self.name,
+			rank = self.rank,
+			description = self.description,
+			portrait = self.portrait,
+			config = self.spawnConfig,
+			status = self.status,
+			storage = self.storage,
+			collar = self.collar,
+			uniqueId = self.uniqueId,
+			collisionPoly = self.collisionPoly,
+			persistent = self.persistent
+		}
 end
 
 function Pet:dead()
-  return self.status and self.status.dead
+	return self.status and self.status.dead
 end
 
 function Pet:_scriptConfig(parameters)
-  return parameters
+	return parameters
 end
 
 function Pet:spawn(position, extraParameters)
-  if self.uniqueId then return end
+	if self.uniqueId then return end
 
-  position = position or entity.position()
-  if self.collisionPoly then
-    position = findCompanionSpawnPosition(position, self.collisionPoly)
-  end
+	position = position or entity.position()
+	if self.collisionPoly then
+		position = findCompanionSpawnPosition(position, self.collisionPoly)
+	end
 
-  local parameters = {}
-  util.mergeTable(parameters, self.spawnConfig.parameters)
-  if extraParameters then
-    util.mergeTable(parameters, extraParameters)
-  end
+	local parameters = {}
+	util.mergeTable(parameters, self.spawnConfig.parameters)
+	if extraParameters then
+		util.mergeTable(parameters, extraParameters)
+	end
 
-  local scriptConfig = self:_scriptConfig(parameters)
-  parameters.persistent = self.persistent
-  scriptConfig.podUuid = self.podUuid
-  scriptConfig.ownerUuid = self.spawner.ownerUuid
-  scriptConfig.tetherUniqueId = self.spawner.tetherUniqueId
+	local scriptConfig = self:_scriptConfig(parameters)
+	parameters.persistent = self.persistent
+	scriptConfig.podUuid = self.podUuid
+	scriptConfig.ownerUuid = self.spawner.ownerUuid
+	scriptConfig.tetherUniqueId = self.spawner.tetherUniqueId
 
-  scriptConfig.initialStatus = copy(self.status) or {}
-  scriptConfig.initialStorage = util.mergeTable(scriptConfig.initialStorage or {}, self.storage or {})
+	scriptConfig.initialStatus = copy(self.status) or {}
+	scriptConfig.initialStorage = util.mergeTable(scriptConfig.initialStorage or {}, self.storage or {})
 
-  -- Pets level with the player, gaining the effects of the player's armor
-  if getPetPersistentEffects then
-    -- If the player is spawning us, we gain the effects of their armor, so
-    -- ignore the monster's level.
-    parameters.level = 1
-  end
-  if self.spawner.levelOverride then
-    -- If a tether is spawning us, we get the level of the world/ship we're on.
-    parameters.level = self.spawner.levelOverride
-  end
+	-- Pets level with the player, gaining the effects of the player's armor
+	if getPetPersistentEffects then
+		-- If the player is spawning us, we gain the effects of their armor, so
+		-- ignore the monster's level.
+		parameters.level = 1
+	end
+	if self.spawner.levelOverride then
+		-- If a tether is spawning us, we get the level of the world/ship we're on.
+		parameters.level = self.spawner.levelOverride
+	end
 
-  scriptConfig.initialStatus.persistentEffects = self:getPersistentEffects()
+	scriptConfig.initialStatus.persistentEffects = self:getPersistentEffects()
 
-  local damageTeam = self:damageTeam()
-  parameters.damageTeamType = damageTeam.type
-  parameters.damageTeam = damageTeam.team
-  parameters.relocatable = false
+	local damageTeam = self:damageTeam()
+	parameters.damageTeamType = damageTeam.type
+	parameters.damageTeam = damageTeam.team
+	parameters.relocatable = false
 
-  if self.collar and self.collar.parameters then
-    util.mergeTable(parameters, self.collar.parameters)
-  end
+	if self.collar and self.collar.parameters then
+		util.mergeTable(parameters, self.collar.parameters)
+	end
 
-  self.uniqueId = sb.makeUuid()
-  scriptConfig.uniqueId = self.uniqueId
+	self.uniqueId = sb.makeUuid()
+	scriptConfig.uniqueId = self.uniqueId
 
-  local result = self:_spawn(position, parameters)
+	local result = self:_spawn(position, parameters)
 
-  self.spawnedCollarParameters = self.collar and self.collar.parameters
-  self.spawning = true
-  self:resetStatusTimer(true)
+	self.spawnedCollarParameters = self.collar and self.collar.parameters
+	self.spawning = true
+	self:resetStatusTimer(true)
 
-  return result
+	return result
 end
 
 function Pet:_spawn(position, parameters)
-  result = world.spawnMonster(self.spawnConfig.type, position, parameters)
-  -- ~Psi:  Debugging pets
-  -- sb.logInfo("[Pet:spawn] " .. table.tostring(parameters))
-  -- sb.logInfo("[Pet:spawn] " .. result )
-  -- sb.logInfo("[Pet:spawn] " .. tostring( world.entityType(result) ))
-  -- sb.logInfo("[Pet:spawn] " .. tostring( world.entityHealth(result)[2] ))
-  return result
+	result = world.spawnMonster(self.spawnConfig.type, position, parameters)
+	-- ~Psi:	Debugging pets
+	-- sb.logInfo("[Pet:spawn] " .. table.tostring(parameters))
+	-- sb.logInfo("[Pet:spawn] " .. result )
+	-- sb.logInfo("[Pet:spawn] " .. tostring( world.entityType(result) ))
+	-- sb.logInfo("[Pet:spawn] " .. tostring( world.entityHealth(result)[2] ))
+	return result
 end
 
 function Pet:resetStatusTimer(initialRequest)
-  if initialRequest then
-    self.statusTimer = config.getParameter("initialStatusTimer", config.getParameter("statusTimer", 0.5))
-  else
-    self.statusTimer = config.getParameter("statusTimer", 2)
-  end
+	if initialRequest then
+		self.statusTimer = config.getParameter("initialStatusTimer", config.getParameter("statusTimer", 0.5))
+	else
+		self.statusTimer = config.getParameter("statusTimer", 2)
+	end
 end
 
 function Pet:damageTeam()
-  local damageTeam = entity.damageTeam()
-  if self.collar and self.collar.damageTeam then
-    util.mergeTable(damageTeam, self.collar.damageTeam)
-  end
-  return damageTeam
+	local damageTeam = entity.damageTeam()
+	if self.collar and self.collar.damageTeam then
+		util.mergeTable(damageTeam, self.collar.damageTeam)
+	end
+	return damageTeam
 end
 
 function Pet:getPersistentEffects()
-  local effects = jarray()
+	local effects = jarray()
 
-  -- The player's armor takes effect if the player is spawning the pet:
-  if getPetPersistentEffects then
+	-- The player's armor takes effect if the player is spawning the pet:
+	if getPetPersistentEffects then
 	local buffer={}
 
 	--khe: overriding the vanilla function somewhat because it's too limited
@@ -177,7 +177,7 @@ function Pet:getPersistentEffects()
 		--powerMultiplier = true,--removing because we're handling it slightly differently.
 		protection = true,
 		maxHealth = true
-	  }
+		}
 	for _,button in pairs(armorEffects) do
 		if type(button)=="table" then
 			if petPersistentEffects[button.stat] then --or self.resistanceList[button.stat] then
@@ -189,8 +189,8 @@ function Pet:getPersistentEffects()
 	table.insert(filteredEffects,{stat="powerMultiplier",effectiveMultiplier=status.stat("powerMultiplier")})
 	--doing the same for hp regen with the upcoming changes to it
 	table.insert(filteredEffects,{stat="healthRegen",amount=status.stat("healthRegen")})
-    util.appendLists(effects,filteredEffects)
-    --util.appendLists(effects, getPetPersistentEffects())
+		util.appendLists(effects,filteredEffects)
+		--util.appendLists(effects, getPetPersistentEffects())
 
 
 	local aUSES=status.activeUniqueStatusEffectSummary()
@@ -234,173 +234,173 @@ function Pet:getPersistentEffects()
 	--sb.logInfo("fpsemb 2: %s",frackinPetStatEffectsMetatableBuffer)
 	util.appendLists(effects,frackinPetStatEffectsMetatableBuffer)
 
-    -- ~Psi:  Provide a bonus to the pet's base max health, and some minor regen, so it sucks less:
-    -- ~Psi:  Total bonus is x4, but we only multiply by 3, since the player's bonusHealth has already been added once
-    --local playerHealthBonus = world.entityHealth(player.id())[2]--pointless.
-    local playerHealthBonus = status.resourceMax("health")
-    playerHealthBonus = playerHealthBonus - 100
-    if playerHealthBonus < 10 then playerHealthBonus = 10 end
-    local petHealthBonus = playerHealthBonus * 3
+		-- ~Psi:	Provide a bonus to the pet's base max health, and some minor regen, so it sucks less:
+		-- ~Psi:	Total bonus is x4, but we only multiply by 3, since the player's bonusHealth has already been added once
+		--local playerHealthBonus = world.entityHealth(player.id())[2]--pointless.
+		local playerHealthBonus = status.resourceMax("health")
+		playerHealthBonus = playerHealthBonus - 100
+		if playerHealthBonus < 10 then playerHealthBonus = 10 end
+		local petHealthBonus = playerHealthBonus * 3
 
 
 
-    --************* FU special pet stats
+		--************* FU special pet stats
 	--khe: phasing this particular variant out
-    --[[local playerProtectionBonus = 0
-    for _, armourEffect in ipairs (effects) do
-        if armourEffect.stat == "protection" then
-            playerProtectionBonus = playerProtectionBonus + armourEffect.amount
-            petHealthBonus = (playerHealthBonus + playerProtectionBonus ) * 1.5 --we add the current Protection of the player x1.5 as bonus health
-        end
-    end]]
+		--[[local playerProtectionBonus = 0
+		for _, armourEffect in ipairs (effects) do
+				if armourEffect.stat == "protection" then
+						playerProtectionBonus = playerProtectionBonus + armourEffect.amount
+						petHealthBonus = (playerHealthBonus + playerProtectionBonus ) * 1.5 --we add the current Protection of the player x1.5 as bonus health
+				end
+		end]]
 	--khe: we now take into account the actual current value of the player's stats. though slightly delayed.
 	petHealthBonus=(petHealthBonus+status.stat("protection"))*1.5
 
 	--below comment is more or less false. pet stats are periodically refreshed
-    --below stats are currently unused, as they need to be linked to update, or they will be permanent after summon, which isnt the intent for them
+		--below stats are currently unused, as they need to be linked to update, or they will be permanent after summon, which isnt the intent for them
 	--[[
-    if config.getParameter("isNocturnal") then  --is it nocturnal?
-      if  world.lightLevel <=0.5 then
-          local petHealthBonus = playerHealthBonus * 1.15
-      end
-    end
-    if config.getParameter("isDiurnal") then -- does it prefer the day?
-      if world.lightLevel > 0.5 then
-          local petHealthBonus = playerHealthBonus * 1.15
-      end
-    end
-    if config.getParameter("isSurface") then -- does it prefer the surface?
-      if world.inSurfaceLayer then
-          local petHealthBonus = playerHealthBonus * 1.15
-      end
-    end
-    if config.getParameter("isSubterrain") then -- does it prefer being underground?
-      if world.underground then
-          local petHealthBonus = playerHealthBonus * 1.15
-      end
-    end
-    if config.getParameter("isWindy") then -- does it prefer windy worlds?
-      if world.windLevel >=10 then
-          local petHealthBonus = playerHealthBonus * 1.15
-      end
-    end
-    ]]
-    -- New Regen formula
-    -- https://www.desmos.com/calculator/mmv4okrc6f
-    local petRegenBonus = math.log(playerHealthBonus * 0.05 + 1) / math.log(10) * 5
+		if config.getParameter("isNocturnal") then	--is it nocturnal?
+			if	world.lightLevel <=0.5 then
+					local petHealthBonus = playerHealthBonus * 1.15
+			end
+		end
+		if config.getParameter("isDiurnal") then -- does it prefer the day?
+			if world.lightLevel > 0.5 then
+					local petHealthBonus = playerHealthBonus * 1.15
+			end
+		end
+		if config.getParameter("isSurface") then -- does it prefer the surface?
+			if world.inSurfaceLayer then
+					local petHealthBonus = playerHealthBonus * 1.15
+			end
+		end
+		if config.getParameter("isSubterrain") then -- does it prefer being underground?
+			if world.underground then
+					local petHealthBonus = playerHealthBonus * 1.15
+			end
+		end
+		if config.getParameter("isWindy") then -- does it prefer windy worlds?
+			if world.windLevel >=10 then
+					local petHealthBonus = playerHealthBonus * 1.15
+			end
+		end
+		]]
+		-- New Regen formula
+		-- https://www.desmos.com/calculator/mmv4okrc6f
+		local petRegenBonus = math.log(playerHealthBonus * 0.05 + 1) / math.log(10) * 5
 
-    -- Health Bonus
-    util.appendLists(effects, {{stat="maxHealth",amount=petHealthBonus},{stat="healthRegen",amount=petRegenBonus}})
+		-- Health Bonus
+		util.appendLists(effects, {{stat="maxHealth",amount=petHealthBonus},{stat="healthRegen",amount=petRegenBonus}})
 
-    -- ~Psi:  Debugging info
-    sb.setLogMap("~[Pet Stats] playerHealthBonus", "%s", tostring(playerHealthBonus))
-    sb.setLogMap("~[Pet Stats] petHealthBonus", "%s", tostring(petHealthBonus + playerHealthBonus))
-    sb.setLogMap("~[Pet Stats] petRegenBonus", "%s", tostring(petRegenBonus))
-  end
+		-- ~Psi:	Debugging info
+		sb.setLogMap("~[Pet Stats] playerHealthBonus", "%s", tostring(playerHealthBonus))
+		sb.setLogMap("~[Pet Stats] petHealthBonus", "%s", tostring(petHealthBonus + playerHealthBonus))
+		sb.setLogMap("~[Pet Stats] petRegenBonus", "%s", tostring(petRegenBonus))
+	end
 
-  -- Collars applied to the capturepod also take effect:
-  if self.collar and self.collar.effects then
-    util.appendLists(effects, self.collar.effects)
-  end
+	-- Collars applied to the capturepod also take effect:
+	if self.collar and self.collar.effects then
+		util.appendLists(effects, self.collar.effects)
+	end
 
 
 	--sb.logInfo("%s",effects)
-  return effects
+	return effects
 end
 
 function Pet:despawn(callback)
-  if not self.uniqueId then return end
-  self.statusTimer = nil
-  promises:add(world.sendEntityMessage(self.uniqueId, self.returnMessage), function (status)
-      self.status = status
-      self.uniqueId = nil
-      if callback then callback() end
-    end)
+	if not self.uniqueId then return end
+	self.statusTimer = nil
+	promises:add(world.sendEntityMessage(self.uniqueId, self.returnMessage), function (status)
+			self.status = status
+			self.uniqueId = nil
+			if callback then callback() end
+		end)
 end
 
 function Pet:needsRespawn()
-  if not self.uniqueId then return false end
-  if not compare(self.spawnedCollarParameters, self.collar and self.collar.parameters) then
-    -- The collar changed and it defines parameter overrides for the pet
-    return true
-  end
-  return false
+	if not self.uniqueId then return false end
+	if not compare(self.spawnedCollarParameters, self.collar and self.collar.parameters) then
+		-- The collar changed and it defines parameter overrides for the pet
+		return true
+	end
+	return false
 end
 
 function Pet:update(dt)
-  if self.statusTimer then
-    if self:needsRespawn() then
-      self:despawn(bind(self.spawn, self))
-      self.uniqueId = nil
-      return
-    end
+	if self.statusTimer then
+		if self:needsRespawn() then
+			self:despawn(bind(self.spawn, self))
+			self.uniqueId = nil
+			return
+		end
 
-    if not self.uniqueId then
-      self.statusTimer = nil
-      return
-    end
+		if not self.uniqueId then
+			self.statusTimer = nil
+			return
+		end
 
-    self.statusTimer = self.statusTimer - dt
-    if self.statusTimer <= 0 then
-      self.statusTimer = nil
+		self.statusTimer = self.statusTimer - dt
+		if self.statusTimer <= 0 then
+			self.statusTimer = nil
 
-      self:sendStatusRequest()
-    end
-  end
+			self:sendStatusRequest()
+		end
+	end
 end
 
 function Pet:statusReady()
-  return self.status and not self.spawning
+	return self.status and not self.spawning
 end
 
 function Pet:statusFailure()
-  if not self.persistent then
-    -- Pet entity doesn't exist.
-    -- It didn't die, because it sends us its status when it does that.
-    -- It just became unloaded. It's not persistent, so respawn it.
-    self.uniqueId = nil
-    self:spawn()
-  else
-    -- Companion was tethered to the world (i.e. persistent) and disappeared.
-    -- Only possible cause is death
-    self.status = self.status or {}
-    self.status.dead = true
-    self.uniqueId = nil
-  end
+	if not self.persistent then
+		-- Pet entity doesn't exist.
+		-- It didn't die, because it sends us its status when it does that.
+		-- It just became unloaded. It's not persistent, so respawn it.
+		self.uniqueId = nil
+		self:spawn()
+	else
+		-- Companion was tethered to the world (i.e. persistent) and disappeared.
+		-- Only possible cause is death
+		self.status = self.status or {}
+		self.status.dead = true
+		self.uniqueId = nil
+	end
 end
 
 function Pet:sendStatusRequest()
-  local persistentEffects = self:getPersistentEffects()
+	local persistentEffects = self:getPersistentEffects()
 
-  promises:add(world.sendEntityMessage(self.uniqueId, self.statusRequestMessage, persistentEffects, self:damageTeam()), function (state)
-      self.status = state.status
-      self.storage = state.storage
-      if state.portrait then
-        self.portrait = state.portrait
-      end
-      self.spawning = false
-      self:resetStatusTimer(false)
-      self.statusTimer = config.getParameter("statusTimer", 2)
-      if self.dirtyOnStatusUpdate then
-        self.spawner:markDirty()
-      end
-    end, function ()
-      if self.spawning then
-        -- The pet may simply not have spawned yet. Try requesting status again.
-        self:resetStatusTimer(true)
-      else
-        self:statusFailure()
-      end
-    end)
+	promises:add(world.sendEntityMessage(self.uniqueId, self.statusRequestMessage, persistentEffects, self:damageTeam()), function (state)
+			self.status = state.status
+			self.storage = state.storage
+			if state.portrait then
+				self.portrait = state.portrait
+			end
+			self.spawning = false
+			self:resetStatusTimer(false)
+			self.statusTimer = config.getParameter("statusTimer", 2)
+			if self.dirtyOnStatusUpdate then
+				self.spawner:markDirty()
+			end
+		end, function ()
+			if self.spawning then
+				-- The pet may simply not have spawned yet. Try requesting status again.
+				self:resetStatusTimer(true)
+			else
+				self:statusFailure()
+			end
+		end)
 end
 
 function Pet:setStatus(status, dead)
-  self.status = status
-  if dead then
-    self.status.dead = true
-    self.uniqueId = nil
-    self.statusTimer = nil
-  end
+	self.status = status
+	if dead then
+		self.status.dead = true
+		self.uniqueId = nil
+		self.statusTimer = nil
+	end
 end
 
 -- Pods are contain one or more pets. All are released and returned at once.
@@ -411,176 +411,176 @@ Pod = {}
 Pod.__index = Pod
 
 function Pod.new(uuid, pets)
-  local self = setmetatable({}, Pod)
-  self.uuid = uuid
-  self.pets = util.map(pets, function (petStore)
-      return Pet.new(uuid, petStore)
-    end)
-  return self
+	local self = setmetatable({}, Pod)
+	self.uuid = uuid
+	self.pets = util.map(pets, function (petStore)
+			return Pet.new(uuid, petStore)
+		end)
+	return self
 end
 
 function Pod:store()
-  return {
-      uuid = self.uuid,
-      pets = util.map(self.pets, Pet.store, jarray())
-    }
+	return {
+			uuid = self.uuid,
+			pets = util.map(self.pets, Pet.store, jarray())
+		}
 end
 
 function Pod.load(json)
-  return Pod.new(json.uuid, json.pets)
+	return Pod.new(json.uuid, json.pets)
 end
 
 function Pod:dead()
-  for _,pet in pairs(self.pets) do
-    if not pet:dead() then
-      return false
-    end
-  end
-  return true
+	for _,pet in pairs(self.pets) do
+		if not pet:dead() then
+			return false
+		end
+	end
+	return true
 end
 
 function Pod:release(position)
-  for _,pet in pairs(self.pets) do
-    if not pet:dead() then
-      pet:spawn(position)
-    end
-  end
+	for _,pet in pairs(self.pets) do
+		if not pet:dead() then
+			pet:spawn(position)
+		end
+	end
 end
 
 function Pod:recall()
-  for _,pet in pairs(self.pets) do
-    pet:despawn()
-  end
+	for _,pet in pairs(self.pets) do
+		pet:despawn()
+	end
 end
 
 function Pod:update(dt)
-  for _,pet in pairs(self.pets) do
-    pet:update(dt)
-  end
+	for _,pet in pairs(self.pets) do
+		pet:update(dt)
+	end
 end
 
 function Pod:setCollar(collar)
-  for _,pet in pairs(self.pets) do
-    pet.collar = collar
-  end
+	for _,pet in pairs(self.pets) do
+		pet.collar = collar
+	end
 end
 
 function Pod:findPetKey(uniqueId)
-  for key,pet in pairs(self.pets) do
-    if pet.uniqueId == uniqueId then
-      return key
-    end
-  end
-  return nil
+	for key,pet in pairs(self.pets) do
+		if pet.uniqueId == uniqueId then
+			return key
+		end
+	end
+	return nil
 end
 
 function Pod:findPet(uniqueId)
-  local key = self:findPetKey(uniqueId)
-  if key then
-    return self.pets[key]
-  else
-    return nil
-  end
+	local key = self:findPetKey(uniqueId)
+	if key then
+		return self.pets[key]
+	else
+		return nil
+	end
 end
 
 function Pod:removePet(uniqueId)
-  local key = self:findPetKey(uniqueId)
-  if key then
-    table.remove(self.pets, key)
-    return true
-  end
-  return false
+	local key = self:findPetKey(uniqueId)
+	if key then
+		table.remove(self.pets, key)
+		return true
+	end
+	return false
 end
 
 function Pod:addPet(pet)
-  self.pets[#self.pets+1] = pet
+	self.pets[#self.pets+1] = pet
 end
 
 petSpawner = {}
 
 function petSpawner:init()
-  message.setHandler("pets.updatePet", simpleHandler(bind(petSpawner.updatePet, self)))
-  message.setHandler("pets.disassociatePet", simpleHandler(bind(petSpawner.disassociatePet, self)))
-  message.setHandler("pets.associatePet", simpleHandler(bind(petSpawner.associatePet, self)))
-  message.setHandler("pets.setPodCollar", simpleHandler(bind(petSpawner.setPodCollar, self)))
+	message.setHandler("pets.updatePet", simpleHandler(bind(petSpawner.updatePet, self)))
+	message.setHandler("pets.disassociatePet", simpleHandler(bind(petSpawner.disassociatePet, self)))
+	message.setHandler("pets.associatePet", simpleHandler(bind(petSpawner.associatePet, self)))
+	message.setHandler("pets.setPodCollar", simpleHandler(bind(petSpawner.setPodCollar, self)))
 
-  -- The values of these should be set by the code using petSpawner.
-  self.pods = {}
-  self.ownerUuid = nil
-  self.tetherUniqueId = nil
-  self.levelOverride = nil
+	-- The values of these should be set by the code using petSpawner.
+	self.pods = {}
+	self.ownerUuid = nil
+	self.tetherUniqueId = nil
+	self.levelOverride = nil
 end
 
 function petSpawner:markDirty()
-  -- Mark health bars and other visual status representations as needing an
-  -- update.
-  self.dirty = true
+	-- Mark health bars and other visual status representations as needing an
+	-- update.
+	self.dirty = true
 end
 
 function petSpawner:clearDirty()
-  -- Indicate that UI elements have been updated
-  self.dirty = false
+	-- Indicate that UI elements have been updated
+	self.dirty = false
 end
 
 function petSpawner:isDirty()
-  -- Do UI elements need updating?
-  return self.dirty
+	-- Do UI elements need updating?
+	return self.dirty
 end
 
 function petSpawner:updatePet(podUuid, uniqueId, status, dead)
-  local pod = self.pods[podUuid]
-  if not pod then
-    sb.logInfo("Cannot update pet %s from invalid pod %s", uniqueId, podUuid)
-    return
-  end
+	local pod = self.pods[podUuid]
+	if not pod then
+		sb.logInfo("Cannot update pet %s from invalid pod %s", uniqueId, podUuid)
+		return
+	end
 
-  local pet = pod:findPet(uniqueId)
-  if not pet then
-    sb.logInfo("Cannot update invalid pet %s from pod %s", uniqueId, podUuid)
-    return
-  end
+	local pet = pod:findPet(uniqueId)
+	if not pet then
+		sb.logInfo("Cannot update invalid pet %s from pod %s", uniqueId, podUuid)
+		return
+	end
 
-  pet:setStatus(status, dead)
-  self:markDirty()
+	pet:setStatus(status, dead)
+	self:markDirty()
 end
 
 function petSpawner:disassociatePet(podUuid, uniqueId)
-  local pod = self.pods[podUuid]
-  if not pod then
-    sb.logInfo("Cannot disassociate pet %s from invalid pod %s", uniqueId, podUuid)
-    return
-  end
+	local pod = self.pods[podUuid]
+	if not pod then
+		sb.logInfo("Cannot disassociate pet %s from invalid pod %s", uniqueId, podUuid)
+		return
+	end
 
-  pod:removePet(uniqueId)
-  self:markDirty()
+	pod:removePet(uniqueId)
+	self:markDirty()
 end
 
 function petSpawner:associatePet(podUuid, petJson)
-  local uniqueId = petJson.uniqueId
-  if not uniqueId then
-    sb.logInfo("Cannot associate non-existent pet with pod %s", podUuid)
-    return
-  end
+	local uniqueId = petJson.uniqueId
+	if not uniqueId then
+		sb.logInfo("Cannot associate non-existent pet with pod %s", podUuid)
+		return
+	end
 
-  local pod = self.pods[podUuid]
-  if not pod then
-    sb.logInfo("Cannot associate pet %s with invalid pod %s", uniqueId, podUuid)
-    return
-  end
+	local pod = self.pods[podUuid]
+	if not pod then
+		sb.logInfo("Cannot associate pet %s with invalid pod %s", uniqueId, podUuid)
+		return
+	end
 
-  local pet = Pet.new(podUuid, petJson)
+	local pet = Pet.new(podUuid, petJson)
 
-  pod:addPet(pet)
-  self:markDirty()
+	pod:addPet(pet)
+	self:markDirty()
 end
 
 function petSpawner:setPodCollar(podUuid, collar)
-  local pod = self.pods[podUuid]
-  if not pod then
-    sb.logInfo("Cannot set a collar %s on invalid pod %s", collar and collar.name, podUuid)
-    return
-  end
+	local pod = self.pods[podUuid]
+	if not pod then
+		sb.logInfo("Cannot set a collar %s on invalid pod %s", collar and collar.name, podUuid)
+		return
+	end
 
-  pod:setCollar(collar)
-  self:markDirty()
+	pod:setCollar(collar)
+	self:markDirty()
 end

--- a/stats/effects/elementalaura/aetheraura.statuseffect
+++ b/stats/effects/elementalaura/aetheraura.statuseffect
@@ -1,0 +1,14 @@
+{
+  "name" : "aetheraura",
+  "defaultDuration" : 0.5,
+
+  "scripts" : [
+    "elementalaura.lua"
+  ],
+  "effectConfig" : {
+    "resistType" : "cosmicResistance",
+    "resistValue" : 0.6
+  },
+
+  "animationConfig" : "cosmicaura.animation"
+}


### PR DESCRIPTION
tooltip name replace for alt abilities: Energy Aura -> `<elementalName>` Aura (result for ice weapon: Ice Aura)
added support for <elementalName> tag in various buildscripts
corrected aetherium hammer alt: it was referencing a nonexistent aetheraura status effect. the effect now exists, and is a copy of cosmicaura3 (which grants 60% cosmic resistance)

corrected blocker effects on bandages to refer to mutaviskheal (the status effect), rather than mutaviskbandage (the item ID), so people no longer can waste those bandages