### PR TITLE
Removing Former Gallery and Fabricated World

### DIFF
--- a/treasure/futreasurepools.treasurepools
+++ b/treasure/futreasurepools.treasurepools
@@ -334,8 +334,6 @@
     [0, {
       "pool" : [
 // fu art pieces
-       {"weight" : 0.037, "item" : "painting_formergallery"},
-       {"weight" : 0.037, "item" : "painting_fabricatedworld"},
        {"weight" : 0.037, "item" : "kittenpainting"},
        {"weight" : 0.037, "item" : "puppypainting"},
        {"weight" : 0.037, "item" : "starrynightpainting"},


### PR DESCRIPTION
All it does is remove them form the treasure pool, any one of them still in the game will still be there, but it's to not break any current builds. 