### PR TITLE
Changes to Shoggoth race

### DIFF
--- a/species/shoggoth.raceeffect
+++ b/species/shoggoth.raceeffect
@@ -13,7 +13,7 @@
 		{"stat": "maxBreath","amount": 1920 }
 	],
 	
-	"diet" : "raw_omnivore",
+	"diet" : "entity",
 	
 	"envEffects": [{
 			"biomes": [

--- a/species/shoggoth.raceeffect
+++ b/species/shoggoth.raceeffect
@@ -14,7 +14,7 @@
 	],
 	
 	"diet" : "entity",
-    "tech" : ["shoggothmadnesstech"],
+	"tech" : ["shoggothmadnesstech"],
 	
 	"envEffects": [{
 			"biomes": [

--- a/species/shoggoth.raceeffect
+++ b/species/shoggoth.raceeffect
@@ -14,6 +14,7 @@
 	],
 	
 	"diet" : "entity",
+    "tech" : ["shoggothmadnesstech"],
 	
 	"envEffects": [{
 			"biomes": [

--- a/species/shoggoth.species.patch
+++ b/species/shoggoth.species.patch
@@ -8,6 +8,7 @@
 ^orange;Perks^reset;:
   +^green;1920^reset; Breath Time (4 mins)
   ^green;Resist^reset;: +^green;30^reset;% Ice, +^green;15^reset;% Shadow, Cosmic
+  Tech: ^green;Invoke Madness^reset;
   ^cyan;Immune^reset;: Slime Bounce, Slime Stick, Insanity
 
 ^orange;Environment^reset;:

--- a/species/shoggoth.species.patch
+++ b/species/shoggoth.species.patch
@@ -3,7 +3,7 @@
     "path" : "/charCreationTooltip/description" ,
     "value" : "Having broken from the shackles of their former abusive owners, they venture space aimlessly, hoping to find a better purpose, make it a worthy equal or a purer cause.
 
-  ^orange;Diet^reset;: Omnivore, can eat raw meat
+  ^orange;Diet^reset;: Any
 
 ^orange;Perks^reset;:
   +^green;1920^reset; Breath Time (4 mins)

--- a/tech/other/shoggothmadness.lua
+++ b/tech/other/shoggothmadness.lua
@@ -1,0 +1,56 @@
+require "/scripts/vec2.lua"
+local foodThreshold=20
+
+function init()
+	self.enabled = 0
+	self.timer = 0
+	self.baseInsanityImmunity = status.stat("insanityImmunity")
+end
+
+function uninit()
+	deactivate()
+end
+
+function checkFood()
+	return (((status.statusProperty("fuFoodTrackerHandler",0)>-1) and status.isResource("food")) and status.resource("food")) or foodThreshold
+end
+
+function update(args)
+	-- Check if F pushed
+	if args.moves["special1"] and self.timer == 0 then
+		self.timer = 0.5
+		if self.enabled == 0 then
+			activate()
+		else
+			deactivate()
+		end
+	end
+	-- Timer to limit activation
+	if self.timer > 0 then
+		self.timer = math.max(0, self.timer - args.dt)
+	end
+	-- Stop if hungry
+	if checkFood() < foodThreshold then
+		deactivate()
+	end
+	-- Consume food
+	if self.enabled == 1 then
+		status.modifyResource("food",-0.006)
+	end
+end
+
+function activate()
+	self.enabled = 1
+	if self.baseInsanityImmunity > 0 then
+		status.setPersistentEffects("insanityVulnerability", {{stat = "insanityImmunity", amount = -1*self.baseInsanityImmunity}})
+	end
+	status.addPersistentEffect("madnesseffect2", "insanitynew", math.huge)
+end
+
+function deactivate()
+	self.enabled = 0
+	if self.baseInsanityImmunity > 0 then
+		status.clearPersistentEffects("insanityVulnerability")
+	end
+	status.setPersistentEffects("madnesseffect2",{})
+end

--- a/tech/other/shoggothmadness.tech
+++ b/tech/other/shoggothmadness.tech
@@ -1,0 +1,13 @@
+{
+  "name" : "shoggothmadnesstech",
+  "type" : "head",
+
+  "scripts" : ["shoggothmadness.lua"],
+
+  "description" : "Embrace your natural madness. Activate with ^green;[F]^reset;",
+  "shortDescription" : "Invoke Madness",
+  "rarity" : "Legendary",
+  "icon" : "/interface/statuses/insanity.png",
+  "chipCost" : 1,
+  "energyCostPerSecond" : 0
+}


### PR DESCRIPTION
Changed diet from omnivore to any to better fit lore. Added a racial tech that disables insanity immunity and grants insanity at the cost of temporarily increased hunger rate. Since insanity is vital to madness research, this tech removes a handicap in that area.