### PR TITLE
hand to face, not the face

### DIFF
--- a/items/active/weapons/fist/aetheriumfists.activeitem
+++ b/items/active/weapons/fist/aetheriumfists.activeitem
@@ -1,111 +1,111 @@
 {
-  "itemName" : "aetheriumfist",
-  "price" : 2500,
-  "level" : 7,
-  "maxStack" : 1,
-  "rarity" : "legendary",
-  "description" : "A lesson in hard love.
+	"itemName" : "aetheriumfist",
+	"price" : 2500,
+	"level" : 7,
+	"maxStack" : 1,
+	"rarity" : "legendary",
+	"description" : "A lesson in hard love.
 ^yellow;Counts as 'energy' for set bonuses^reset;",
-  "shortdescription" : "Aetherium Claw",
-  "tooltipKind" : "fist2aetherium",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist","energy","aetherium","cosmic","upgradeableWeapon"],
+	"shortdescription" : "Aetherium Claw",
+	"tooltipKind" : "fist2aetherium",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist","energy","aetherium","cosmic","upgradeableWeapon"],
 
-  "inventoryIcon" : "aetherium_fist_ashey.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "aetherium_fist_ashey.png",
-    "weaponfullbright" : "aetherium_fistfullbright.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"inventoryIcon" : "aetherium_fist_ashey.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "aetherium_fist_ashey.png",
+		"weaponfullbright" : "aetherium_fistfullbright.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 3,
-  "comboTiming" : [0.2, 0.5],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/supernovarush.combofinisher",
-  "elementalType" : "cosmic",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"comboSteps" : 3,
+	"comboTiming" : [0.2, 0.5],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/supernovarush.combofinisher",
+	"elementalType" : "cosmic",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.14,
-    "fireTime" : 0.25,
-    "baseDps" : 8,
-    "damageConfig" : {
-      "damageSourceKind" : "aetherfist",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1,
-      "statusEffects":["defenseboostneg20"]
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.14,
+		"fireTime" : 0.25,
+		"baseDps" : 8,
+		"damageConfig" : {
+			"damageSourceKind" : "aetherfist",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1,
+			"statusEffects":["defenseboostneg20"]
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : false,
-        "allowFlip" : true,
+				"allowRotate" : false,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance": 7,
-  "critBonus": 4,
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance": 7,
+	"critBonus": 4,
 
-  "builder" : "/items/buildscripts/buildfist.lua"
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/boneclaws.activeitem
+++ b/items/active/weapons/fist/boneclaws.activeitem
@@ -1,116 +1,116 @@
 {
-  "itemName" : "fuboneclaws",
-  "price" : 20,
-  "level" : 1,
-  "maxStack" : 1,
-  "rarity" : "common",
-  "description" : "Kinda strange choice of weapon... but hey, it's sharp.",
-  "shortdescription" : "Bone Claw",
-  "tooltipKind" : "fistweapon",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon","bone"],
-  //"collectablesOnPickup" : { "fu_weaponfist" : "fuboneclaws" },
-  "inventoryIcon" : "boneclaws.png:front",
-  "animation" : "fistweapon.animation",
-  "animationParts" : {
-    "weapon" : "boneclaws.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "fuboneclaws",
+	"price" : 20,
+	"level" : 1,
+	"maxStack" : 1,
+	"rarity" : "common",
+	"description" : "Kinda strange choice of weapon... but hey, it's sharp.",
+	"shortdescription" : "Bone Claw",
+	"tooltipKind" : "fistweapon",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon","bone"],
+	//"collectablesOnPickup" : { "fu_weaponfist" : "fuboneclaws" },
+	"inventoryIcon" : "boneclaws.png:front",
+	"animation" : "fistweapon.animation",
+	"animationParts" : {
+		"weapon" : "boneclaws.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 4,
-  "comboTiming" : [0.1, 0.5],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/backdash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.5],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/backdash.combofinisher",
 
-  "freezeLimit" : 2,
-  
-  "elementalType":"physical",
+	"freezeLimit" : 2,
+	
+	"elementalType":"physical",
 
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.13,
-    "fireTime" : 0.22,
-    "baseDps" : 8.0,
-    "damageConfig" : {
-      "statusEffects" : [ ],
-      "damageSourceKind" : "dagger",
-      "knockback" : [0, 12],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.13,
+		"fireTime" : 0.22,
+		"baseDps" : 8.0,
+		"damageConfig" : {
+			"statusEffects" : [ ],
+			"damageSourceKind" : "dagger",
+			"knockback" : [0, 12],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 2,
-  "critBonus" : 2, 
-  "fistBonus" : 3,
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 2,
+	"critBonus" : 2, 
+	"fistBonus" : 3,
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/combofinishers/sonicslash.lua
+++ b/items/active/weapons/fist/combofinishers/sonicslash.lua
@@ -5,87 +5,88 @@ require "/items/active/weapons/weapon.lua"
 SonicSlash = WeaponAbility:new()
 
 function SonicSlash:init()
-  self.freezeTimer = 0
+	self.freezeTimer = 0
 
-  self.weapon.onLeaveAbility = function()
-    self.weapon:setStance(self.stances.idle)
-  end
+	self.weapon.onLeaveAbility = function()
+		self.weapon:setStance(self.stances.idle)
+	end
 end
 
 -- Ticks on every update regardless if this is the active ability
 function SonicSlash:update(dt, fireMode, shiftHeld)
-  WeaponAbility.update(self, dt, fireMode, shiftHeld)
+	WeaponAbility.update(self, dt, fireMode, shiftHeld)
 
-  self.freezeTimer = math.max(0, self.freezeTimer - self.dt)
-  if self.freezeTimer > 0 and not mcontroller.onGround() and math.abs(world.gravity(mcontroller.position())) > 0 then
-    mcontroller.controlApproachVelocity({0, 0}, 1000)
-  end
+	self.freezeTimer = math.max(0, self.freezeTimer - self.dt)
+	if self.freezeTimer > 0 and not mcontroller.onGround() and math.abs(world.gravity(mcontroller.position())) > 0 then
+		mcontroller.controlApproachVelocity({0, 0}, 1000)
+	end
 end
 
 -- used by fist weapon combo system
 function SonicSlash:startAttack()
-  self:setState(self.windup)
+	self:setState(self.windup)
 
-  self.weapon.freezesLeft = 0
-  self.freezeTimer = self.freezeTime or 0
+	self.weapon.freezesLeft = 0
+	self.freezeTimer = self.freezeTime or 0
 end
 
 -- State: windup
 function SonicSlash:windup()
-  self.weapon:setStance(self.stances.windup)
+	self.weapon:setStance(self.stances.windup)
 
-  util.wait(self.stances.windup.duration)
+	util.wait(self.stances.windup.duration)
 
-  self:setState(self.windup2)
+	self:setState(self.windup2)
 end
 
 -- State: windup2
 function SonicSlash:windup2()
-  self.weapon:setStance(self.stances.windup2)
+	self.weapon:setStance(self.stances.windup2)
 
-  util.wait(self.stances.windup2.duration)
+	util.wait(self.stances.windup2.duration)
 
-  self:setState(self.fire)
+	self:setState(self.fire)
 end
 
 -- State: special
 function SonicSlash:fire()
-  self.weapon:setStance(self.stances.fire)
-  self.weapon:updateAim()
+	self.weapon:setStance(self.stances.fire)
+	self.weapon:updateAim()
 
-  animator.setAnimationState("attack", "special")
-  animator.playSound("special")
+	animator.setAnimationState("attack", "special")
+	animator.playSound("special")
 
-  status.addEphemeralEffect("invulnerable", self.stances.fire.duration + 0.1)
+	status.addEphemeralEffect("invulnerable", self.stances.fire.duration + 0.1)
+	self.damageConfig.statusEffects=self.damageConfig.statusEffects or {}
+	table.insert(self.damageConfig.statusEffects,"fushieldbreaker")
+	util.wait(self.stances.fire.duration, function()
+		local damageArea = partDamageArea("specialswoosh")
 
-  util.wait(self.stances.fire.duration, function()
-    local damageArea = partDamageArea("specialswoosh")
+		self.weapon:setDamage(self.damageConfig, damageArea, self.fireTime)
+	end)
 
-    self.weapon:setDamage(self.damageConfig, damageArea, self.fireTime)
-  end)
-
-      local position = vec2.add(mcontroller.position(), {self.projectileOffset[1] * mcontroller.facingDirection(), self.projectileOffset[2]})
+			local position = vec2.add(mcontroller.position(), {self.projectileOffset[1] * mcontroller.facingDirection(), self.projectileOffset[2]})
 	local params = {
-    powerMultiplier = activeItem.ownerPowerMultiplier(),
-    power = self:damageAmount(),
+		powerMultiplier = activeItem.ownerPowerMultiplier(),
+		power = self:damageAmount(),
 	speed = 120
-  }
-  world.spawnProjectile("sonic", position, activeItem.ownerEntityId(), self:aimVector(), false, params)
+	}
+	world.spawnProjectile("sonic", position, activeItem.ownerEntityId(), self:aimVector(), false, params)
 
-  finishFistCombo()
-  activeItem.callOtherHandScript("finishFistCombo")
+	finishFistCombo()
+	activeItem.callOtherHandScript("finishFistCombo")
 end
 
 function SonicSlash:aimVector()
-  local aimVector = vec2.rotate({1, 0}, self.weapon.aimAngle)
-  aimVector[1] = aimVector[1] * mcontroller.facingDirection()
-  return aimVector
+	local aimVector = vec2.rotate({1, 0}, self.weapon.aimAngle)
+	aimVector[1] = aimVector[1] * mcontroller.facingDirection()
+	return aimVector
 end
 
 function SonicSlash:damageAmount()
-  return self.baseDamage * config.getParameter("damageLevelMultiplier")
+	return self.baseDamage * config.getParameter("damageLevelMultiplier")
 end
 
 function SonicSlash:uninit(unloaded)
-  self.weapon:setDamage()
+	self.weapon:setDamage()
 end

--- a/items/active/weapons/fist/cultivatorsgauntlets.activeitem
+++ b/items/active/weapons/fist/cultivatorsgauntlets.activeitem
@@ -1,111 +1,111 @@
 {
-  "itemName" : "cultivatorsgauntlets",
-  "price" : 5500,
-  "level" : 6,
-  "maxStack" : 1,
-  "rarity" : "legendary",
-  "description" : "No, they are not perfectly balanced.
+	"itemName" : "cultivatorsgauntlets",
+	"price" : 5500,
+	"level" : 6,
+	"maxStack" : 1,
+	"rarity" : "legendary",
+	"description" : "No, they are not perfectly balanced.
 ^yellow;Inflicts burn, poison, radburn, defense reduction and shadow.^reset;",
-  "shortdescription" : "Infinite Fists",
-  "tooltipKind" : "swordunique",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","melee","fist","upgradeableWeapon"],
+	"shortdescription" : "Infinite Fists",
+	"tooltipKind" : "swordunique",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","melee","fist","upgradeableWeapon"],
 
-  "inventoryIcon" : "cultivatorsgauntlets.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "cultivatorsgauntlets.png",
-    "weaponfullbright" : "cultivatorsgauntletsfullbright.png",
-    "swoosh" : "swoosh/cuteswoosh.png"
-  },
-  "animationCustom" : {
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"inventoryIcon" : "cultivatorsgauntlets.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "cultivatorsgauntlets.png",
+		"weaponfullbright" : "cultivatorsgauntletsfullbright.png",
+		"swoosh" : "swoosh/cuteswoosh.png"
+	},
+	"animationCustom" : {
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 8,
-  "comboTiming" : [0.2, 0.5],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/lovepunch.combofinisher",
-  "elementalType" : "physical",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"comboSteps" : 3,
+	"comboTiming" : [0.2, 0.5],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/lovepunch.combofinisher",
+	"elementalType" : "physical",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.15,
-    "fireTime" : 0.27,
-    "baseDps" : 5.5,
-    "damageConfig" : {
-      "damageSourceKind" : "fist",
-      "statusEffects" : [ "radiationburn", "weakpoison", "burning", "shadowgasfx", "defenseboostneg20"],
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.15,
+		"fireTime" : 0.27,
+		"baseDps" : 5.5,
+		"damageConfig" : {
+			"damageSourceKind" : "fist",
+			"statusEffects" : [ "radiationburn", "weakpoison", "burning", "shadowgasfx", "defenseboostneg20"],
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : false,
-        "allowFlip" : true,
+				"allowRotate" : false,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance": 2,
-  "critBonus": 9,
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance": 2,
+	"critBonus": 9,
 
-  "builder" : "/items/buildscripts/buildfist.lua"
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/cutecestus.activeitem
+++ b/items/active/weapons/fist/cutecestus.activeitem
@@ -1,111 +1,111 @@
 {
-  "itemName" : "cutecestus",
-  "price" : 500,
-  "level" : 4,
-  "maxStack" : 1,
-  "rarity" : "Rare",
-  "description" : "Ripe with adorable energy.
+	"itemName" : "cutecestus",
+	"price" : 500,
+	"level" : 4,
+	"maxStack" : 1,
+	"rarity" : "Rare",
+	"description" : "Ripe with adorable energy.
 ^yellow;Counts as 'energy' for set bonuses^reset;",
-  "shortdescription" : "Prismatic Cestus",
-  "tooltipKind" : "fistweapon",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist","energy","upgradeableWeapon", "cute","cosmic"],
+	"shortdescription" : "Prismatic Cestus",
+	"tooltipKind" : "fistweapon",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist","energy","upgradeableWeapon", "cute","cosmic"],
 
-  "inventoryIcon" : "cutecestus.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "cutecestus.png",
-    "weaponfullbright" : "cutecestusfullbright.png",
-    "swoosh" : "swoosh/cuteswoosh.png"
-  },
-  "animationCustom" : {
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"inventoryIcon" : "cutecestus.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "cutecestus.png",
+		"weaponfullbright" : "cutecestusfullbright.png",
+		"swoosh" : "swoosh/cuteswoosh.png"
+	},
+	"animationCustom" : {
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 3,
-  "comboTiming" : [0.2, 0.5],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/lovepunch.combofinisher",
-  "elementalType" : "cosmic",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"comboSteps" : 3,
+	"comboTiming" : [0.2, 0.5],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/lovepunch.combofinisher",
+	"elementalType" : "cosmic",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.15,
-    "fireTime" : 0.3,
-    "baseDps" : 7.5,
-    "damageConfig" : {
-      "statusEffects" : [ ],
-      "damageSourceKind" : "cosmicfist",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.15,
+		"fireTime" : 0.3,
+		"baseDps" : 7.5,
+		"damageConfig" : {
+			"statusEffects" : [ ],
+			"damageSourceKind" : "cosmicfist",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : false,
-        "allowFlip" : true,
+				"allowRotate" : false,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance": 2,
-  "critBonus": 9,
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance": 2,
+	"critBonus": 9,
 
-  "builder" : "/items/buildscripts/buildfist.lua"
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/cutegauntlet.activeitem
+++ b/items/active/weapons/fist/cutegauntlet.activeitem
@@ -1,110 +1,110 @@
 {
-  "itemName" : "cutegauntlet",
-  "price" : 500,
-  "level" : 4,
-  "maxStack" : 1,
-  "rarity" : "Rare",
-  "description" : "A lesson in hard love.
+	"itemName" : "cutegauntlet",
+	"price" : 500,
+	"level" : 4,
+	"maxStack" : 1,
+	"rarity" : "Rare",
+	"description" : "A lesson in hard love.
 ^yellow;Counts as 'energy' for set bonuses^reset;",
-  "shortdescription" : "Prismatic Gauntlet",
-  "tooltipKind" : "fistweapon",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist","energy","upgradeableWeapon", "cute","cosmic"],
+	"shortdescription" : "Prismatic Gauntlet",
+	"tooltipKind" : "fistweapon",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist","energy","upgradeableWeapon", "cute","cosmic"],
 
-  "inventoryIcon" : "cutegauntlet.png:front",
-  "animation" : "fistweapon.animation",
-  "animationParts" : {
-    "weapon" : "cutegauntlet.png",
-    "swoosh" : "swoosh/cuteswoosh.png"
-  },
-  "animationCustom" : {
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"inventoryIcon" : "cutegauntlet.png:front",
+	"animation" : "fistweapon.animation",
+	"animationParts" : {
+		"weapon" : "cutegauntlet.png",
+		"swoosh" : "swoosh/cuteswoosh.png"
+	},
+	"animationCustom" : {
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 3,
-  "comboTiming" : [0.2, 0.5],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/lovepunch.combofinisher",
-  "elementalType" : "cosmic",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"comboSteps" : 3,
+	"comboTiming" : [0.2, 0.5],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/lovepunch.combofinisher",
+	"elementalType" : "cosmic",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.15,
-    "fireTime" : 0.3,
-    "baseDps" : 7.5,
-    "damageConfig" : {
-      "statusEffects" : [ ],
-      "damageSourceKind" : "cosmicfist",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.15,
+		"fireTime" : 0.3,
+		"baseDps" : 7.5,
+		"damageConfig" : {
+			"statusEffects" : [ ],
+			"damageSourceKind" : "cosmicfist",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : false,
-        "allowFlip" : true,
+				"allowRotate" : false,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : false,
-        "allowFlip" : false,
+				"allowRotate" : false,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance": 7,
-  "critBonus": 4,
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance": 7,
+	"critBonus": 4,
 
-  "builder" : "/items/buildscripts/buildfist.lua"
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/extraclawglove.activeitem
+++ b/items/active/weapons/fist/extraclawglove.activeitem
@@ -1,117 +1,117 @@
 {
-  "itemName" : "extraclawglove",
-  "price" : 1000,
-  "level" : 6,
-  "maxStack" : 1,
-  "rarity" : "Legendary",
-  "description" : "Claws designed like a bird's talons.",
-  "shortdescription" : "Zel-Claw",
-  "tooltipKind" : "fistweapon",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon", "fist", "upgradeableWeapon"],
+	"itemName" : "extraclawglove",
+	"price" : 1000,
+	"level" : 6,
+	"maxStack" : 1,
+	"rarity" : "Legendary",
+	"description" : "Claws designed like a bird's talons.",
+	"shortdescription" : "Zel-Claw",
+	"tooltipKind" : "fistweapon",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon", "fist", "upgradeableWeapon"],
 
-  "inventoryIcon" : "extraclawglove.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "extraclawglove.png",
-    "weaponfullbright" : "extraclawglovefullbright.png",
-    "swoosh" : "swoosh/extraclawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-5.5, -1.1], [9.2, -0.6], [9.2, 0.8], [-5.5, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"inventoryIcon" : "extraclawglove.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "extraclawglove.png",
+		"weaponfullbright" : "extraclawglovefullbright.png",
+		"swoosh" : "swoosh/extraclawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-5.5, -1.1], [9.2, -0.6], [9.2, 0.8], [-5.5, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.2,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.2,
 
-  "comboSteps" : 4,
-  "comboTiming" : [0.2, 0.75],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/sonicslash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.2, 0.75],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/sonicslash.combofinisher",
 
-  "freezeLimit" : 0,
-  "elementalType" : "cosmic",
+	"freezeLimit" : 0,
+	"elementalType" : "cosmic",
 
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.25,
-    "fireTime" : 0.2,
-    "baseDps" : 11.5,
-    "damageConfig" : {
-      "statusEffects" : [ "frostsnare" ],
-      "damageSourceKind" : "cosmicbroadsword",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.25,
+		"fireTime" : 0.2,
+		"baseDps" : 11.5,
+		"damageConfig" : {
+			"statusEffects" : [ "frostsnare" ],
+			"damageSourceKind" : "cosmicbroadsword",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
 
-  "critChance" : 1,
-  "critBonus" : 5, 
-//  "learnBlueprintsOnPickup" : [ "extraclawglove" ],
-  "builder" : "/items/buildscripts/buildfist.lua"
+	"critChance" : 1,
+	"critBonus" : 5, 
+//	"learnBlueprintsOnPickup" : [ "extraclawglove" ],
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/fuapexclaws.activeitem
+++ b/items/active/weapons/fist/fuapexclaws.activeitem
@@ -1,114 +1,114 @@
 {
-  "itemName" : "fuapexclaws",
-  "price" : 1000,
-  "level" : 5,
-  "maxStack" : 1,
-  "rarity" : "legendary",
-  "description" : "A deadly fist weapon that projects kinetic force.",
-  "shortdescription" : "Force Gauntlet",
-  "tooltipKind" : "fist2",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon"],
-  //"collectablesOnPickup" : { "fu_weaponfist" : "fuapexclaws" },
-  "inventoryIcon" : "apexclaws.png:front",
-  "animation" : "fistweapon.animation",
-  "animationParts" : {
-    "weapon" : "apexclaws.png",
-    "swoosh" : "swoosh/electricswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/energywhip_swing1.ogg", "/sfx/melee/energywhip_swing2.ogg", "/sfx/melee/energywhip_swing3.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "fuapexclaws",
+	"price" : 1000,
+	"level" : 5,
+	"maxStack" : 1,
+	"rarity" : "legendary",
+	"description" : "A deadly fist weapon that projects kinetic force.",
+	"shortdescription" : "Force Gauntlet",
+	"tooltipKind" : "fist2",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon"],
+	//"collectablesOnPickup" : { "fu_weaponfist" : "fuapexclaws" },
+	"inventoryIcon" : "apexclaws.png:front",
+	"animation" : "fistweapon.animation",
+	"animationParts" : {
+		"weapon" : "apexclaws.png",
+		"swoosh" : "swoosh/electricswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/energywhip_swing1.ogg", "/sfx/melee/energywhip_swing2.ogg", "/sfx/melee/energywhip_swing3.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.15,
-  
-  "comboSteps" : 5,
-  "comboTiming" : [0.1, 0.35],
-  "comboCooldown" : 0.25,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/thunderpunch.combofinisher",
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.15,
+	
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.35],
+	"comboCooldown" : 0.25,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/thunderpunch.combofinisher",
 
-  "freezeLimit" : 2,
-  "elementalType" : "electric",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"freezeLimit" : 2,
+	"elementalType" : "electric",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.15,
-    "fireTime" : 0.2,
-    "baseDps" : 13.0,
-    "damageConfig" : {
-      "statusEffects" : [ ],
-      "damageSourceKind" : "electric",
-      "knockback" : [0, 10],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.11
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.15,
+		"fireTime" : 0.2,
+		"baseDps" : 13.0,
+		"damageConfig" : {
+			"statusEffects" : [ ],
+			"damageSourceKind" : "electric",
+			"knockback" : [0, 10],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.11
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 4,
-  "critBonus" : 6, 
-  "fistBonus" : 2,
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 4,
+	"critBonus" : 6, 
+	"fistBonus" : 2,
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/fupowerglove.activeitem
+++ b/items/active/weapons/fist/fupowerglove.activeitem
@@ -1,112 +1,112 @@
 {
-  "itemName" : "fupowerglove",
-  "price" : 4000,
-  "level" : 4,
-  "maxStack" : 1,
-  "rarity" : "Legendary",
-  "description" : "All the tech since 1989 still couldn't save this travesty.",
-  "shortdescription" : "Power Glove",
-  "tooltipKind" : "fist2",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon"],
-  "inventoryIcon" : "powerglove.png:front",
-  "animation" : "fistweapon.animation",
-  "animationParts" : {
-    "weapon" : "powerglove.png",
-    "swoosh" : "swoosh/powerpunchswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "fupowerglove",
+	"price" : 4000,
+	"level" : 4,
+	"maxStack" : 1,
+	"rarity" : "Legendary",
+	"description" : "All the tech since 1989 still couldn't save this travesty.",
+	"shortdescription" : "Power Glove",
+	"tooltipKind" : "fist2",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon"],
+	"inventoryIcon" : "powerglove.png:front",
+	"animation" : "fistweapon.animation",
+	"animationParts" : {
+		"weapon" : "powerglove.png",
+		"swoosh" : "swoosh/powerpunchswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 7,
-  "comboTiming" : [0.2, 0.5],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/sonicslash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.2, 0.5],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/sonicslash.combofinisher",
 
-  "freezeLimit" : 2,
-  "elementalType" : "cosmic",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"freezeLimit" : 2,
+	"elementalType" : "cosmic",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.15,
-    "fireTime" : 0.15,
-    "baseDps" : 12.25,
-    "damageConfig" : {
-      "statusEffects" : [ ],
-      "damageSourceKind" : "cosmic",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.15,
+		"fireTime" : 0.15,
+		"baseDps" : 12.25,
+		"damageConfig" : {
+			"statusEffects" : [ ],
+			"damageSourceKind" : "cosmic",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 3,
-  "critBonus" : 4, 
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 3,
+	"critBonus" : 4, 
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/hellclaw.activeitem
+++ b/items/active/weapons/fist/hellclaw.activeitem
@@ -1,114 +1,114 @@
 {
-  "itemName" : "fuhellclaw",
-  "price" : 200,
-  "level" : 2,
-  "maxStack" : 1,
-  "rarity" : "uncommon",
-  "description" : "Flaming claws? Yes please. Just... don't burn your hands.
+	"itemName" : "fuhellclaw",
+	"price" : 200,
+	"level" : 2,
+	"maxStack" : 1,
+	"rarity" : "uncommon",
+	"description" : "Flaming claws? Yes please. Just... don't burn your hands.
 ^cyan;Inflicts Burning^reset;",
-  "shortdescription" : "Hellion Claw",
-  "tooltipKind" : "fist2",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon"],
-  "inventoryIcon" : "hellclaw.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "hellclaw.png",
-    "weaponfullbright" : "hellclawfullbright.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"shortdescription" : "Hellion Claw",
+	"tooltipKind" : "fist2",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon"],
+	"inventoryIcon" : "hellclaw.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "hellclaw.png",
+		"weaponfullbright" : "hellclawfullbright.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 6,
-  "comboTiming" : [0.2, 0.6],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/megadashslash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.2, 0.6],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/megadashslash.combofinisher",
 
-  "freezeLimit" : 2,
-  "elementalType" : "hellfire",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"freezeLimit" : 2,
+	"elementalType" : "hellfire",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.15,
-    "fireTime" : 0.2,
-    "baseDps" : 6.0,
-    "damageConfig" : {
-      "damageSourceKind" : "hellfire",
-      "statusEffects" : [ "burning" ],
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.15,
+		"fireTime" : 0.2,
+		"baseDps" : 6.0,
+		"damageConfig" : {
+			"damageSourceKind" : "hellfire",
+			"statusEffects" : [ "burning" ],
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 3,
-  "critBonus" : 4, 
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 3,
+	"critBonus" : 4, 
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/monsterclaw.activeitem
+++ b/items/active/weapons/fist/monsterclaw.activeitem
@@ -1,115 +1,115 @@
 {
-  "itemName" : "fumonsterclaw",
-  "price" : 200,
-  "level" : 5,
-  "maxStack" : 1,
-  "rarity" : "uncommon",
-  "description" : "Are these... severed monster hands? AWESOME!
+	"itemName" : "fumonsterclaw",
+	"price" : 200,
+	"level" : 5,
+	"maxStack" : 1,
+	"rarity" : "uncommon",
+	"description" : "Are these... severed monster hands? AWESOME!
 ^cyan;Inflicts Bleeding^reset;",
-  "shortdescription" : "Mutaclaw",
-  "tooltipKind" : "fist2",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon"],
-  //"collectablesOnPickup" : { "fu_weaponfist" : "fumonsterclaw" },
-  "inventoryIcon" : "monsterclaw.png:front",
-  "animation" : "fistweapon.animation",
-  "animationParts" : {
-    "weapon" : "monsterclaw.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"shortdescription" : "Mutaclaw",
+	"tooltipKind" : "fist2",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon"],
+	//"collectablesOnPickup" : { "fu_weaponfist" : "fumonsterclaw" },
+	"inventoryIcon" : "monsterclaw.png:front",
+	"animation" : "fistweapon.animation",
+	"animationParts" : {
+		"weapon" : "monsterclaw.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 4,
-  "comboTiming" : [0.1, 0.8],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.8],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
 
-  "freezeLimit" : 2,  
-  "elementalType" : "physical",
+	"freezeLimit" : 2,	
+	"elementalType" : "physical",
 
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.2,
-    "fireTime" : 0.2,
-    "baseDps" : 9.0,
-    "damageConfig" : {
-      "statusEffects" : [ "bleedingshort" ],
-      "damageSourceKind" : "dagger",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.2,
+		"fireTime" : 0.2,
+		"baseDps" : 9.0,
+		"damageConfig" : {
+			"statusEffects" : [ "bleedingshort" ],
+			"damageSourceKind" : "dagger",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.01,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.01,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 3,
-  "critBonus" : 4, 
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 3,
+	"critBonus" : 4, 
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/penumbritefist.activeitem
+++ b/items/active/weapons/fist/penumbritefist.activeitem
@@ -1,112 +1,112 @@
 {
-  "itemName" : "penumbritefist",
-  "price" : 300,
-  "level" : 3,
-  "maxStack" : 1,
-  "rarity" : "rare",
-  "description" : "Sharp, puncturing edge provides fun for all.",
-  "shortdescription" : "Penumbrite Thresher",
-  "tooltipKind" : "fist2",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "penumbrite", "upgradeableWeapon","silver"],
-  "inventoryIcon" : "penumbritefist.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "penumbritefist.png",
-    "weaponfullbright" : "penumbritefistfullbright.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "penumbritefist",
+	"price" : 300,
+	"level" : 3,
+	"maxStack" : 1,
+	"rarity" : "rare",
+	"description" : "Sharp, puncturing edge provides fun for all.",
+	"shortdescription" : "Penumbrite Thresher",
+	"tooltipKind" : "fist2",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "penumbrite", "upgradeableWeapon","silver"],
+	"inventoryIcon" : "penumbritefist.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "penumbritefist.png",
+		"weaponfullbright" : "penumbritefistfullbright.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 8,
-  "comboTiming" : [0.1, 0.8],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.8],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
 
-  "freezeLimit" : 1.75,
-  "elementalType" : "silverweapon",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"freezeLimit" : 1.75,
+	"elementalType" : "silverweapon",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.2,
-    "fireTime" : 0.18,
-    "baseDps" : 7.5,
-    "damageConfig" : {
-      "damageSourceKind" : "silverweapon",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.2,
+		"fireTime" : 0.18,
+		"baseDps" : 7.5,
+		"damageConfig" : {
+			"damageSourceKind" : "silverweapon",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.01,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.01,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 2,
-  "critBonus" : 6, 
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 2,
+	"critBonus" : 6, 
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/precursorfist.activeitem
+++ b/items/active/weapons/fist/precursorfist.activeitem
@@ -1,116 +1,116 @@
 {
-  "itemName" : "precursorfist",
-  "price" : 1500,
-  "level" : 5,
-  "maxStack" : 1,
-  "rarity" : "Legendary",
-  "description" : "Potent, ancient design.",
-  "shortdescription" : "Honed Lunari Cestus",
-  "tooltipKind" : "fistweapon",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon", "fist", "upgradeableWeapon", "precursor", "energy"],
+	"itemName" : "precursorfist",
+	"price" : 1500,
+	"level" : 5,
+	"maxStack" : 1,
+	"rarity" : "Legendary",
+	"description" : "Potent, ancient design.",
+	"shortdescription" : "Honed Lunari Cestus",
+	"tooltipKind" : "fistweapon",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon", "fist", "upgradeableWeapon", "precursor", "energy"],
 
-  "inventoryIcon" : "precursorfist.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "precursorfist.png",
-    "weaponfullbright" : "precursorfistfullbright.png",
-    "swoosh" : "swoosh/precursorswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { 
-      "parts" : { 
-      "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {"damageArea" : [[-3.5, -1.1], [4.5, -0.6], [4.5, 0.8], [-3.5, 1.3]]}}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"inventoryIcon" : "precursorfist.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "precursorfist.png",
+		"weaponfullbright" : "precursorfistfullbright.png",
+		"swoosh" : "swoosh/precursorswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { 
+			"parts" : { 
+			"swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {"damageArea" : [[-3.5, -1.1], [4.5, -0.6], [4.5, 0.8], [-3.5, 1.3]]}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.2,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.2,
 
-  "comboSteps" : 7,
-  "comboTiming" : [0.2, 0.65],
-  "comboCooldown" : 0.3,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/supernovarush.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.2, 0.65],
+	"comboCooldown" : 0.3,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/supernovarush.combofinisher",
 
-  "freezeLimit" : 1.4,
-  "elementalType" : "radioactive",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"freezeLimit" : 1.4,
+	"elementalType" : "radioactive",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.25,
-    "fireTime" : 0.2,
-    "baseDps" : 9.5,
-    "damageConfig" : {
-      "statusEffects" : [ "radiationburn" ],
-      "damageSourceKind" : "radioactivebroadsword",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.25,
+		"fireTime" : 0.2,
+		"baseDps" : 9.5,
+		"damageConfig" : {
+			"statusEffects" : [ "radiationburn" ],
+			"damageSourceKind" : "radioactivebroadsword",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
 
-  "critChance" : 2,
-  "critBonus" : 5, 
-//  "learnBlueprintsOnPickup" : [ "precursorfist" ],
-  "builder" : "/items/buildscripts/buildfist.lua"
+	"critChance" : 2,
+	"critBonus" : 5, 
+//	"learnBlueprintsOnPickup" : [ "precursorfist" ],
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/punch.lua
+++ b/items/active/weapons/fist/punch.lua
@@ -5,96 +5,96 @@ require "/items/active/weapons/weapon.lua"
 Punch = WeaponAbility:new()
 
 function Punch:init()
-  self.damageConfig.baseDamage = self.baseDps * self.fireTime
+	self.damageConfig.baseDamage = self.baseDps * self.fireTime
 
-  self.weapon:setStance(self.stances.idle)
+	self.weapon:setStance(self.stances.idle)
 
-  self.cooldownTimer = self:cooldownTime()
+	self.cooldownTimer = self:cooldownTime()
 
-  self.freezesLeft = self.freezeLimit
-  self.freezeTimer = 0
+	self.freezesLeft = self.freezeLimit
+	self.freezeTimer = 0
 
-  self.weapon.onLeaveAbility = function()
-    self.weapon:setStance(self.stances.idle)
-  end
+	self.weapon.onLeaveAbility = function()
+		self.weapon:setStance(self.stances.idle)
+	end
 end
 
 -- Ticks on every update regardless if this is the active ability
 function Punch:update(dt, fireMode, shiftHeld)
-  WeaponAbility.update(self, dt, fireMode, shiftHeld)
+	WeaponAbility.update(self, dt, fireMode, shiftHeld)
 
-  self.cooldownTimer = math.max(0, self.cooldownTimer - self.dt)
+	self.cooldownTimer = math.max(0, self.cooldownTimer - self.dt)
 
-  self.freezeTimer = math.max(0, self.freezeTimer - dt)
-  if self.freezeTimer > 0 and not mcontroller.onGround() and math.abs(world.gravity(mcontroller.position())) > 0 then
-    mcontroller.controlApproachVelocity({0, 0}, 1000)
-  end
+	self.freezeTimer = math.max(0, self.freezeTimer - dt)
+	if self.freezeTimer > 0 and not mcontroller.onGround() and math.abs(world.gravity(mcontroller.position())) > 0 then
+		mcontroller.controlApproachVelocity({0, 0}, 1000)
+	end
 end
 
 function Punch:canStartAttack()
-  return not self.weapon.currentAbility and self.cooldownTimer == 0
+	return not self.weapon.currentAbility and self.cooldownTimer == 0
 end
 
 -- used by fist weapon combo system
 function Punch:startAttack()
-  self:setState(self.windup)
+	self:setState(self.windup)
 
-  if self.weapon.freezesLeft > 0 then
-    self.weapon.freezesLeft = self.weapon.freezesLeft - 1
-    self.freezeTimer = self.freezeTime or 0
-  end
+	if self.weapon.freezesLeft > 0 then
+		self.weapon.freezesLeft = self.weapon.freezesLeft - 1
+		self.freezeTimer = self.freezeTime or 0
+	end
 end
 
 -- State: windup
 function Punch:windup()
-  self.weapon:setStance(self.stances.windup)
+	self.weapon:setStance(self.stances.windup)
 
-  util.wait(self.stances.windup.duration)
+	util.wait(self.stances.windup.duration)
 
-  self:setState(self.windup2)
+	self:setState(self.windup2)
 end
 
 -- State: windup2
 function Punch:windup2()
-  self.weapon:setStance(self.stances.windup2)
+	self.weapon:setStance(self.stances.windup2)
 
-  util.wait(self.stances.windup2.duration)
+	util.wait(self.stances.windup2.duration)
 
-  self:setState(self.fire)
+	self:setState(self.fire)
 end
 
 -- State: fire
 function Punch:fire()
-  self.weapon:setStance(self.stances.fire)
-  self.weapon:updateAim()
+	self.weapon:setStance(self.stances.fire)
+	self.weapon:updateAim()
 
-  animator.setAnimationState("attack", "fire")
-  animator.playSound("fire")
+	animator.setAnimationState("attack", "fire")
+	animator.playSound("fire")
 
-  status.addEphemeralEffect("invulnerable", self.stances.fire.duration + 0.05)
+	status.addEphemeralEffect("invulnerable", self.stances.fire.duration + 0.05)
 
-  util.wait(self.stances.fire.duration, function()
-    local damageArea = partDamageArea("swoosh")
+	util.wait(self.stances.fire.duration, function()
+		local damageArea = partDamageArea("swoosh")
 
-    self.weapon:setDamage(self.damageConfig, damageArea, self.fireTime)
-  end)
+		self.weapon:setDamage(self.damageConfig, damageArea, self.fireTime)
+	end)
 
-  -- ************* FU
-  -- apply bonus stun
-  self.fistBonus = config.getParameter("fistBonus",0)
-  self.stunValue = math.random(100) + self.fistBonus
-  if self.stunValue >= 90 then
-    params2 = { speed=20, power = 0 , damageKind = "default", knockback = 0 } -- Stun
-    world.spawnProjectile("shieldBashStunProjectile",mcontroller.position(),activeItem.ownerEntityId(),{0,0},false,params2)
-  end
+	-- ************* FU
+	-- apply bonus stun
+	self.fistBonus = config.getParameter("fistBonus",0)
+	self.stunValue = math.random(100) + self.fistBonus
+	if self.stunValue >= 90 then
+		params2 = { speed=20, power = 0 , damageKind = "default", knockback = 0 } -- Stun
+		world.spawnProjectile("shieldBashStunProjectile",mcontroller.position(),activeItem.ownerEntityId(),{0,0},false,params2)
+	end
 
-  self.cooldownTimer = self:cooldownTime()
+	self.cooldownTimer = self:cooldownTime()
 end
 
 function Punch:cooldownTime()
-  return self.fireTime - self.stances.windup.duration - self.stances.fire.duration
+	return self.fireTime - self.stances.windup.duration - self.stances.fire.duration
 end
 
 function Punch:uninit(unloaded)
-  self.weapon:setDamage()
+	self.weapon:setDamage()
 end

--- a/items/active/weapons/fist/solariumfist.activeitem
+++ b/items/active/weapons/fist/solariumfist.activeitem
@@ -1,112 +1,112 @@
 {
-  "itemName" : "solariumfist",
-  "price" : 1200,
-  "level" : 6,
-  "maxStack" : 1,
-  "rarity" : "legendary",
-  "description" : "Really unhealthily radioactive.",
-  "shortdescription" : "Solarium Cestus",
-  "tooltipKind" : "fist2",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon","solarium","crystal"],
-  "inventoryIcon" : "solariumfist.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "solariumfist.png",
-    "weaponfullbright" : "solariumfistfullbright.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "solariumfist",
+	"price" : 1200,
+	"level" : 6,
+	"maxStack" : 1,
+	"rarity" : "legendary",
+	"description" : "Really unhealthily radioactive.",
+	"shortdescription" : "Solarium Cestus",
+	"tooltipKind" : "fist2",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon","solarium","crystal"],
+	"inventoryIcon" : "solariumfist.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "solariumfist.png",
+		"weaponfullbright" : "solariumfistfullbright.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 8,
-  "comboTiming" : [0.1, 0.8],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.8],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
 
-  "freezeLimit" : 1.75,
-  "elementalType" : "radioactive",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"freezeLimit" : 1.75,
+	"elementalType" : "radioactive",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.2,
-    "fireTime" : 0.18,
-    "baseDps" : 8.5,
-    "damageConfig" : {
-      "damageSourceKind" : "radioactive",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.2,
+		"fireTime" : 0.18,
+		"baseDps" : 8.5,
+		"damageConfig" : {
+			"damageSourceKind" : "radioactive",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.01,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.01,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 4,
-  "critBonus" : 3, 
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 4,
+	"critBonus" : 3, 
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/stabfists.activeitem
+++ b/items/active/weapons/fist/stabfists.activeitem
@@ -1,114 +1,114 @@
 {
-  "itemName" : "stabfists",
-  "price" : 20,
-  "level" : 1,
-  "maxStack" : 1,
-  "rarity" : "common",
-  "description" : "Strap these blades to your hands. Fun ensues.",
-  "shortdescription" : "Iron Fists",
-  "tooltipKind" : "fistweapon",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon"],
-  //"collectablesOnPickup" : { "fu_weaponfist" : "stabfists" },
-  "inventoryIcon" : "stabfists.png:front",
-  "animation" : "fistweapon.animation",
-  "animationParts" : {
-    "weapon" : "stabfists.png",
-    "swoosh" : "swoosh/slash.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "stabfists",
+	"price" : 20,
+	"level" : 1,
+	"maxStack" : 1,
+	"rarity" : "common",
+	"description" : "Strap these blades to your hands. Fun ensues.",
+	"shortdescription" : "Iron Fists",
+	"tooltipKind" : "fistweapon",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon"],
+	//"collectablesOnPickup" : { "fu_weaponfist" : "stabfists" },
+	"inventoryIcon" : "stabfists.png:front",
+	"animation" : "fistweapon.animation",
+	"animationParts" : {
+		"weapon" : "stabfists.png",
+		"swoosh" : "swoosh/slash.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 4,
-  "comboTiming" : [0.1, 0.45],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/megauppercut.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.45],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/megauppercut.combofinisher",
 
-  "freezeLimit" : 2,  
-  "elementalType" : "physical",
+	"freezeLimit" : 2,	
+	"elementalType" : "physical",
 
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.12,
-    "fireTime" : 0.2,
-    "baseDps" : 7,
-    "damageConfig" : {
-      "statusEffects" : [ ],
-      "damageSourceKind" : "dagger",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.12,
+		"fireTime" : 0.2,
+		"baseDps" : 7,
+		"damageConfig" : {
+			"statusEffects" : [ ],
+			"damageSourceKind" : "dagger",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 3,
-  "critBonus" : 4, 
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 3,
+	"critBonus" : 4, 
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/telebriumfist.activeitem
+++ b/items/active/weapons/fist/telebriumfist.activeitem
@@ -1,112 +1,112 @@
 {
-  "itemName" : "telebriumfist",
-  "price" : 200,
-  "level" : 2,
-  "maxStack" : 1,
-  "rarity" : "common",
-  "description" : "Refined for light and deadly punches.",
-  "shortdescription" : "Telebrium Cestus",
-  "tooltipKind" : "fist2",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon","telebrium"],
-  "inventoryIcon" : "telebriumfist.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "telebriumfist.png",
-    "weaponfullbright" : "telebriumfistfullbright.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "telebriumfist",
+	"price" : 200,
+	"level" : 2,
+	"maxStack" : 1,
+	"rarity" : "common",
+	"description" : "Refined for light and deadly punches.",
+	"shortdescription" : "Telebrium Cestus",
+	"tooltipKind" : "fist2",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon","telebrium"],
+	"inventoryIcon" : "telebriumfist.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "telebriumfist.png",
+		"weaponfullbright" : "telebriumfistfullbright.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 4,
-  "comboTiming" : [0.1, 0.8],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.8],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
 
-  "freezeLimit" : 2,
-  "elementalType" : "poison",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"freezeLimit" : 2,
+	"elementalType" : "poison",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.2,
-    "fireTime" : 0.18,
-    "baseDps" : 8.5,
-    "damageConfig" : {
-      "damageSourceKind" : "poison",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.2,
+		"fireTime" : 0.18,
+		"baseDps" : 8.5,
+		"damageConfig" : {
+			"damageSourceKind" : "poison",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.01,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.01,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 3,
-  "critBonus" : 4, 
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 3,
+	"critBonus" : 4, 
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/veluuclaws.activeitem
+++ b/items/active/weapons/fist/veluuclaws.activeitem
@@ -1,114 +1,114 @@
 {
-  "itemName" : "veluuclaws",
-  "price" : 20,
-  "level" : 2,
-  "maxStack" : 1,
-  "rarity" : "common",
-  "description" : "A wonderfully sharp fist weapon.",
-  "shortdescription" : "Vel'uuish Claw",
-  "tooltipKind" : "fistweapon",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon","veluu"],
-  "inventoryIcon" : "veluuclaws.png:front",
-  "animation" : "fistweapon.animation",
-  "animationParts" : {
-    "weapon" : "veluuclaws.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "veluuclaws",
+	"price" : 20,
+	"level" : 2,
+	"maxStack" : 1,
+	"rarity" : "common",
+	"description" : "A wonderfully sharp fist weapon.",
+	"shortdescription" : "Vel'uuish Claw",
+	"tooltipKind" : "fistweapon",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon","veluu"],
+	"inventoryIcon" : "veluuclaws.png:front",
+	"animation" : "fistweapon.animation",
+	"animationParts" : {
+		"weapon" : "veluuclaws.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 4,
-  "comboTiming" : [0.1, 0.5],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/backdash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.5],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/backdash.combofinisher",
 
-  "freezeLimit" : 2,  
-  "elementalType" : "physical",
+	"freezeLimit" : 2,	
+	"elementalType" : "physical",
 
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.13,
-    "fireTime" : 0.22,
-    "baseDps" : 8.0,
-    "damageConfig" : {
-      "statusEffects" : [ ],
-      "damageSourceKind" : "dagger",
-      "knockback" : [0, 12],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.13,
+		"fireTime" : 0.22,
+		"baseDps" : 8.0,
+		"damageConfig" : {
+			"statusEffects" : [ ],
+			"damageSourceKind" : "dagger",
+			"knockback" : [0, 12],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.1,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.1,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 2,
-  "critBonus" : 2, 
-  "fistBonus" : 3,
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 2,
+	"critBonus" : 2, 
+	"fistBonus" : 3,
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/xithricitefist.activeitem
+++ b/items/active/weapons/fist/xithricitefist.activeitem
@@ -1,113 +1,113 @@
 {
-  "itemName" : "xithricitefist",
-  "price" : 700,
-  "level" : 6,
-  "maxStack" : 1,
-  "rarity" : "legendary",
-  "description" : "Great for punchification.",
-  "shortdescription" : "Xithricite Cestus",
-  "tooltipKind" : "fist2",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "xithricite", "upgradeableWeapon"],
-  "inventoryIcon" : "xithricitefist.png:front",
-  "animation" : "fistweaponglow.animation",
-  "animationParts" : {
-    "weapon" : "xithricitefist.png",
-    "weaponfullbright" : "xithricitefistfullbright.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "xithricitefist",
+	"price" : 700,
+	"level" : 6,
+	"maxStack" : 1,
+	"rarity" : "legendary",
+	"description" : "Great for punchification.",
+	"shortdescription" : "Xithricite Cestus",
+	"tooltipKind" : "fist2",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "xithricite", "upgradeableWeapon"],
+	"inventoryIcon" : "xithricitefist.png:front",
+	"animation" : "fistweaponglow.animation",
+	"animationParts" : {
+		"weapon" : "xithricitefist.png",
+		"weaponfullbright" : "xithricitefistfullbright.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 8,
-  "comboTiming" : [0.1, 0.8],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.8],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/dashslash.combofinisher",
 
-  "freezeLimit" : 1.75,
-  "elementalType" : "cosmic",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"freezeLimit" : 1.75,
+	"elementalType" : "cosmic",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.2,
-    "fireTime" : 0.18,
-    "baseDps" : 8.5,
-    "damageConfig" : {
-      "damageSourceKind" : "cosmic",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "statusEffects" : [ "defenseboostneg20" ],
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.2,
+		"fireTime" : 0.18,
+		"baseDps" : 8.5,
+		"damageConfig" : {
+			"damageSourceKind" : "cosmic",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"statusEffects" : [ "defenseboostneg20" ],
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.01,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.01,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 4,
-  "critBonus" : 3, 
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 4,
+	"critBonus" : 3, 
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/fist/zerchesiumfist.activeitem
+++ b/items/active/weapons/fist/zerchesiumfist.activeitem
@@ -1,111 +1,111 @@
 {
-  "itemName" : "zerchesiumfist",
-  "price" : 500,
-  "level" : 3,
-  "maxStack" : 1,
-  "rarity" : "uncommon",
-  "description" : "Chillingly effective. Freeze'em dead.",
-  "shortdescription" : "Zerchesium Fistblade",
-  "tooltipKind" : "fist2",
-  "category" : "fistWeapon",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","fist", "upgradeableWeapon","zerchesium"],
-  "inventoryIcon" : "zerchesiumfist.png:front",
-  "animation" : "fistweapon.animation",
-  "animationParts" : {
-    "weapon" : "zerchesiumfist.png",
-    "swoosh" : "swoosh/clawswoosh.png"
-  },
-  "animationCustom" : {
-    "animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
-      "damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
-    }}}}}}},
-    "sounds" : {
-      "fire" : [ "/sfx/melee/swing_dagger.ogg" ]
-    }
-  },
-  "scripts" : [ "fistweapon.lua" ],
+	"itemName" : "zerchesiumfist",
+	"price" : 500,
+	"level" : 3,
+	"maxStack" : 1,
+	"rarity" : "uncommon",
+	"description" : "Chillingly effective. Freeze'em dead.",
+	"shortdescription" : "Zerchesium Fistblade",
+	"tooltipKind" : "fist2",
+	"category" : "fistWeapon",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","fist", "upgradeableWeapon","zerchesium"],
+	"inventoryIcon" : "zerchesiumfist.png:front",
+	"animation" : "fistweapon.animation",
+	"animationParts" : {
+		"weapon" : "zerchesiumfist.png",
+		"swoosh" : "swoosh/clawswoosh.png"
+	},
+	"animationCustom" : {
+		"animatedParts" : { "parts" : { "swoosh" : { "partStates" : { "attack" : { "fire" : { "properties" : {
+			"damageArea" : [[-1, -1.1], [2.1, -0.6], [2.1, 0.8], [-1, 1.3]]
+		}}}}}}},
+		"sounds" : {
+			"fire" : [ "/sfx/melee/swing_dagger.ogg" ]
+		}
+	},
+	"scripts" : [ "fistweapon.lua" ],
 
-  "needsEdgeTrigger" : true,
-  "edgeTriggerGrace" : 0.1,
+	"needsEdgeTrigger" : true,
+	"edgeTriggerGrace" : 0.1,
 
-  "comboSteps" : 4,
-  "comboTiming" : [0.1, 0.8],
-  "comboCooldown" : 0.2,
-  "comboFinisherSource" : "/items/active/weapons/fist/combofinishers/zerchslash.combofinisher",
+	"comboSteps" : 3,
+	"comboTiming" : [0.1, 0.8],
+	"comboCooldown" : 0.2,
+	"comboFinisherSource" : "/items/active/weapons/fist/combofinishers/zerchslash.combofinisher",
 
-  "freezeLimit" : 2,
-  "elementalType" : "ice",
-  "primaryAbility" : {
-    "scripts" : ["/items/active/weapons/fist/punch.lua"],
-    "class" : "Punch",
+	"freezeLimit" : 2,
+	"elementalType" : "ice",
+	"primaryAbility" : {
+		"scripts" : ["/items/active/weapons/fist/punch.lua"],
+		"class" : "Punch",
 
-    "freezeTime" : 0.2,
-    "fireTime" : 0.18,
-    "baseDps" : 8.5,
-    "damageConfig" : {
-      "damageSourceKind" : "ice",
-      "knockback" : [0, 15],
-      "timeoutGroup" : "primary",
-      "timeout" : 0.1
-    },
-    "stances" : {
-      "idle" : {
-        "armRotation" : 0,
-        "weaponRotation" : 45,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.25, -0.575],
+		"freezeTime" : 0.2,
+		"fireTime" : 0.18,
+		"baseDps" : 8.5,
+		"damageConfig" : {
+			"damageSourceKind" : "ice",
+			"knockback" : [0, 15],
+			"timeoutGroup" : "primary",
+			"timeout" : 0.1
+		},
+		"stances" : {
+			"idle" : {
+				"armRotation" : 0,
+				"weaponRotation" : 45,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.25, -0.575],
 
-        "allowRotate" : true,
-        "allowFlip" : true,
+				"allowRotate" : true,
+				"allowFlip" : true,
 
-        "frontArmFrame" : "run.2",
-        "backArmFrame" : "jump.3"
-      },
-      "windup" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.625, -0.125],
+				"frontArmFrame" : "run.2",
+				"backArmFrame" : "jump.3"
+			},
+			"windup" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.625, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1"
-      },
-      "windup2" : {
-        "duration" : 0.05,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [-0.75, -0.125],
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1"
+			},
+			"windup2" : {
+				"duration" : 0.05,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [-0.75, -0.125],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "swimIdle.1",
-        "backArmFrame" : "swim.1",
+				"frontArmFrame" : "swimIdle.1",
+				"backArmFrame" : "swim.1",
 
-        "recoil" : true
-      },
-      "fire" : {
-        "duration" : 0.01,
-        "armRotation" : 0,
-        "weaponRotation" : 0,
-        "weaponRotationCenter" : [-1.0, 0.0],
-        "weaponOffset" : [0.125, -0.25],
+				"recoil" : true
+			},
+			"fire" : {
+				"duration" : 0.01,
+				"armRotation" : 0,
+				"weaponRotation" : 0,
+				"weaponRotationCenter" : [-1.0, 0.0],
+				"weaponOffset" : [0.125, -0.25],
 
-        "allowRotate" : true,
-        "allowFlip" : false,
+				"allowRotate" : true,
+				"allowFlip" : false,
 
-        "frontArmFrame" : "rotation",
-        "backArmFrame" : "rotation"
-      }
-    }
-  },
-  "critChance" : 3,
-  "critBonus" : 4, 
-  "builder" : "/items/buildscripts/buildfist.lua"
+				"frontArmFrame" : "rotation",
+				"backArmFrame" : "rotation"
+			}
+		}
+	},
+	"critChance" : 3,
+	"critBonus" : 4, 
+	"builder" : "/items/buildscripts/buildfist.lua"
 }

--- a/items/active/weapons/melee/dagger/silverseablade.activeitem
+++ b/items/active/weapons/melee/dagger/silverseablade.activeitem
@@ -1,47 +1,46 @@
 {
-  "itemName" : "silverseablade",
-  "price" : 440,
-  "maxStack" : 1,
-  "rarity" : "uncommon",
-  "description" : "Able to damage all elements equally.",
-  "shortdescription" : "Silver Sea Blade",
-  "tooltipKind" : "sword2",
-  "category" : "dagger",
-  "twoHanded" : false,
-  "itemTags" : ["weapon","melee","dagger", "upgradeableWeapon"],
-  "level" : 2,
-  "inventoryIcon" : "silverseablade.png",
-  //"collectablesOnPickup" : { "fu_weapondagger" : "silverseablade" },
-  "animation" : "daggercombo.animation",
-  "animationParts" : {
-    "handle" : "",
-    "blade" : "silverseablade.png"
-  },
+	"itemName" : "silverseablade",
+	"price" : 440,
+	"maxStack" : 1,
+	"rarity" : "uncommon",
+	"description" : "Able to damage all elements equally.",
+	"shortdescription" : "Silver Sea Blade",
+	"tooltipKind" : "sword2",
+	"category" : "dagger",
+	"twoHanded" : false,
+	"itemTags" : ["weapon","melee","dagger", "upgradeableWeapon"],
+	"level" : 2,
+	"inventoryIcon" : "silverseablade.png",
+	//"collectablesOnPickup" : { "fu_weapondagger" : "silverseablade" },
+	"animation" : "daggercombo.animation",
+	"animationParts" : {
+		"handle" : "",
+		"blade" : "silverseablade.png"
+	},
 
-  "animationCustom" : {
-    "animatedParts" : { 
-      "parts" : { 
-        "blade" : { "properties" : {"offset" : [0.4, 2.2]}},
-        "swoosh" : { "properties" : {"offset" : [1, 2]}}      
-      }
-    }
-  },
+	"animationCustom" : {
+		"animatedParts" : { 
+			"parts" : { 
+				"blade" : { "properties" : {"offset" : [0.4, 2.2]}},
+				"swoosh" : { "properties" : {"offset" : [1, 2]}}			
+			}
+		}
+	},
 
-  "scripts" : ["/items/active/weapons/melee/meleeweapon.lua"],
+	"scripts" : ["/items/active/weapons/melee/meleeweapon.lua"],
 
-  "elementalType" : "silverweapon",
+	"elementalType" : "silverweapon",
 
-  "aimOffset" : -1.0,
-  "primaryAbilityType" : "daggercombo",
-  "primaryAbility" : {
-    "fireTime" : 0.4,
-    "baseDps" : 9,
-    "damageConfig" : {
-      "knockback" : 10
-    }
-  },
-  "critChance" : 1, 
-  "critBonus" : 4,
-  "stunChance" : 50,
-  "builder" : "/items/buildscripts/buildunrandweapon.lua"
+	"aimOffset" : -1.0,
+	"primaryAbilityType" : "daggercombo",
+	"primaryAbility" : {
+		"fireTime" : 0.4,
+		"baseDps" : 9,
+		"damageKindImage" : "/interface/elements/silverweapon.png",
+		"damageConfig" : { "damageSourceKind" : "silverweapon","knockback" : 10 }
+	},
+	"critChance" : 1, 
+	"critBonus" : 4,
+	"stunChance" : 50,
+	"builder" : "/items/buildscripts/buildunrandweapon.lua"
 }


### PR DESCRIPTION
fixed silverseablade not doing the intended silverweapon damage

fist weapon minor rework:
'sonic slash' combo ability now will break shields if you hit with the fist weapon (not the projectile)
revised fist weapons to have 3 step combos like vanilla
fist weapons now support broadsword-esque hold to attack styling, costing 1% energy per swing. this resets combo count.
fist weapon combos require a bit more finesse, requiring a bit of a delay between strikes or they will default to the above case. combos still require you to attack within a certain time to progress. 