### PR TITLE
Bed tags

### DIFF
--- a/objects/densinium/densiniumbed/densiniumbed.object
+++ b/objects/densinium/densiniumbed/densiniumbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "densiniumbed",
-  "colonyTags" : ["densinium"],
+  "colonyTags" : ["densinium","bed"],
   "printable" : false,
   "rarity" : "legendary",
   "description" : "A bed made from densinium.",

--- a/objects/lunari/lunaribed/lunaribed.object
+++ b/objects/lunari/lunaribed/lunaribed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "lunaribed",
-  "colonyTags" : ["lunari"],
+  "colonyTags" : ["lunari","bed"],
   "printable" : false,
   "rarity" : "rare",
   "description" : "A bed made from lunari.",

--- a/objects/proppack/igloo/igloo.object
+++ b/objects/proppack/igloo/igloo.object
@@ -1,10 +1,10 @@
 {
   "objectName": "igloo",
   "printable": false,
-  "colonyTags": [ "ice" ],
+  "colonyTags": [ "ice", "bed" ],
   "rarity": "Uncommon",
   "race": "generic",
-  "price": 0,
+  "price": 50,
   "category" : "furniture",
 
   "description": "An igloo. It's much warmer than you'd expect!",

--- a/objects/themed/roman/romanbed/romanbed.object
+++ b/objects/themed/roman/romanbed/romanbed.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "romanbed",
-  "colonyTags" : ["roman","pretty","valuable"],
+  "colonyTags" : ["roman","pretty","valuable","bed"],
   "printable" : false,
   "rarity" : "Rare",
   "description" : "A robust, roman-style bed.",


### PR DESCRIPTION
- Added the Bed colony tag to Densinium, Lunari and Roman beds, and the Igloo. All FU and vanilla beds should now be valid for use with Mk2 colony deeds and crew deeds.