### PR TITLE
Info Booth text timer extended

### DIFF
--- a/objects/scienceoutpost/scienceinfobooth/scienceinfobooth.lua
+++ b/objects/scienceoutpost/scienceinfobooth/scienceinfobooth.lua
@@ -5,6 +5,8 @@ function init()
   self.containsPlayers = {}
   object.setInteractive(true)
   self.chatIndex = 0
+  self.chatTimer = -1
+  self.chatOptions = config.getParameter("chatOptions", {})
 end
 
 function update(dt)
@@ -17,11 +19,26 @@ function update(dt)
     end
   end
   self.containsPlayers = newPlayers
+  
+  
+  if self.chatTimer == 0 and self.chatIndex ~= 0  then
+  chatOptions = config.getParameter("chatOptions", {})
+	object.say(chatOptions[(self.chatIndex % #chatOptions)])
+	--animator.playSound("chatter")
+	self.chatTimer = self.chatTimer - 1
+	else
+		if self.chatTimer >= 0 then
+		self.chatTimer = self.chatTimer - 1
+		--object.say(self.chatTimer)
+		end
+	end
+  
 end
 
 function onInteraction(args)
-  local chatOptions = config.getParameter("chatOptions", {})
+  chatOptions = config.getParameter("chatOptions", {})
   object.say(chatOptions[(self.chatIndex % #chatOptions) + 1])
+  self.chatTimer = 50
   self.chatIndex = self.chatIndex + 1
   animator.playSound("chatter")
 end


### PR DESCRIPTION
Took a while - certainly longer than it should have, anyway - but thanks to the help of Zarra, Edward, and Sayter, the text from the Science Outpost Info Booth should stick around longer. Be warned that it's fundamentally a workaround, so although it appears fine to me, don't be surprised if there ends up being some unusual behavior.