### PR TITLE
Extra Dungeons beamUpRule

### DIFF
--- a/instance_worlds.config.patch
+++ b/instance_worlds.config.patch
@@ -907,6 +907,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "japaneseruins",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -959,6 +960,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "letheiafacility",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1013,6 +1015,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "penguinhighway",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1090,6 +1093,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "avianhydro",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1144,6 +1148,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "extrahome",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1220,6 +1225,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "alienjungle",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1315,6 +1321,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "ancienttemple",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1369,6 +1376,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "sunsetriders",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"dayLength": 10000,
@@ -1445,6 +1453,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "snowcrash",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1499,6 +1508,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "grandarena",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1553,6 +1563,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "forestoffae",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"dayLength": 10000,
@@ -1629,6 +1640,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "evernight",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1683,6 +1695,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "volcanobase",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1737,6 +1750,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "lethialabs",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1791,6 +1805,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "skytemple",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1867,6 +1882,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "infiltration",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1921,6 +1937,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "verdantruins",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"spaceLevel": 3000,
@@ -1975,6 +1992,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "pavillion",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"dayLength": 10000,
@@ -2051,6 +2069,7 @@
 			"type": "FloatingDungeon",
 			"dungeonWorld": "magickaforest",
 			"spawningEnabled": false,
+			"beamUpRule": "AnywhereWithWarning",
 			"disableDeathDrops": true,
 			"skyParameters": {
 				"dayLength": 10000,


### PR DESCRIPTION
- Fixed an issue where players could not beam up in Extra Dungeons. They now follow the same rules as all other dungeon instances.