### PR TITLE
aisle check

### DIFF
--- a/items/active/weapons/crits.lua
+++ b/items/active/weapons/crits.lua
@@ -1,5 +1,32 @@
 Crits = {}
 
+--[[
+placing this in lua demo: 
+	local passR1=0
+	local passR2=0
+	local sampleSize=1000000
+	local comparisonValue=99
+
+	for i=1,sampleSize do
+		rand=math.random(100)--y=math.random(x): 1<=y<=100
+		if(rand)>=comparisonValue then
+			passR1=passR1+1
+		end
+		if(rand)>comparisonValue then
+			passR2=passR2+1
+		end
+	end
+
+	print("Pass R1 ",passR1*(100/sampleSize)," Pass R2 ",passR2*(100/sampleSize))
+
+--results in an output like this:
+
+	Pass R1 	2.0105	 Pass R2 	0.9941
+--translated, this output means that when attempting to get a roll out of 100, the average roll will be these.
+--in other words, math.random(100)>=99 means 2% chance, not 1%.
+--changing the comparison from >= to > thus results in reducing the 'success' chance over an average of 1 million samples by ~1.0.
+]]
+
 function Crits:setCritDamage(damage)
     local critChance = config.getParameter("critChance", 1) + status.stat("critChance")  -- Integer % chance to activate crit
     local critBonus = config.getParameter("critBonus", 0) + status.stat("critBonus")     --  flat damage bonus to critical hits
@@ -11,12 +38,12 @@ function Crits:setCritDamage(damage)
         critChance = critChance + 1
     end
 
-	local crit = math.random(100) <= critChance -- Chance out of 100
-
+	local crit = (math.random(100)<=critChance) -- Chance out of 100
     -- Crit damage bonus is 50% + critDamage%
 	damage = crit and (damage * (1.5 + critDamage) + critBonus) or damage -- Inherent 50% damage boost further increased by critBonus
 
 	if crit then
+		--sb.logInfo("sum.critChance:%s, config.critChance:%s stat.critChance:%s",config.getParameter("critChance", 1)+status.stat("critChance"),config.getParameter("critChance", 1),status.stat("critChance"))
         if heldItem then
             -- exclude mining lasers
             if not root.itemHasTag(heldItem, "mininggun") or root.itemHasTag(heldItem, "bugnet") then
@@ -30,27 +57,28 @@ function Crits:setCritDamage(damage)
                 -- *****************************************************************
                 --	weapon specific crit abilities!
                 -- *****************************************************************
-                local stunChance = math.random(100) + status.stat("stunChance") + config.getParameter("stunChance",0)
-                local daggerChance = math.random(100) + status.stat("daggerChance") + config.getParameter("daggerChance",0)
-
-                if stunChance >= 95 and root.itemHasTag(heldItem, "dagger") then
+                local stunRoll = (math.random(100)) + status.stat("stunChance") + config.getParameter("stunChance",0)
+                --local daggerChance = math.random(100) + status.stat("daggerChance") + config.getParameter("daggerChance",0)--unused
+				
+                if stunRoll > 95 and root.itemHasTag(heldItem, "dagger") then
                     params = { speed=14, power = 1, damageKind = "default"}
                     world.spawnProjectile("daggerCrit",mcontroller.position(),activeItem.ownerEntityId(),Crits.aimVectorSpecial(self),true,params)
                 end
-                if stunChance >= 99 and root.itemHasTag(heldItem, "spear") then
+                if stunRoll > 99 and root.itemHasTag(heldItem, "spear") then
                     params = { speed=55, power = 1, damageKind = "default"}
                     world.spawnProjectile("spearCrit",mcontroller.position(),activeItem.ownerEntityId(),Crits.aimVectorSpecial(self),false,params)
                 end
-                if stunChance >= 99 and root.itemHasTag(heldItem, "shortspear") then
+                if stunRoll > 99 and root.itemHasTag(heldItem, "shortspear") then
                     params = { speed=22, power = 1, damageKind = "default"}
                     world.spawnProjectile("spearCrit",mcontroller.position(),activeItem.ownerEntityId(),Crits.aimVectorSpecial(self),false,params)
                 end
-                if stunChance >= 99 and root.itemHasTag(heldItem, "rapier") or root.itemHasTag(heldItem, "shortsword") then
+                if stunRoll > 99 and root.itemHasTag(heldItem, "rapier") or root.itemHasTag(heldItem, "shortsword") then
                     params = { speed=30, power = 1, damageKind = "default"}
                     world.spawnProjectile("rapierCrit",mcontroller.position(),activeItem.ownerEntityId(),Crits.aimVectorSpecial(self),false,params)
                 end
-                if stunChance >= 99 and (root.itemHasTag(heldItem, "hammer") or root.itemHasTag(heldItem, "greataxe") or root.itemHasTag(heldItem, "quarterstaff") or root.itemHasTag(heldItem, "mace")) then -- Stun!!!!
-                    params = { speed=35, power = 1, damageKind = "default"}
+                if stunRoll > 99 and (root.itemHasTag(heldItem, "fist") or root.itemHasTag(heldItem, "hammer") or root.itemHasTag(heldItem, "greataxe") or root.itemHasTag(heldItem, "quarterstaff") or root.itemHasTag(heldItem, "mace")) then -- Stun!!!!
+                    --sb.logInfo("sum.stunRoll:%s, random.stunRoll:%s, stat.stunChance:%s, config.stunChance:%s",stunRoll,stunRoll-(status.stat("stunChance") + config.getParameter("stunChance",0)),status.stat("stunChance"),config.getParameter("stunChance",0))
+					params = { speed=35, power = 1, damageKind = "default"}
                     world.spawnProjectile("shieldBashStunProjectile",mcontroller.position(),activeItem.ownerEntityId(),Crits.aimVectorSpecial(self),false,params)
                 end
             end

--- a/items/active/weapons/fist/fistweapon.lua
+++ b/items/active/weapons/fist/fistweapon.lua
@@ -57,7 +57,7 @@ function update(dt, fireMode, shiftHeld)
 
 	self.edgeTriggerTimer = math.max(0, self.edgeTriggerTimer - dt)
 	if self.lastFireMode ~= "primary" and fireMode == "primary" then
-			self.edgeTriggerTimer = self.edgeTriggerGrace
+		self.edgeTriggerTimer = self.edgeTriggerGrace
 	end
 	self.lastFireMode = fireMode
 
@@ -84,28 +84,44 @@ function update(dt, fireMode, shiftHeld)
 				--*************************************
 
 				if self.comboTimer >= self.comboTiming[1] then
-					if self.comboStep % 2 == 0 then
+					if shiftHeld then
 						if self.primaryAbility:canStartAttack() then
-							if self.comboStep == self.comboSteps then
-								-- sb.logInfo("[%s] %s fist starting a combo finisher", os.clock(), activeItem.hand())
-								self.comboFinisher:startAttack()
-							else
-								self.primaryAbility:startAttack()
-								-- sb.logInfo("[%s] %s fist continued the combo", os.clock(), activeItem.hand())
-								advanceFistCombo()
-							end
+							self.comboFinisher:startAttack()
+							resetFistCombo()
 						end
-					elseif activeItem.callOtherHandScript("triggerComboAttack", self.comboStep) then
-						-- sb.logInfo("[%s] %s fist triggered opposing attack", os.clock(), activeItem.hand())
-						advanceFistCombo()
+					else
+						if self.comboStep % 2 == 0 then
+							if self.primaryAbility:canStartAttack() then
+								if self.comboStep == self.comboSteps then
+									-- sb.logInfo("[%s] %s fist starting a combo finisher", os.clock(), activeItem.hand())
+									--self.comboFinisher:startAttack()
+									self.primaryAbility:startAttack()
+									resetFistCombo()
+								else
+									self.primaryAbility:startAttack()
+									-- sb.logInfo("[%s] %s fist continued the combo", os.clock(), activeItem.hand())
+									advanceFistCombo()
+								end
+							end
+						elseif activeItem.callOtherHandScript("triggerComboAttack", self.comboStep) then
+							-- sb.logInfo("[%s] %s fist triggered opposing attack", os.clock(), activeItem.hand())
+							advanceFistCombo()
+						end
 					end
 				end
 			else
 				if self.primaryAbility:canStartAttack() then
-					self.primaryAbility:startAttack()
-					if activeItem.callOtherHandScript("resetFistCombo") then
-						-- sb.logInfo("[%s] %s fist started a combo", os.clock(), activeItem.hand())
-						advanceFistCombo()
+					if shiftHeld then
+						if self.primaryAbility:canStartAttack() then
+							resetFistCombo()
+							self.comboFinisher:startAttack()
+						end
+					else
+						self.primaryAbility:startAttack()
+						if activeItem.callOtherHandScript("resetFistCombo") then
+							-- sb.logInfo("[%s] %s fist started a combo", os.clock(), activeItem.hand())
+							advanceFistCombo()
+						end
 					end
 				end
 			end
@@ -113,12 +129,9 @@ function update(dt, fireMode, shiftHeld)
 			--non-combo hits reset the chain and cost energy. allows attack spam.
 			if self.primaryAbility:canStartAttack() then
 				if status.overConsumeResource("energy",status.resourceMax("energy")*0.01) then
-					self.comboStep=0
+					resetFistCombo()
+					activeItem.callOtherHandScript("resetFistCombo")
 					self.primaryAbility:startAttack()
-					if activeItem.callOtherHandScript("resetFistCombo") then
-						advanceFistCombo()
-					end
-					self.comboStep=0
 				end
 			end
 		end
@@ -143,7 +156,7 @@ function uninit()
 		self.helper:clearPersistent()
 	end
 	--*************************************
-
+	resetFistCombo()
 	if unloaded then
 		activeItem.callOtherHandScript("resetFistCombo")
 	end
@@ -164,7 +177,8 @@ function triggerComboAttack(comboStep)
 	if self.primaryAbility:canStartAttack() then
 		-- sb.logInfo("%s fist received combo trigger for combostep %s", activeItem.hand(), comboStep)
 		if comboStep == self.comboSteps then
-			self.comboFinisher:startAttack()
+			--self.comboFinisher:startAttack()
+			self.primaryAbility:startAttack()
 		else
 			self.primaryAbility:startAttack()
 		end
@@ -175,11 +189,16 @@ function triggerComboAttack(comboStep)
 end
 
 -- advance to the next step of the combo
-function advanceFistCombo()
+function advanceFistCombo(reset)
 	self.comboTimer = 0
 	if self.comboStep < self.comboSteps then
 		-- sb.logInfo("%s fist advancing combo from step %s to %s", activeItem.hand(), self.comboStep, self.comboStep + 1)
 		self.comboStep = self.comboStep + 1
+		world.sendEntityMessage(activeItem.ownerEntityId(),"recordFUArmorSetBonus","fistweaponcombobonus")
+		status.setPersistentEffects("fistweaponcombobonus",{
+			{stat="stunChance",amount=self.comboStep*4},
+			{stat="critChance",amount=self.comboStep*1}
+		})
 	end
 end
 
@@ -188,6 +207,7 @@ function resetFistCombo()
 	-- sb.logInfo("%s fist resetting combo from step %s to 0", activeItem.hand(), self.comboStep)
 	self.comboStep = 0
 	self.comboTimer = nil
+	status.setPersistentEffects("fistweaponcombobonus",{})
 	return true
 end
 

--- a/items/active/weapons/fist/fistweapon.lua
+++ b/items/active/weapons/fist/fistweapon.lua
@@ -45,21 +45,21 @@ function update(dt, fireMode, shiftHeld)
 	--*************************************
 
 	if mcontroller.onGround() then
-				self.weapon.freezesLeft = self.weapon.freezeLimit
+		self.weapon.freezesLeft = self.weapon.freezeLimit
 	end
 
 	if self.comboStep > 0 then
-				self.comboTimer = self.comboTimer + dt
-				if self.comboTimer > self.comboTiming[2] then
-						resetFistCombo()
-				end
+		self.comboTimer = self.comboTimer + dt
+		if self.comboTimer > self.comboTiming[2] then
+			resetFistCombo()
 		end
+	end
 
-		self.edgeTriggerTimer = math.max(0, self.edgeTriggerTimer - dt)
-		if self.lastFireMode ~= "primary" and fireMode == "primary" then
-				self.edgeTriggerTimer = self.edgeTriggerGrace
-		end
-		self.lastFireMode = fireMode
+	self.edgeTriggerTimer = math.max(0, self.edgeTriggerTimer - dt)
+	if self.lastFireMode ~= "primary" and fireMode == "primary" then
+			self.edgeTriggerTimer = self.edgeTriggerGrace
+	end
+	self.lastFireMode = fireMode
 
 	--*************************************
 	-- FR pre-combo script location
@@ -70,7 +70,7 @@ function update(dt, fireMode, shiftHeld)
 	end
 	--*************************************
 
-		if fireMode == "primary" then
+	if fireMode == "primary" then
 		if (not self.needsEdgeTrigger) or (self.edgeTriggerTimer > 0) then
 			if self.comboStep > 0 then
 
@@ -122,31 +122,30 @@ function update(dt, fireMode, shiftHeld)
 				end
 			end
 		end
-		end
+	end
 
 	--*************************************
 	-- FR post-combo script location
 	--*************************************
 	if self.helper then
 		self.state = "postcombo"
-	 		self.helper:runScripts("fist-postcombo", self, dt, fireMode, shiftHeld)	-- effect after combo
+		self.helper:runScripts("fist-postcombo", self, dt, fireMode, shiftHeld)	-- effect after combo
 	end
 	--*************************************
-
-		self.weapon:update(dt, fireMode, shiftHeld)
-		updateHand()
+	self.weapon:update(dt, fireMode, shiftHeld)
+	updateHand()
 end
 
 function uninit()
 	--*************************************
 	-- FU/FR ADDONS
-		if self.helper then
-				self.helper:clearPersistent()
+	if self.helper then
+		self.helper:clearPersistent()
 	end
 	--*************************************
 
 	if unloaded then
-				activeItem.callOtherHandScript("resetFistCombo")
+		activeItem.callOtherHandScript("resetFistCombo")
 	end
 	self.weapon:uninit()
 end
@@ -163,15 +162,15 @@ end
 -- called remotely to attempt to perform a combo-continuing attack
 function triggerComboAttack(comboStep)
 	if self.primaryAbility:canStartAttack() then
-				-- sb.logInfo("%s fist received combo trigger for combostep %s", activeItem.hand(), comboStep)
-				if comboStep == self.comboSteps then
-						self.comboFinisher:startAttack()
-				else
-						self.primaryAbility:startAttack()
-				end
-				return true
+		-- sb.logInfo("%s fist received combo trigger for combostep %s", activeItem.hand(), comboStep)
+		if comboStep == self.comboSteps then
+			self.comboFinisher:startAttack()
+		else
+			self.primaryAbility:startAttack()
+		end
+		return true
 	else
-				return false
+		return false
 	end
 end
 
@@ -179,8 +178,8 @@ end
 function advanceFistCombo()
 	self.comboTimer = 0
 	if self.comboStep < self.comboSteps then
-				-- sb.logInfo("%s fist advancing combo from step %s to %s", activeItem.hand(), self.comboStep, self.comboStep + 1)
-				self.comboStep = self.comboStep + 1
+		-- sb.logInfo("%s fist advancing combo from step %s to %s", activeItem.hand(), self.comboStep, self.comboStep + 1)
+		self.comboStep = self.comboStep + 1
 	end
 end
 

--- a/items/active/weapons/fist/fistweapon.lua
+++ b/items/active/weapons/fist/fistweapon.lua
@@ -189,7 +189,7 @@ function triggerComboAttack(comboStep)
 end
 
 -- advance to the next step of the combo
-function advanceFistCombo(reset)
+function advanceFistCombo()
 	self.comboTimer = 0
 	if self.comboStep < self.comboSteps then
 		-- sb.logInfo("%s fist advancing combo from step %s to %s", activeItem.hand(), self.comboStep, self.comboStep + 1)

--- a/items/active/weapons/weapon.lua
+++ b/items/active/weapons/weapon.lua
@@ -5,287 +5,287 @@ require "/items/active/weapons/crits.lua"
 Weapon = {}
 
 function Weapon:new(weaponConfig)
-  local newWeapon = weaponConfig or {}
-  newWeapon.damageLevelMultiplier = config.getParameter("damageLevelMultiplier", root.evalFunction("weaponDamageLevelMultiplier", config.getParameter("level", 1)))
-  newWeapon.elementalType = config.getParameter("elementalType")
-  newWeapon.muzzleOffset = config.getParameter("muzzleOffset") or {0,0}
-  newWeapon.aimOffset = config.getParameter("aimOffset") or (newWeapon.muzzleOffset[2] - 0.25) -- why is it off by 0.25? nobody knows!
-  newWeapon.abilities = {}
-  newWeapon.transformationGroups = {}
-  newWeapon.handGrip = config.getParameter("handGrip", "inside")
-  setmetatable(newWeapon, extend(self))
-  return newWeapon
+	local newWeapon = weaponConfig or {}
+	newWeapon.damageLevelMultiplier = config.getParameter("damageLevelMultiplier", root.evalFunction("weaponDamageLevelMultiplier", config.getParameter("level", 1)))
+	newWeapon.elementalType = config.getParameter("elementalType")
+	newWeapon.muzzleOffset = config.getParameter("muzzleOffset") or {0,0}
+	newWeapon.aimOffset = config.getParameter("aimOffset") or (newWeapon.muzzleOffset[2] - 0.25) -- why is it off by 0.25? nobody knows!
+	newWeapon.abilities = {}
+	newWeapon.transformationGroups = {}
+	newWeapon.handGrip = config.getParameter("handGrip", "inside")
+	setmetatable(newWeapon, extend(self))
+	return newWeapon
 end
 
 function Weapon:init()
-  self.attackTimer = 0
-  self.aimAngle = 0
-  self.aimDirection = 1
-  animator.setGlobalTag("elementalType", self.elementalType or "")
+	self.attackTimer = 0
+	self.aimAngle = 0
+	self.aimDirection = 1
+	animator.setGlobalTag("elementalType", self.elementalType or "")
 
-  for _,ability in pairs(self.abilities) do
-    ability:init()
-  end
+	for _,ability in pairs(self.abilities) do
+		ability:init()
+	end
 
 end
 
 function Weapon:update(dt, fireMode, shiftHeld)
 
-  self.attackTimer = math.max(0, self.attackTimer - dt)
+	self.attackTimer = math.max(0, self.attackTimer - dt)
 
-  for _,ability in pairs(self.abilities) do
-    ability:update(dt, fireMode, shiftHeld)
-  end
+	for _,ability in pairs(self.abilities) do
+		ability:update(dt, fireMode, shiftHeld)
+	end
 
-  if self.currentState then
-    if coroutine.status(self.stateThread) ~= "dead" then
-      local status, result = coroutine.resume(self.stateThread)
-      if not status then error(result) end
-    else
-      self.currentAbility:uninit()
-      self.currentAbility = nil
-      self.currentState = nil
-      self.stateThread = nil
-      if self.onLeaveAbility then
-        self.onLeaveAbility()
-      end
-    end
-  end
+	if self.currentState then
+		if coroutine.status(self.stateThread) ~= "dead" then
+			local status, result = coroutine.resume(self.stateThread)
+			if not status then error(result) end
+		else
+			self.currentAbility:uninit()
+			self.currentAbility = nil
+			self.currentState = nil
+			self.stateThread = nil
+			if self.onLeaveAbility then
+				self.onLeaveAbility()
+			end
+		end
+	end
 
-  if self.stance then
-    self:updateAim()
-    self.relativeArmRotation = self.relativeArmRotation + self.armAngularVelocity * dt
-    self.relativeWeaponRotation = self.relativeWeaponRotation + self.weaponAngularVelocity * dt
-  end
+	if self.stance then
+		self:updateAim()
+		self.relativeArmRotation = self.relativeArmRotation + self.armAngularVelocity * dt
+		self.relativeWeaponRotation = self.relativeWeaponRotation + self.weaponAngularVelocity * dt
+	end
 
-  if self.handGrip == "wrap" then
-    activeItem.setOutsideOfHand(self:isFrontHand())
-  elseif self.handGrip == "embed" then
-    activeItem.setOutsideOfHand(not self:isFrontHand())
-  elseif self.handGrip == "outside" then
-    activeItem.setOutsideOfHand(true)
-  elseif self.handGrip == "inside" then
-    activeItem.setOutsideOfHand(false)
-  end
+	if self.handGrip == "wrap" then
+		activeItem.setOutsideOfHand(self:isFrontHand())
+	elseif self.handGrip == "embed" then
+		activeItem.setOutsideOfHand(not self:isFrontHand())
+	elseif self.handGrip == "outside" then
+		activeItem.setOutsideOfHand(true)
+	elseif self.handGrip == "inside" then
+		activeItem.setOutsideOfHand(false)
+	end
 
-  self:clearDamageSources()
+	self:clearDamageSources()
 
 end
 
 function Weapon:uninit()
-  for _,ability in pairs(self.abilities) do
-    if ability.uninit then
-      ability:uninit(true)
-    end
-  end
+	for _,ability in pairs(self.abilities) do
+		if ability.uninit then
+			ability:uninit(true)
+		end
+	end
 end
 
 function Weapon:clearDamageSources()
-  if not self.damageWasSet and not self.damageCleared then
-    activeItem.setItemDamageSources({})
-    self.damageCleared = true
-  end
+	if not self.damageWasSet and not self.damageCleared then
+		activeItem.setItemDamageSources({})
+		self.damageCleared = true
+	end
 
-  if not self.ownerDamageWasSet and not self.ownerDamageCleared then
-    activeItem.setDamageSources({})
-    self.ownerDamageCleared = true
-  end
+	if not self.ownerDamageWasSet and not self.ownerDamageCleared then
+		activeItem.setDamageSources({})
+		self.ownerDamageCleared = true
+	end
 
-  self.damageWasSet = false
-  self.ownerDamageWasSet = false
+	self.damageWasSet = false
+	self.ownerDamageWasSet = false
 end
 
 function Weapon:setAbilityState(ability, state, ...)
-  self.currentAbility = ability
-  self.currentState = state
-  self.stateThread = coroutine.create(state)
-  local status, result = coroutine.resume(self.stateThread, ability, ...)
-  if not status then
-    error(result)
-  end
+	self.currentAbility = ability
+	self.currentState = state
+	self.stateThread = coroutine.create(state)
+	local status, result = coroutine.resume(self.stateThread, ability, ...)
+	if not status then
+		error(result)
+	end
 end
 
 function Weapon:addAbility(newAbility)
-  newAbility.weapon = self
-  table.insert(self.abilities, newAbility)
+	newAbility.weapon = self
+	table.insert(self.abilities, newAbility)
 end
 
 function Weapon:addTransformationGroup(name, offset, rotation, rotationCenter)
-  self.transformationGroups = self.transformationGroups or {}
-  table.insert(self.transformationGroups, {name = name, offset = offset, rotation = rotation, rotationCenter = rotationCenter})
+	self.transformationGroups = self.transformationGroups or {}
+	table.insert(self.transformationGroups, {name = name, offset = offset, rotation = rotation, rotationCenter = rotationCenter})
 end
 
 function Weapon:transformationChanged()
-  if compare(self.lastWeaponOffset, self.weaponOffset)
-     and compare(self.lastWeaponRotation, self.relativeWeaponRotation)
-     and compare(self.lastWeaponRotationCenter, self.relativeWeaponRotationCenter) then
-    return false
-  else
-    self.lastWeaponOffset = self.weaponOffset
-    self.lastWeaponRotation = self.relativeWeaponRotation
-    self.lastWeaponRotationCenter = self.relativeWeaponRotationCenter
-    return true
-  end
+	if compare(self.lastWeaponOffset, self.weaponOffset)
+	and compare(self.lastWeaponRotation, self.relativeWeaponRotation)
+	and compare(self.lastWeaponRotationCenter, self.relativeWeaponRotationCenter) then
+		return false
+	else
+		self.lastWeaponOffset = self.weaponOffset
+		self.lastWeaponRotation = self.relativeWeaponRotation
+		self.lastWeaponRotationCenter = self.relativeWeaponRotationCenter
+		return true
+	end
 end
 
 function Weapon:updateAim()
-  if self:transformationChanged() then
-    for _,group in pairs(self.transformationGroups) do
-      animator.resetTransformationGroup(group.name)
-      animator.translateTransformationGroup(group.name, group.offset)
-      animator.rotateTransformationGroup(group.name, group.rotation, group.rotationCenter)
-      animator.translateTransformationGroup(group.name, self.weaponOffset)
-      animator.rotateTransformationGroup(group.name, self.relativeWeaponRotation, self.relativeWeaponRotationCenter)
-    end
-  end
+	if self:transformationChanged() then
+		for _,group in pairs(self.transformationGroups) do
+			animator.resetTransformationGroup(group.name)
+			animator.translateTransformationGroup(group.name, group.offset)
+			animator.rotateTransformationGroup(group.name, group.rotation, group.rotationCenter)
+			animator.translateTransformationGroup(group.name, self.weaponOffset)
+			animator.rotateTransformationGroup(group.name, self.relativeWeaponRotation, self.relativeWeaponRotationCenter)
+		end
+	end
 
-  local aimAngle, aimDirection = activeItem.aimAngleAndDirection(self.aimOffset, activeItem.ownerAimPosition())
+	local aimAngle, aimDirection = activeItem.aimAngleAndDirection(self.aimOffset, activeItem.ownerAimPosition())
 
-  if self.stance.allowRotate then
-    self.aimAngle = aimAngle
-  elseif self.stance.aimAngle then
-    self.aimAngle = self.stance.aimAngle
-  end
+	if self.stance.allowRotate then
+		self.aimAngle = aimAngle
+	elseif self.stance.aimAngle then
+		self.aimAngle = self.stance.aimAngle
+	end
 
-  --activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation)
-  activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation, not self.stance.noAimCompensation)   -- StardustLib edit; added allowRotate parameter
+	--activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation)
+	activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation, not self.stance.noAimCompensation)	 -- StardustLib edit; added allowRotate parameter
 
-  local isPrimary = activeItem.hand() == "primary"
-  if isPrimary then
-    -- primary hand weapons should set their aim direction whenever they can be flipped,
-    -- unless paired with an alt hand that CAN'T flip, in which case they should use that
-    -- weapon's aim direction
-    if self.stance.allowFlip then
-      if activeItem.callOtherHandScript("dwDisallowFlip") then
-        local altAimDirection = activeItem.callOtherHandScript("dwAimDirection")
-        if altAimDirection then
-          self.aimDirection = altAimDirection
-        end
-      else
-        self.aimDirection = aimDirection
-      end
-    end
-  elseif self.stance.allowFlip then
-    -- alt hand weapons should be slaved to the primary whenever they can be flipped
-    local primaryAimDirection = activeItem.callOtherHandScript("dwAimDirection")
-    if primaryAimDirection then
-      self.aimDirection = primaryAimDirection
-    else
-      self.aimDirection = aimDirection
-    end
-  end
+	local isPrimary = activeItem.hand() == "primary"
+	if isPrimary then
+		-- primary hand weapons should set their aim direction whenever they can be flipped,
+		-- unless paired with an alt hand that CAN'T flip, in which case they should use that
+		-- weapon's aim direction
+		if self.stance.allowFlip then
+			if activeItem.callOtherHandScript("dwDisallowFlip") then
+				local altAimDirection = activeItem.callOtherHandScript("dwAimDirection")
+				if altAimDirection then
+					self.aimDirection = altAimDirection
+				end
+			else
+				self.aimDirection = aimDirection
+			end
+		end
+	elseif self.stance.allowFlip then
+		-- alt hand weapons should be slaved to the primary whenever they can be flipped
+		local primaryAimDirection = activeItem.callOtherHandScript("dwAimDirection")
+		if primaryAimDirection then
+			self.aimDirection = primaryAimDirection
+		else
+			self.aimDirection = aimDirection
+		end
+	end
 
-  activeItem.setFacingDirection(self.aimDirection)
+	activeItem.setFacingDirection(self.aimDirection)
 
-  activeItem.setFrontArmFrame(self.stance.frontArmFrame)
-  activeItem.setBackArmFrame(self.stance.backArmFrame)
+	activeItem.setFrontArmFrame(self.stance.frontArmFrame)
+	activeItem.setBackArmFrame(self.stance.backArmFrame)
 end
 
 function Weapon:setOwnerDamage(damageConfig, damageArea, damageTimeout)
-  self.ownerDamageWasSet = true
-  self.ownerDamageCleared = false
-  activeItem.setDamageSources({ self:damageSource(damageConfig, damageArea, damageTimeout) })
+	self.ownerDamageWasSet = true
+	self.ownerDamageCleared = false
+	activeItem.setDamageSources({ self:damageSource(damageConfig, damageArea, damageTimeout) })
 end
 
 function Weapon:setOwnerDamageAreas(damageConfig, damageAreas, damageTimeout)
-  self.ownerDamageWasSet = true
-  self.ownerDamageCleared = false
-  local damageSources = {}
-  for i, area in ipairs(damageAreas) do
-    table.insert(damageSources, self:damageSource(damageConfig, area, damageTimeout))
-  end
-  activeItem.setDamageSources(damageSources)
+	self.ownerDamageWasSet = true
+	self.ownerDamageCleared = false
+	local damageSources = {}
+	for i, area in ipairs(damageAreas) do
+		table.insert(damageSources, self:damageSource(damageConfig, area, damageTimeout))
+	end
+	activeItem.setDamageSources(damageSources)
 end
 
 function Weapon:setDamage(damageConfig, damageArea, damageTimeout)
-  self.damageWasSet = true
-  self.damageCleared = false
-  activeItem.setItemDamageSources({ self:damageSource(damageConfig, damageArea, damageTimeout) })
+	self.damageWasSet = true
+	self.damageCleared = false
+	activeItem.setItemDamageSources({ self:damageSource(damageConfig, damageArea, damageTimeout) })
 end
 
 function Weapon:setDamageAreas(damageConfig, damageAreas, damageTimeout)
-  self.damageWasSet = true
-  self.damageCleared = false
-  local damageSources = {}
-  for i, area in ipairs(damageAreas) do
-    table.insert(damageSources, self:damageSource(damageConfig, area, damageTimeout))
-  end
-  activeItem.setItemDamageSources(damageSources)
+	self.damageWasSet = true
+	self.damageCleared = false
+	local damageSources = {}
+	for i, area in ipairs(damageAreas) do
+		table.insert(damageSources, self:damageSource(damageConfig, area, damageTimeout))
+	end
+	activeItem.setItemDamageSources(damageSources)
 end
 
 function Weapon:damageSource(damageConfig, damageArea, damageTimeout)
-  if damageArea then
-    local knockback = damageConfig.knockback
-    if knockback and damageConfig.knockbackDirectional ~= false then
-      knockback = knockbackMomentum(damageConfig.knockback, damageConfig.knockbackMode, self.aimAngle, self.aimDirection)
-    end
-    local damage = damageConfig.baseDamage * self.damageLevelMultiplier * activeItem.ownerPowerMultiplier()
+	if damageArea then
+		local knockback = damageConfig.knockback
+		if knockback and damageConfig.knockbackDirectional ~= false then
+			knockback = knockbackMomentum(damageConfig.knockback, damageConfig.knockbackMode, self.aimAngle, self.aimDirection)
+		end
+		local damage = damageConfig.baseDamage * self.damageLevelMultiplier * activeItem.ownerPowerMultiplier()
 
-    local damageLine, damagePoly
-    if #damageArea == 2 then
-      damageLine = damageArea
-    else
-      damagePoly = damageArea
-    end
+		local damageLine, damagePoly
+		if #damageArea == 2 then
+			damageLine = damageArea
+		else
+			damagePoly = damageArea
+		end
 
-    return {
-      poly = damagePoly,
-      line = damageLine,
+		return {
+			poly = damagePoly,
+			line = damageLine,
 
-      -- **********************************************
-      -- FU Critical Hit script
-      -- damage = damage,
-      damage = Crits.setCritDamage(self, damage),
+			-- **********************************************
+			-- FU Critical Hit script
+			-- damage = damage,
+			damage = Crits.setCritDamage(self, damage),
 
-      -- **********************************************
+			-- **********************************************
 
-      trackSourceEntity = damageConfig.trackSourceEntity,
-      sourceEntity = activeItem.ownerEntityId(),
-      team = activeItem.ownerTeam(),
-      damageSourceKind = damageConfig.damageSourceKind,
-      statusEffects = damageConfig.statusEffects,
-      knockback = knockback or 0,
-      rayCheck = true,
-      damageRepeatGroup = damageRepeatGroup(damageConfig.timeoutGroup),
-      damageRepeatTimeout = damageTimeout or damageConfig.timeout
-    }
-  end
+			trackSourceEntity = damageConfig.trackSourceEntity,
+			sourceEntity = activeItem.ownerEntityId(),
+			team = activeItem.ownerTeam(),
+			damageSourceKind = damageConfig.damageSourceKind,
+			statusEffects = damageConfig.statusEffects,
+			knockback = knockback or 0,
+			rayCheck = true,
+			damageRepeatGroup = damageRepeatGroup(damageConfig.timeoutGroup),
+			damageRepeatTimeout = damageTimeout or damageConfig.timeout
+		}
+	end
 end
 
 function Weapon:setStance(stance)
-  stance=stance or {}
-  self.stance = stance
-  self.weaponOffset = stance.weaponOffset or {0,0}
-  self.relativeWeaponRotation = util.toRadians(stance.weaponRotation or 0)
-  self.relativeWeaponRotationCenter = stance.weaponRotationCenter or {0, 0}
-  self.relativeArmRotation = util.toRadians(stance.armRotation or 0)
-  self.armAngularVelocity = util.toRadians(stance.armAngularVelocity or 0)
-  self.weaponAngularVelocity = util.toRadians(stance.weaponAngularVelocity or 0)
+	stance=stance or {}
+	self.stance = stance
+	self.weaponOffset = stance.weaponOffset or {0,0}
+	self.relativeWeaponRotation = util.toRadians(stance.weaponRotation or 0)
+	self.relativeWeaponRotationCenter = stance.weaponRotationCenter or {0, 0}
+	self.relativeArmRotation = util.toRadians(stance.armRotation or 0)
+	self.armAngularVelocity = util.toRadians(stance.armAngularVelocity or 0)
+	self.weaponAngularVelocity = util.toRadians(stance.weaponAngularVelocity or 0)
 
-  for stateType, state in pairs(stance.animationStates or {}) do
-    animator.setAnimationState(stateType, state)
-  end
+	for stateType, state in pairs(stance.animationStates or {}) do
+		animator.setAnimationState(stateType, state)
+	end
 
-  for _, soundName in pairs(stance.playSounds or {}) do
-    animator.playSound(soundName)
-  end
+	for _, soundName in pairs(stance.playSounds or {}) do
+		animator.playSound(soundName)
+	end
 
-  for _, particleEmitterName in pairs(stance.burstParticleEmitters or {}) do
-    animator.burstParticleEmitter(particleEmitterName)
-  end
+	for _, particleEmitterName in pairs(stance.burstParticleEmitters or {}) do
+		animator.burstParticleEmitter(particleEmitterName)
+	end
 
-  activeItem.setFrontArmFrame(self.stance.frontArmFrame)
-  activeItem.setBackArmFrame(self.stance.backArmFrame)
-  activeItem.setTwoHandedGrip(stance.twoHanded or false)
-  activeItem.setRecoil(stance.recoil == true)
+	activeItem.setFrontArmFrame(self.stance.frontArmFrame)
+	activeItem.setBackArmFrame(self.stance.backArmFrame)
+	activeItem.setTwoHandedGrip(stance.twoHanded or false)
+	activeItem.setRecoil(stance.recoil == true)
 end
 
 function Weapon:isFrontHand()
-  return (activeItem.hand() == "primary") == (self.aimDirection < 0)
+	return (activeItem.hand() == "primary") == (self.aimDirection < 0)
 end
 
 function Weapon:faceVector(vector)
-  return {vector[1] * self.aimDirection, vector[2]}
+	return {vector[1] * self.aimDirection, vector[2]}
 end
 
 -- Weapon abilities, state machines for weapon functionality
@@ -293,107 +293,107 @@ end
 WeaponAbility = {}
 
 function WeaponAbility:new(abilityConfig)
-  local newAbility = abilityConfig or {}
-  newAbility.stances = newAbility.stances or {}
-  setmetatable(newAbility, extend(self))
-  return newAbility
+	local newAbility = abilityConfig or {}
+	newAbility.stances = newAbility.stances or {}
+	setmetatable(newAbility, extend(self))
+	return newAbility
 end
 
 function WeaponAbility:update(dt, fireMode, shiftHeld)
-  self.dt, self.fireMode, self.shiftHeld = dt, fireMode, shiftHeld
+	self.dt, self.fireMode, self.shiftHeld = dt, fireMode, shiftHeld
 end
 
 function WeaponAbility:setState(state, ...)
-  self.weapon:setAbilityState(self, state, ...)
+	self.weapon:setAbilityState(self, state, ...)
 end
 
 function getAbility(abilitySlot, abilityConfig)
-  for _, script in ipairs(abilityConfig.scripts) do
-    require(script)
-  end
-  local class = _ENV[abilityConfig.class]
-  abilityConfig.abilitySlot = abilitySlot
-  return class:new(abilityConfig)
+	for _, script in ipairs(abilityConfig.scripts) do
+		require(script)
+	end
+	local class = _ENV[abilityConfig.class]
+	abilityConfig.abilitySlot = abilitySlot
+	return class:new(abilityConfig)
 end
 
 function getPrimaryAbility()
-  local primaryAbilityConfig = config.getParameter("primaryAbility")
-  return getAbility("primary", primaryAbilityConfig)
+	local primaryAbilityConfig = config.getParameter("primaryAbility")
+	return getAbility("primary", primaryAbilityConfig)
 end
 
 function getAltAbility()
-  local altAbilityConfig = config.getParameter("altAbility")
-  if altAbilityConfig then
-    return getAbility("alt", altAbilityConfig)
-  end
+	local altAbilityConfig = config.getParameter("altAbility")
+	if altAbilityConfig then
+		return getAbility("alt", altAbilityConfig)
+	end
 end
 
 function partDamageArea(partName, polyName)
-  return animator.partPoly(partName, polyName or "damageArea")
+	return animator.partPoly(partName, polyName or "damageArea")
 end
 
 function damageRepeatGroup(mode)
-  mode = mode or ""
-  return activeItem.ownerEntityId() .. config.getParameter("itemName") .. activeItem.hand() .. mode
+	mode = mode or ""
+	return activeItem.ownerEntityId() .. config.getParameter("itemName") .. activeItem.hand() .. mode
 end
 
 function knockbackMomentum(knockback, knockbackMode, aimAngle, aimDirection)
-  knockbackMode = knockbackMode or "aim"
+	knockbackMode = knockbackMode or "aim"
 
-  if type(knockback) == "table" then
-    return knockback
-  end
+	if type(knockback) == "table" then
+		return knockback
+	end
 
-  if knockbackMode == "facing" then
-    return {aimDirection * knockback, 0}
-  elseif knockbackMode == "aim" then
-    local aimVector = vec2.rotate({knockback, 0}, aimAngle)
-    aimVector[1] = aimDirection * aimVector[1]
-    return aimVector
-  end
-  return knockback
+	if knockbackMode == "facing" then
+		return {aimDirection * knockback, 0}
+	elseif knockbackMode == "aim" then
+		local aimVector = vec2.rotate({knockback, 0}, aimAngle)
+		aimVector[1] = aimDirection * aimVector[1]
+		return aimVector
+	end
+	return knockback
 end
 
 -- used for cross-hand communication while dual wielding
 function dwAimDirection()
-  if self and self.weapon then
-    return self.weapon.aimDirection
-  end
+	if self and self.weapon then
+		return self.weapon.aimDirection
+	end
 end
 
 function dwDisallowFlip()
-  if self.weapon and self.weapon.stance then
-    return not self.weapon.stance.allowFlip
-  end
+	if self.weapon and self.weapon.stance then
+		return not self.weapon.stance.allowFlip
+	end
 
-  return false
+	return false
 end
 
 do -- StardustLib shim
-  local _new = Weapon.new
-  Weapon.new = function(...)
-    Weapon.new = _new
-    if root.hasTech("stardustlib:enable-extenders") then
-      require "/sys/stardust/weaponext.lua"
-    else -- use old correction if stardustlib not present
-      local follow = false
-      local armAngle = 0
-      local setArmAngle = activeItem.setArmAngle
-      function activeItem.setArmAngle(angle, f)
-        follow = not not f
-        if follow then angle = angle - mcontroller.rotation() * mcontroller.facingDirection() end
-        armAngle = angle
-        return setArmAngle(armAngle)
-      end
-      local handPosition = activeItem.handPosition
-      function activeItem.handPosition(off)
-        if not follow then return handPosition(off) end
-        setArmAngle(armAngle + mcontroller.rotation() * mcontroller.facingDirection())
-        local vec = handPosition(off)
-        setArmAngle(armAngle)
-        return vec
-      end
-    end
-    return Weapon.new(...)
-  end
+	local _new = Weapon.new
+	Weapon.new = function(...)
+		Weapon.new = _new
+		if root.hasTech("stardustlib:enable-extenders") then
+			require "/sys/stardust/weaponext.lua"
+		else -- use old correction if stardustlib not present
+			local follow = false
+			local armAngle = 0
+			local setArmAngle = activeItem.setArmAngle
+			function activeItem.setArmAngle(angle, f)
+				follow = not not f
+				if follow then angle = angle - mcontroller.rotation() * mcontroller.facingDirection() end
+				armAngle = angle
+				return setArmAngle(armAngle)
+			end
+			local handPosition = activeItem.handPosition
+			function activeItem.handPosition(off)
+				if not follow then return handPosition(off) end
+				setArmAngle(armAngle + mcontroller.rotation() * mcontroller.facingDirection())
+				local vec = handPosition(off)
+				setArmAngle(armAngle)
+				return vec
+			end
+		end
+		return Weapon.new(...)
+	end
 end

--- a/items/armors/tier3/cultcrown/cultcrown.head
+++ b/items/armors/tier3/cultcrown/cultcrown.head
@@ -4,7 +4,7 @@
 	"dropCollision": [-4.0, -3.0, 4.0, 3.0],
 	"maxStack": 1,
 	"rarity": "rare",
-	"description": "A grotesque, bizarre crown of gold.\n+^green;25^reset;% Shadow Resistance.\n^green;+30^reset;% Energy Regen\nDefense x^green;1.15^reset;.\n^cyan;Immune^reset;: Caliginous Gas, Shadow Taint",
+	"description": "A grotesque, bizarre crown of gold.\n+^green;25^reset;% Shadow Resistance.\n^green;+30^reset;% Energy Regen\nDefense x^green;1.15^reset;, Damage x^green;1.2^reset;.\n^cyan;Immune^reset;: Caliginous Gas, Shadow Taint",
 	"shortdescription": "Elder Crown",
 	"category": "headarmour",
 	"tooltipKind": "armornew2",
@@ -19,8 +19,8 @@
 			"effectiveMultiplier": 1.15
 		},
 		{
-			"stat": "damagebonus",
-			"amount": 1.2
+			"stat": "powerMultiplier",
+			"effectiveMultiplier": 1.2
 		},
 		"energyregenfu_armor30",
 		{

--- a/items/armors/uniques/randolphcarterhat/randolphcarterhat.head
+++ b/items/armors/uniques/randolphcarterhat/randolphcarterhat.head
@@ -38,7 +38,7 @@
   ],   
   "statusEffects" : [
     {
-      "stat" : "mentalResistance",
+      "stat" : "mentalProtection",
       "amount" : 0.2
     }
   ],

--- a/monsters/boss/shoggoth/bossmonster.lua
+++ b/monsters/boss/shoggoth/bossmonster.lua
@@ -60,6 +60,13 @@ function init()
 end
 
 function update(dt)
+	if wrongWorld or (world.type()~="eldershoggoth") then
+		if not wrongWorld then
+			monster.setDropPool(nil)
+		end
+		status.setResource("health",0)
+		wrongWorld=true
+	end
 	dungeonIDCheck=math.min((dungeonIDCheck or 0)-dt)
 	world.debugPoint(entity.position(),"red")
 	self.tookDamage = false

--- a/npcs/merchantpools.config.patch
+++ b/npcs/merchantpools.config.patch
@@ -46,7 +46,19 @@
 				{"item": {"name": "scienceoutpost_khe-codex"}, "prerequisiteQuest": "create_elder"},
 				{"item": {"name": "fukhestreakerrewardbag"}, "prerequisiteQuest": "khe_fabric"},
 				{"item": {"name": "lanterrortreasuretrollking"}, "prerequisiteQuest": "khe_lantern"},
-				{"item": {"name": "accordion"}, "prerequisiteQuest": "khe_lantern"}
+				{"item": {"name": "accordion"}, "prerequisiteQuest": "khe_lantern"}//,
+				//{"item": {"name": "fu_t10_gaterepairbeacon"}, "prerequisiteQuest": "fu_t10_initial"},
+				//{"item": {"name": "fu_t10_human_mission1beacon"}, "prerequisiteQuest": "fu_t10_gaterepair"},
+				//{"item": {"name": "fu_t10_floran_mission2beacon"}, "prerequisiteQuest": "fu_t10_human_mission1"},
+				//{"item": {"name": "fu_t10_floranarena1beacon"}, "prerequisiteQuest": "fu_t10_floran_mission2"},
+				//{"item": {"name": "fu_t10_hylotl_mission2beacon"}, "prerequisiteQuest": "fu_t10_floranarena1"},
+				//{"item": {"name": "fu_t10_floranarena2beacon"}, "prerequisiteQuest": "fu_t10_hylotl_mission2"},
+				//{"item": {"name": "fu_t10_avian_mission2beacon"}, "prerequisiteQuest": "fu_t10_floranarena2"},
+				//{"item": {"name": "fu_t10_floranarena3beacon"}, "prerequisiteQuest": "fu_t10_avian_mission2"},
+				//{"item": {"name": "fu_t10_apex_mission2beacon"}, "prerequisiteQuest": "fu_t10_floranarena3"},
+				//{"item": {"name": "fu_t10_precursorbeacon"}, "prerequisiteQuest": "fu_t10_apex_mission2"},
+				//{"item": {"name": "fu_t10_glitch_mission2beacon"}, "prerequisiteQuest": "fu_t10_precursor"}
+				//still to make: DF2, ruin, and swansong beacons.
 			] ]
 		]
 	},

--- a/npcs/scienceoutpost/lostandfoundnpc.npctype
+++ b/npcs/scienceoutpost/lostandfoundnpc.npctype
@@ -2,16 +2,13 @@
 	"type": "fulostandfoundnpc",
 	"baseType": "merchant",
 	"damageTeamType": "friendly",
-	
+
 	"npcname" : "Khe",
 	"identity" : {
 		"name" : "Khe",
 		"gender" : "female",
 		"hairGroup" : "hair",
 		"hairType" : "1",
-		
-		
-		
 
 		//{ "FFCA8A" : "555555", "E0975C" : "424242", "A85636" : "303030", "6F2919" : "151515" },
 		"bodyDirectives" : "?replace=FFCA8A=555555?replace=E0975C=424242?replace=A85636=303030?replace=6F2919=151515?replace=FFD800=2D2D2D?replace=D8B400=101010?replace=FFCC00=555555?replace=56CC7B=555555",
@@ -26,10 +23,19 @@
 		"personalityHeadOffset" : [-1, 0],
 		"personalityArmOffset" : [0, 0]
 	},
-	
+
 	"scriptConfig": {
-		"offeredQuests" : [ "khe_fabric","khe_lantern" ],
-		"turnInQuests": ["kevin_feedkhe","khe_fabric","khe_lantern","fu_t10_glitch_mission2","fu_t10_hylotl_mission2","fu_t10_apex_mission2","fu_t10_avian_mission2","fu_t10_floran_mission2","fu_t10_floranarena3","fu_t10_floranarena2","fu_t10_floranarena1"],
+		"offeredQuests" : [
+			"khe_fabric","khe_lantern"//,
+			//"fu_t10_initial"//disabled. quest will reward a beacon which is used to access the arena. each quest will reward ONE beacon to the next arena. more can be bought.
+		],
+		"turnInQuests": [
+			"kevin_feedkhe","khe_fabric","khe_lantern",
+			"fu_t10_initial","fu_t10_gaterepair","fu_t10_human_mission1","fu_t10_floran_mission2",
+			"fu_t10_floranarena1","fu_t10_hylotl_mission2","fu_t10_floranarena2","fu_t10_avian_mission2",
+			"fu_t10_floranarena3","fu_t10_apex_mission2","fu_t10_precursor","fu_t10_glitch_mission2"
+			//df2 (7) -> ruin (6) -> swansong (6)
+		],
 		"merchant": {
 			"waitTime": 40,
 			"storeRadius": 8,

--- a/quests/optionalhardmode/fu_t10_apex_mission2.questtemplate
+++ b/quests/optionalhardmode/fu_t10_apex_mission2.questtemplate
@@ -1,0 +1,30 @@
+{
+	"id": "fu_t10_apex_mission2",
+	"prerequisites": [ "fu_t10_floranarena3" ],
+	"title": "Dark Imperator",
+	"text": "Next on da list, smacking da monkey. Okay, not that kind. Go kill a Big Ape.",
+	"completionText": "Okay, mew is really really concerned now. New Kevin message. \"My fault. All my fault. ALL MY FAULT.\" Very unlike him. What his fault though?",
+	"moneyRange": [0, 0],
+	"rewards": [],
+	"canBeAbandoned": true,
+	"questGiverIndicator": "mainquestgiver",
+	"questReceiverIndicator": "mainquestreceiver",
+
+	"updateDelta": 10,
+	"script": "/quests/scripts/fuartifacthardmode.lua",
+	"scriptConfig": {
+		"portraits": {
+			"questStarted": "questGiver",
+			"questComplete": "questReceiver"
+		},
+		"associatedMission": "fuapexmission1t10",
+		"descriptions"	: {
+			"artifact": "Find the ^orange;artifact^reset; in the ^orange;Dark Miniknog stronghold^reset;",
+			"turnIn": "Return to ^orange;Khe^reset; at ^orange;the Science Outpost^reset;"
+		},
+
+		"artifactUid": "apexartifactaltar",
+		"artifactMessage": "apexArtifactTaken",
+		"estherUid": "kheraeoutpost"
+	}
+}

--- a/quests/optionalhardmode/fu_t10_avian_mission2.questtemplate
+++ b/quests/optionalhardmode/fu_t10_avian_mission2.questtemplate
@@ -1,0 +1,30 @@
+{
+	"id": "fu_t10_avian_mission2",
+	"prerequisites": [ "fu_t10_floranarena2" ],	
+	"title": "Of Dark Gods and Dark Falls",
+	"text": "'...and then the hero met the devout.'...or was it 'devoured'? Sorry, missed a snack. Go to bird temple.",
+	"completionText": "No message, just breadcrumbs. Sadmew. Maybe this Kevin had clone-rot and went addle-brained.",
+	"moneyRange": [0, 0],
+	"rewards": [],
+	"canBeAbandoned": true,
+	"questGiverIndicator": "mainquestgiver",
+	"questReceiverIndicator": "mainquestreceiver",
+
+	"updateDelta": 10,
+	"script": "/quests/scripts/fuartifacthardmode.lua",
+	"scriptConfig": {
+		"portraits": {
+			"questStarted": "questGiver",
+			"questComplete": "questReceiver"
+		},
+		"associatedMission": "fuavianmission1t10",
+		"descriptions"	: {
+			"artifact": "Find the ^orange;artifact^reset; in the ^orange;Dark Sovereign Temple^reset;",
+			"turnIn": "Return to ^orange;Kherae^reset; at ^orange;the Science Outpost^reset;"
+		},
+
+		"artifactUid": "avianartifactaltar",
+		"artifactMessage": "avianArtifactTaken",
+		"estherUid": "kheraeoutpost"
+	}
+}

--- a/quests/optionalhardmode/fu_t10_floran_mission2.questtemplate
+++ b/quests/optionalhardmode/fu_t10_floran_mission2.questtemplate
@@ -1,0 +1,29 @@
+{
+	"id": "fu_t10_floran_mission2",
+	"prerequisites": [ "fu_t10_human_mission1" ],
+	"title": "Darkness among the Trees",
+	"text": "Hero fetches artifacts, saves universe. Right? Not in other reality. Why not? Go find first one. See if Kevin was there.",
+	"completionText": "Kevin touched artifact, definitely, and...eww! He left it covered in raptor piss! Dirty stinker used it to etch 'Kevin was here' in the shiny. Hmm...have beacon with new signature though.",
+	"moneyRange": [0, 0],
+	"rewards": [],
+	"canBeAbandoned": true,
+	"questGiverIndicator": "mainquestgiver",
+	"questReceiverIndicator": "mainquestreceiver",
+
+	"updateDelta": 10,
+	"script": "/quests/scripts/fuartifacthardmode.lua",
+	"scriptConfig": {
+		"portraits": {
+			"questStarted": "questGiver",
+			"questComplete": "questReceiver"
+		},
+		"associatedMission": "fufloranmission1t10",
+		"descriptions"	: {
+			"artifact": "Find the ^orange;artifact^reset; in ^green;the Dark Hunting Grounds^reset;",
+			"turnIn": "Return to ^orange;Kherae^reset; at ^orange;the Science Outpost^reset;"
+		},
+
+		"artifactUid": "floranartifactaltar",
+		"estherUid": "kheraeoutpost"
+	}
+}

--- a/quests/optionalhardmode/fu_t10_floranarena1.questtemplate
+++ b/quests/optionalhardmode/fu_t10_floranarena1.questtemplate
@@ -1,0 +1,34 @@
+{
+	"id" : "fu_t10_floranarena1",
+	"prerequisites" : [ "fu_t10_floran_mission2" ],
+	"title" : "A Darker Contest",
+	"text" : "Kevin went to an arena. Maybe to fight? Go there, kill things, and come back with energy signature. Be careful, this one feels...wrong. Really wrong.",
+	"completionText" : "No Kevin, but energy signature there. Fresher. Kinda. Mew...keep going. Beacons here.",
+	"moneyRange" : [0, 0],
+	"rewards" : [],
+
+	"updateDelta" : 10,
+	"script" : "/quests/scripts/fuhardmodeinstance.lua",
+	"scriptConfig" : {
+		"portraits" : {
+			"default" : "questGiver"
+		},
+
+		"descriptions" : {
+			"enterInstance" : "Use the ^orange;Bronze Arena Beacon^reset;.",
+			"findGoal" : "Win the arena battle",
+			"turnIn" : "Return to ^orange;Khe^reset; at the ^orange;Science Outpost^reset;"
+		},
+
+		"warpAction" : "fuarena1t10",
+
+		"goalTrigger" : "proximity",
+		"proximityRange" : 20,
+
+		"goalEntityUid" : "arena1teleporter",
+		"indicateGoal" : false,
+		"trackGoalEntity" : false,
+
+		"turnInEntityUid" : "kheraeoutpost"
+	}
+}

--- a/quests/optionalhardmode/fu_t10_floranarena2.questtemplate
+++ b/quests/optionalhardmode/fu_t10_floranarena2.questtemplate
@@ -1,0 +1,34 @@
+{
+	"id" : "fu_t10_floranarena2",
+	"prerequisites" : [ "fu_t10_hylotl_mission2" ],
+	"title" : "Dark 'Lord' Volo Mort",
+	"text" : "Signature leads to another nasty place full of awful badness. But it's best we have. Go win, bring shiny, and...no die. Okay?",
+	"completionText" : "Another dead body, another signature with a message. \"No sandwiches.\" This Kevin worries mew. Something isn't right.",
+	"moneyRange" : [0, 0],
+	"rewards" : [],
+
+	"updateDelta" : 10,
+	"script" : "/quests/scripts/fuhardmodeinstance.lua",
+	"scriptConfig" : {
+		"portraits" : {
+			"default" : "questGiver"
+		},
+
+		"descriptions" : {
+			"enterInstance" : "Use the ^orange;Silver Arena Beacon^reset;",
+			"findGoal" : "Win the arena battle",
+			"turnIn" : "Return to ^orange;Khe^reset; at the ^orange;Science Outpost^reset;"
+		},
+
+		"warpAction" : "fuarena2t10",
+
+		"goalTrigger" : "proximity",
+		"proximityRange" : 20,
+
+		"goalEntityUid" : "arena2teleporter",
+		"indicateGoal" : false,
+		"trackGoalEntity" : false,
+
+		"turnInEntityUid" : "kheraeoutpost"
+	}
+}

--- a/quests/optionalhardmode/fu_t10_floranarena3.questtemplate
+++ b/quests/optionalhardmode/fu_t10_floranarena3.questtemplate
@@ -1,0 +1,34 @@
+{
+	"id" : "fu_t10_floranarena3",
+	"prerequisites" : [ "fu_t10_avian_mission2" ],
+	"title" : "Dark Flames",
+	"text" : "Another super bad place, you know da drill by now.",
+	"completionText" : "New signature, another message. Mew disapproves. Picture of Mantizi in codpiece armor. Not Kevin. Face upside down smiling. Kevin clue?",
+	"moneyRange" : [0, 0],
+	"rewards" : [],
+
+	"updateDelta" : 10,
+	"script" : "/quests/scripts/fuhardmodeinstance.lua",
+	"scriptConfig" : {
+		"portraits" : {
+			"default" : "questGiver"
+		},
+
+		"descriptions" : {
+			"enterInstance" : "Use the ^orange;Gold Arena Beacon^reset;",
+			"findGoal" : "Win the arena battle",
+			"turnIn" : "Return to ^orange;Khe^reset; at the ^orange;Science Outpost^reset;"
+		},
+
+		"warpAction" : "fuarena3t10",
+
+		"goalTrigger" : "proximity",
+		"proximityRange" : 20,
+
+		"goalEntityUid" : "arena3teleporter",
+		"indicateGoal" : false,
+		"trackGoalEntity" : false,
+
+		"turnInEntityUid" : "kheraeoutpost"
+	}
+}

--- a/quests/optionalhardmode/fu_t10_gaterepair.questtemplate
+++ b/quests/optionalhardmode/fu_t10_gaterepair.questtemplate
@@ -1,0 +1,26 @@
+{
+	"text": "Mew. Kevin clone problem? It went to other reality. Bad things happened there, everything went wrong. Go open gate, get gate signature data.",
+	"completionText": "Mew...gate signatures old. Sad kitty. More tracking needed. Have new beacon.",
+	"title": "Through the Darkness",
+	"id": "fu_t10_gaterepair",
+	"updateDelta": 10,
+	"script": "/quests/scripts/story/fuhardmodegaterepair.lua",
+	"prerequisites": ["fu_t10_initial"],
+	"moneyRange": [0, 0],
+	"scriptConfig": {
+		"portraits": {
+			"questComplete": "questReceiver",
+			"questStarted": "questReceiver"
+		},
+		"descriptions": {
+			"findEsther": "Return to ^orange;Khe^reset; at the ^orange;Science Outpost^reset;",
+			"repairGate": "Open the ^orange;Gate^reset;.",
+			"explore": "Use a ^orange;Dark Cave Beacon^reset;."
+		},
+		"caveUid": "ancientgate2",
+		"estherUid": "kheraeoutpost",
+		"instanceWorld":"fucavedungeont10",
+		"targetUid":"ancientgate2"
+	},
+	"rewards": []
+}

--- a/quests/optionalhardmode/fu_t10_glitch_mission2.questtemplate
+++ b/quests/optionalhardmode/fu_t10_glitch_mission2.questtemplate
@@ -1,0 +1,30 @@
+{
+	"id": "fu_t10_glitch_mission2",
+	"prerequisites": [ "fu_t10_precursor" ],
+	"title": "[PH] Glitch Hard Mode",
+	"text": "[PH] Glitch Dark Mode Text",
+	"completionText": "[PH] Glitch Dark Mode Completion Text",
+	"moneyRange": [0, 0],
+	"rewards": [],
+	"canBeAbandoned": true,
+	"questGiverIndicator": "mainquestgiver",
+	"questReceiverIndicator": "mainquestreceiver",
+
+	"updateDelta": 10,
+	"script": "/quests/scripts/fuartifacthardmode.lua",
+	"scriptConfig": {
+		"portraits": {
+			"questStarted": "questGiver",
+			"questComplete": "questReceiver"
+		},
+		"associatedMission": "fumissionglitch1t10",
+		"descriptions"	: {
+			"artifact": "Find the ^orange;artifact^reset; in the ^orange;old Glitch keep^reset;",
+			"turnIn": "Return to ^orange;Kherae^reset; at ^orange;the Science Outpost^reset;"
+		},
+
+		"artifactUid": "glitchartifactaltar",
+		"artifactMessage": "glitchArtifactTaken",
+		"estherUid": "kheraeoutpost"
+	}
+}

--- a/quests/optionalhardmode/fu_t10_human_mission1.questtemplate
+++ b/quests/optionalhardmode/fu_t10_human_mission1.questtemplate
@@ -1,0 +1,25 @@
+{
+	"text": "Cave was like one you saw, yes? Mew had a thought. Kevin experiments, tries following in your footsteps. Everything goes wrong. Maybe he got bored?",
+	"title": "Glittering in the Dark",
+	"updateDelta": 10,
+	"script": "/quests/scripts/story/human_mission1.lua",
+	"id": "fu_t10_human_mission1",
+	"completionText": "Kevin touched crystals. No doubt about it. Old signature, faint, but clear. Maybe Kevin's fault things went wrong. Have another beacon.",
+	"prerequisites": ["fu_t10_gaterepair"],
+	"moneyRange": [0, 0],
+	"scriptConfig": {
+		"portraits": {
+			"questStarted": "questGiver",
+			"questComplete": "questReceiver"
+		},
+		"associatedMission": "fulunarbaset10",
+		"mechanicUid": "kheraeoutpost",
+		"descriptions": {
+			"turnIn": "^green;Bring^reset; the ^orange;Dark Erchius Crystals^reset; to ^orange;Kherae^reset; at the ^orange;Science Outpost^reset;",
+			"findCrystals": "^green;Fetch ^orange;Dark Erchius Crystals^reset; from the ^orange;Dark Erchius Mining Facility^reset;"
+		},
+		"drillUid": "erchiusdrillmachine",
+		"compassUpdate": 0.2
+	},
+	"rewards": []
+}

--- a/quests/optionalhardmode/fu_t10_hylotl_mission2.questtemplate
+++ b/quests/optionalhardmode/fu_t10_hylotl_mission2.questtemplate
@@ -1,0 +1,30 @@
+{
+	"id": "fu_t10_hylotl_mission2",
+	"prerequisites": [ "fu_t10_floranarena1" ],
+	"title": "Darkest Pages, Darkest Knowledge",
+	"text": "Hero visits the library! Right? Get events out of order sometimes. Kevin probably went there. Go look.",
+	"completionText": "Artifact had energy signature, yus. Different. Encoded message. Kevin's. \"There was no Kevin.\" That's...concerning. Well...cookie trail.",
+	"moneyRange": [0, 0],
+	"rewards": [],
+	"canBeAbandoned": true,
+	"questGiverIndicator": "mainquestgiver",
+	"questReceiverIndicator": "mainquestreceiver",
+
+	"updateDelta": 10,
+	"script": "/quests/scripts/fuartifacthardmode.lua",
+	"scriptConfig": {
+		"portraits": {
+			"questStarted": "questGiver",
+			"questComplete": "questReceiver"
+		},
+		"associatedMission": "fumissionhylotl1t10",
+		"descriptions"	: {
+			"artifact": "Find the ^orange;artifact^reset; in the ^orange;Grand Pagoda Library^reset;",
+			"turnIn": "Return to ^orange;Kherae^reset; at ^orange;the Science Outpost^reset;"
+		},
+
+		"artifactUid": "hylotlartifactaltar",
+		"artifactMessage": "hylotlArtifactTaken",
+		"estherUid": "kheraeoutpost"
+	}
+}

--- a/quests/optionalhardmode/fu_t10_initial.questtemplate
+++ b/quests/optionalhardmode/fu_t10_initial.questtemplate
@@ -1,0 +1,27 @@
+{
+	"text": "Mew. Need help. See Kevin? New copy from terminal. Nobody noticed lack of corpse yet. Have temporo-spatial beacons to universe where he went, don't ask how. Help find traces, find what happened.\n^red;This begins the optional, tier 10, hard mode for Frackin Universe and Vanilla dungeons. It is designed to be a form of challenge for those who have reached the heights of what FU offers.^reset;",
+	"completionText": "You gonna help mew? YAY! Can provide more beacons for shiny, if you can't manage first try.",
+	"title": "Khe's Quest",
+	"id": "fu_t10_initial",
+	"updateDelta": 10,
+	"script": "/quests/scripts/main.lua",
+	"prerequisites": ["kevin_feedkhe","destroyruin","cultist_mission1","precursor_unlock","shoggoth_defeat"],
+	"moneyRange": [0, 0],
+	"scriptConfig": {
+		"requireTurnIn" : true,
+		"portraits": {
+			"questComplete": "questReceiver",
+			"questStarted": "questReceiver"
+		},
+		"conditions" : [
+			{
+				"type" : "gatherItem",
+				"itemName" : "money",
+				"count" : 1000,
+				"consume" : true,
+				"description" : "Bring ^orange;<itemName>^reset;: ^green;<current> / <required>^reset;"
+			}
+		]
+	},
+	"rewards": []
+}

--- a/quests/optionalhardmode/fu_t10_precursor.questtemplate
+++ b/quests/optionalhardmode/fu_t10_precursor.questtemplate
@@ -1,0 +1,38 @@
+{
+	"id" : "fu_t10_precursor",
+	"mainQuest" : true,
+	"title" : "[PH] Dark Precursor",
+	"prerequisites" : ["fu_t10_apex_mission2"],
+	"text" : "[PH] Dark Precursor Text",
+	"completionText" : "[PH] Dark Precursor Completion Text",
+	"portraits" : {
+		"questStarted" : "questGiver",
+		"questComplete" : "questReceiver"
+	},
+	"moneyRange" : [0, 0],
+	"missionUnlockedCinema" : "/cinematics/coordinates.cinematic",
+	"rewards" : [],
+	"canBeAbandoned" : true,
+
+	"updateDelta" : 10,
+	"script" : "/quests/scripts/fuhardmodeinstance.lua",
+	"scriptConfig" : {
+		"portraits" : {
+			"default" : "questGiver"
+		},
+		"descriptions" : {
+			"enterInstance" : "Use the ^orange;Bronze Arena Beacon^reset;.",
+			"findGoal" : "Win the arena battle",
+			"turnIn" : "Return to ^orange;Khe^reset; at the ^orange;Science Outpost^reset;"
+		},
+		"warpAction" : "fuarena1t10",
+		"goalTrigger" : "proximity",
+		"proximityRange" : 20,
+
+		"goalEntityUid" : "arena1teleporter",
+		"indicateGoal" : false,
+		"trackGoalEntity" : false,
+
+		"turnInEntityUid" : "kheraeoutpost"
+	}
+}

--- a/species/everis.raceeffect
+++ b/species/everis.raceeffect
@@ -6,10 +6,9 @@
 		{ "stat":"iceResistance", "amount":0.3 },
 		{ "stat":"poisonResistance", "amount":-0.1 },
 		{ "stat":"electricResistance", "amount":0.2 },
-		{ "stat":"slushslowimmunity", "amount":1 },
-		{ "stat":"snowslowimmunity", "amount":1 },
-		{ "stat":"iceslipimmunity", "amount":1 },
-		{ "stat":"coldimmunity", "amount":1 },
+		{ "stat":"slushslowImmunity", "amount":1 },
+		{ "stat":"snowslowImmunity", "amount":1 },
+		{ "stat":"iceslipImmunity", "amount":1 },
 		{ "stat":"biomecoldImmunity", "amount":1 }
 	],
 	"diet" : "omnivore",

--- a/species/pony.raceeffect
+++ b/species/pony.raceeffect
@@ -72,7 +72,7 @@
 		],
 		"stats": [
 			{
-				"stat": "protecion",
+				"stat": "protection",
 				"effectiveMultiplier": 0.66
 			}
 		],

--- a/species/saturn.raceeffect
+++ b/species/saturn.raceeffect
@@ -6,7 +6,7 @@
 			"effectiveMultiplier": 0.75
 		},
 		{
-			"stat": "physicalResisance",
+			"stat": "physicalResistance",
 			"amount": -0.10
 		},
 		{

--- a/species/saturn2.raceeffect
+++ b/species/saturn2.raceeffect
@@ -6,7 +6,7 @@
 			"effectiveMultiplier": 0.75
 		},
 		{
-			"stat": "physicalResisance",
+			"stat": "physicalResistance",
 			"amount": -0.10
 		},
 		{

--- a/species/saturnmothman.raceeffect
+++ b/species/saturnmothman.raceeffect
@@ -10,7 +10,7 @@
 			"effectiveMultiplier": 1.05
 		},		
 		{
-			"stat": "physicalResisance",
+			"stat": "physicalResistance",
 			"amount": -0.10
 		},
 		{

--- a/species/woggle.raceeffect
+++ b/species/woggle.raceeffect
@@ -45,7 +45,7 @@
 			"amount": 1
 		},
 		{
-			"stat": "ffextremeradiationimmunity",
+			"stat": "ffextremeradiationImmunity",
 			"amount": 1
 		}
 	],

--- a/stats/__STAT_LIST.TXT
+++ b/stats/__STAT_LIST.TXT
@@ -1,19 +1,21 @@
-NOTICE: 
+NOTICE:
  > YES, THERE ARE SOME REDUNDANT STATS IN HERE.
  > YES, THEY ARE ALL NEEDED. For instance, if you want to add immunity to something like mudslow, add fumudslow AND mudslow.
- 
+
  > [0-Relative] means that THE STATS ARE ORIENTED AROUND 0. This means that the default state is 0. These must use [amount] or [effectiveMultiplier]. [effectiveMultiplier] will only have an effect if other sources use [amount]!
  > [X-Relative] means that THE STATS ARE ORIENTED AROUND X (As example:1). Default values are stated.
- 
+
  > [baseMultiplier]: This means that the default state is X (100%). Values < 1 subtract from this stat, and values > 1 add to this stat. (e.g. 0.5 means "50% of this stat's value")
  > [effectiveMultiplier]: applies a multiplier. 0.5 means half of whatever the stat currently is. 2 means twice.
- 
+
  > [armorStatA]: stats that use [amount] on armor stat lists and [effectiveMultiplier] on pretty much every other case
  > [armorStatB]: stats that use [baseMultiplier] on armor stat lists and [effectiveMultiplier] on pretty much every other case
- 
- > [boolean] means that THE VALUE IS A SWITCH, AND MUST BE OFF (0) OR ON (1). No other values are legal.
+
+ > [boolean] means that THE VALUE IS A SWITCH, AND MUST BE OFF (0) OR ON (1). No other values are legal. that said, typically any value that isnt 0 is treated as true.
 
  > [fixed]: special case. stat comes only in specific values
+
+ > [Variant]: it has specific cases it can be, but varies by context.
 
 RESISTANCES: These use float values (0.5 is 50% Resistance)
 	ELEMENTAL:
@@ -21,18 +23,18 @@ RESISTANCES: These use float values (0.5 is 50% Resistance)
 		poisonResistance            [amount] [0-Relative]
 		iceResistance               [amount] [0-Relative]
 		electricResistance          [amount] [0-Relative]
-		
+
 		radioactiveResistance       [amount] [0-Relative]
 		shadowResistance            [amount] [0-Relative]
 		darknessResistance          [amount] [0-Relative] - not used in FU anywhere. is on a few races.
 		cosmicResistance            [amount] [0-Relative]
-		
-		
+
+
 	PHYSICAL:
 		physicalResistance          [amount] [0-Relative]
 		grit                        [amount] [0-Relative] - Impacts knockback from big hits. See /stats/*_primary.lua
-		
-		
+
+
 	OTHER:
 		mentalProtection            [amount] [0-Relative] - Impacts insanity effect frequency and potency, and madness decay.
 
@@ -43,104 +45,134 @@ IMMUNITIES
         fumudslowImmunity           [amount] [Boolean]
         fuclayslowImmunity          [amount] [Boolean]
         jungleslowImmunity          [amount] [Boolean]
-        
+
         slushslowImmunity           [amount] [Boolean]
         snowslowImmunity            [amount] [Boolean]
         snowslipImmunity            [amount] [Boolean]
         iceslipImmunity             [amount] [Boolean]
-        
+
         tarImmunity                 [amount] [Boolean]
         tarStatusImmunity           [amount] [Boolean]
         blacktarImmunity            [amount] [Boolean]
-		
+
         quicksandImmunity           [amount] [Boolean]
-        
+
         slimefrictionImmunity       [amount] [Boolean] - this is basically only used on certain enemy effects.
         slimestickImmunity          [amount] [Boolean] - This is for tiles
         honeyslowImmunity           [amount] [Boolean]
         webstickImmunity            [amount] [Boolean]
-		
+
         stunImmunity                [amount] [Boolean]
-        
-        
+
+
     ENVIRONMENT_WEATHER_AND_ELEMENTAL:
         biomecoldImmunity           [amount] [Boolean]
         ffextremecoldImmunity       [amount] [Boolean]
         liquidnitrogenImmunity      [amount] [Boolean]
         iceStatusImmunity           [amount] [Boolean]
         coldimmunity    			[amount] [Boolean]
-		
+
         biomeheatImmunity           [amount] [Boolean]
         ffextremeheatImmunity       [amount] [Boolean]
         fireStatusImmunity          [amount] [Boolean] - burning
         lavaImmunity                [amount] [Boolean]
-		
+
         biomeradiationImmunity      [amount] [Boolean]
         ffextremeradiationImmunity  [amount] [Boolean]
         radiationburnImmunity       [amount] [Boolean]
-		
+
         poisonStatusImmunity        [amount] [Boolean]
+        poisongasImmunity           [amount] [Boolean] - poison gas weather
         biooozeImmunity             [amount] [Boolean]
-		
+        boozeImmunity               [amount] [Boolean]
+
         electricStatusImmunity      [amount] [Boolean]
-		
+
         sandstormImmunity           [amount] [Boolean]
-		
+
         breathProtection            [amount] [Boolean] - includes water breath protection
         waterbreathProtection       [amount] [Boolean] - anti-drowning
-		
+
         waterImmunity               [amount] [Boolean] - blocks swimming
         wetImmunity                 [amount] [Boolean] - blocks 'wet' effects
-		
+
         pressureProtection          [amount] [Boolean] - These two are put together everywhere. Use both, even if this one isn't used on any biome effects.
         extremepressureProtection   [amount] [Boolean]
-		
+        negativeMiasma              [amount] [Boolean] - negates (extreme) pressure protection. not actually used.
+
         beestingImmunity            [amount] [Boolean] - BEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEES!
         erchiusImmunity             [amount] [Boolean] - because big spooky ghosty is a nuisance
         slimeImmunity               [amount] [Boolean] - vanilla, rarely used.
-		
+
         darknessImmunity            [amount] [Boolean] - unbreachable darkness
         shadowImmunity              [amount] [Boolean] - shadow taint, caliginous (formerly shadow) gas
+		metallichydrogengasImmunity [amount] [Boolean] - not actually used.
         insanityImmunity            [amount] [Boolean] - nearly all forms of madness
+		freudBonus                  [amount] [0-Relative] - see /quests/madness/madnessdata.lua. tl;dr: higher number, madness decays faster. lower number, madness decays slower.
         aetherImmunity              [amount] [Boolean]
-        
-  
+
+
     MISC:
-        specialStatusImmunity       [amount] [Boolean] - Used almost exclusively on bosses.
+        specialStatusImmunity       [amount] [Boolean] - Used almost exclusively on bosses. when 'hard targets' are referred to, it means targets with this.
         healingStatusImmunity       [amount] [Boolean] - Used primarily on bosses.
-    
+		invulnerable                [amount] [Boolean] - immunity to damage. vanilla. appears engine-side.
+		statusImmunity              [amount] [Boolean] - Typically Binary (0 or 1), blanket ephemeral status immunity. vanilla. appears engine-side.
 
 OTHER:
     maxHealth                       [armorStatB]     	  [X-Relative, Default:100]
     healthRegen                     [amount]              [0-Relative] - Flat value regenerated each second.
 	healingBonus                    [amount]              [0-Relative, Float] Used as a percentage increase to healing effects. 0.05 is +5%.
-	
+	xiBonus                         [amount] [0-Relative] - applies to xi bulbs' healing mechanic.
+
     maxEnergy                       [armorStatB]		  [X-Relative, Default: 100]
     energyRegenBlockTime            [baseMultiplier]      [X-Relative, Default: 1.5] - Delay in seconds til regen starts.
     energyRegenPercentageRate       [baseMultiplier]      [X-Relative, Default: 0.585] - Result: 1.75 second recharge time
-    
-    maxFood                         [any] 				  [X-Relative, Default: 70]
+
+    maxFood                         [any] 				  [X-Relative, Default: 70] Source: FU
     noFood                          [amount]              [Boolean] - doesn't really do anything?
     foodDelta                       [baseMultiplier]      [X-Relative, Default: -0.0583] Results in -70 food over 20 minutes. Flat modifier to food per second.
-    
+	foodImmunity                    [amount] [Boolean]    immunity to the effects of food.
+
     maxBreath                       [amount]              [Static Number, Default: 100]
-    breathDepletionRate             [baseMultiplier]      [X-Relative, Default: 4]
-    breathRegenerationRate          [amount]              [Static Number, Unit unknown: Breath/sec? Default: 10]
-	
+    breathDepletionRate             [baseMultiplier]      [X-Relative, Default: 4] due to how some numpty coded things, this is effectively applied TWICE.
+    breathRegenerationRate          [amount]              [Static Number, Unit unknown: Breath/sec? Default: 10] due to how some numpty coded things, this is effectively applied TWICE.
+	boostAmount                     [Variant]             COMPLICATED. this is used for swim boosts effects. base is 1, effects ADD 1 to the base, then multiply by a value.
+	riseAmount                      [Variant]             COMPLICATED. swim code stuff.
+
     shieldRegen                     [amount]              [Unknown. Default: 0]
+    perfectBlockLimit               [amount]              [Unknown. Default: ?]
     perfectBlockLimitRegen          [amount]              [Unknown. Default: 0.2]
     shieldStaminaRegen          	[amount]              [Unknown. Default: 0.2]
-    
+
     protection                      [armorStatA]		  [0-Relative]
     powerMultiplier                 [armorStatB]      	  [1-Relative]
 	knockbackThreshold				[any]				  [Unknown. Default: 9]
-    fallDamageMultiplier            [effectiveMultiplier] [1-Relative]
-    
-    bowDrawTimeBonus                [amount]              [Unknown]
+    fallDamageMultiplier            [effectiveMultiplier] [1-Relative] DO NOT use baseMultiplier. We want to avoid players getting fall damage immunity from additive sources.
+    jumpModifier                    [amount] [1-Relative] vanilla thing.
+	activeMovementAbilities         [amount]              [0-Relative] Typically Binary (0 or 1), used to block movement related abilities. vanilla.
+
+	bowAirBonus                     [amount]              [0-Relative] additive damage multiplier while airborne, only for supported bow/crossbow weapons. primarily added by quivers.
+	bowEnergyBonus                  [amount]              [0-Relative] positive value, subtracted from bow drain.
+	nebsrngbowdamagebonus           [amount]              [0-Relative] additive damage multiplier, only for supported bow/crossbow weapons. primarily added by quivers.
+    bowDrawTimeBonus                [amount]              [0-Relative] increases bow draw speed.
 	critChance                      [amount]              [0-relative. Default: 0] Chance for weapons to crit. value of 42 is 42% chance to crit.
 	critBonus                       [amount]              [0-relative. Default: 0] Bonus Crit Damage. Flat amount added, does not scale with critDamage. Avoid using this stat. It should only be part of weapon config files.
 	critDamage                      [amount]              [0-relative. Default: 0] Bonus to Crit Damage multiplier. This is added to a base value of 1.50, but the stat starts as 0. +0.1 will make the crit damage multiplier 1.6.
-	stunChance                      [amount]              [0-relative. Default: 0] Chance to stun. Requires a crit. value of 42 is 42% chance to stun on crit.
-    
+	stunChance                      [amount]              [0-relative. Default: 0] Chance to stun. Requires a crit. value of 42 is 42% chance to stun on crit. so if you have 42% chance for both, that equates to about 17% chance to stun.
+
     fuCharisma                      [baseMultiplier]	  [1-Relative] Used for trading on space stations.
 	fuFoodTrackerHandler			[fixed]				  [-1,0,1] set by fu_player_init. -1 means food isnt draining,1 means it is, 0 means the value isnt initialized.
+
+	fu_<setname>set_<partname>      [amount]              [Variant] metagroup used by armor sets. see each set for whether it does something or not. in most cases, the default value is 1. Most set bonuses require an entire set worn to function.
+	<setname>setcount               [amount]              This will eventually be phased out. hopefully. it's used by "new" set bonus code, which needs removal.
+
+	jumpTechBonus                   [amount]              [0-Relative] used as part of multipliers for scaling FU techs
+	healTechBonus                   [amount]              [0-Relative] used as part of multipliers for scaling FU techs
+	bombTechBonus                   [amount]              [0-Relative] used as part of multipliers for scaling FU techs
+	dashTechBonus                   [amount]              [0-Relative] used as part of multipliers for scaling FU techs
+	dodgeTechBonus                  [amount]              [0-Relative] used as part of multipliers for scaling FU techs
+	defenseTechBonus                [amount]              [0-Relative] used as part of multipliers for scaling FU techs
+	phaseTechBonus                  [amount]              [0-Relative] used as part of multipliers for scaling FU techs
+	gravFlightOverride              [amount] [Boolean]    used by flight techs to disable gravity code
+
+	pandoraBoxExtraPets             [amount]              [0-Relative] increase to pet count

--- a/stats/__STAT_LIST.TXT
+++ b/stats/__STAT_LIST.TXT
@@ -137,6 +137,10 @@ OTHER:
     fallDamageMultiplier            [effectiveMultiplier] [1-Relative]
     
     bowDrawTimeBonus                [amount]              [Unknown]
+	critChance                      [amount]              [0-relative. Default: 0] Chance for weapons to crit. value of 42 is 42% chance to crit.
+	critBonus                       [amount]              [0-relative. Default: 0] Bonus Crit Damage. Flat amount added, does not scale with critDamage. Avoid using this stat. It should only be part of weapon config files.
+	critDamage                      [amount]              [0-relative. Default: 0] Bonus to Crit Damage multiplier. This is added to a base value of 1.50, but the stat starts as 0. +0.1 will make the crit damage multiplier 1.6.
+	stunChance                      [amount]              [0-relative. Default: 0] Chance to stun. Requires a crit. value of 42 is 42% chance to stun on crit.
     
     fuCharisma                      [baseMultiplier]	  [1-Relative] Used for trading on space stations.
 	fuFoodTrackerHandler			[fixed]				  [-1,0,1] set by fu_player_init. -1 means food isnt draining,1 means it is, 0 means the value isnt initialized.

--- a/stats/effects/fu_armoreffects/new/set_bonuses/tier2/bearsetbonus.statuseffect
+++ b/stats/effects/fu_armoreffects/new/set_bonuses/tier2/bearsetbonus.statuseffect
@@ -6,7 +6,7 @@
     "armorBonuses" : {
       "hammerMastery" : { "amount" : 0.20 },
       "iceStatusImmunity" : {},
-      "slushslowimmunity" : {},
+      "slushslowImmunity" : {},
       "grit" : { "amount" : 0.20 }
     },
 

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/blistersetbonuseffect2.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/blistersetbonuseffect2.lua
@@ -7,7 +7,7 @@ weaponBonus={
 }
 
 armorBonus={
-	{stat = "mentalResistance", amount = 0.2},
+	{stat = "mentalProtection", amount = 0.2},
 	{stat = "poisonStatusImmunity", amount = 1.0},
 	{stat = "protoImmunity", amount = 1.0},
 	{stat = "pusImmunity", amount = 1.0},

--- a/stats/effects/stun/stun.lua
+++ b/stats/effects/stun/stun.lua
@@ -1,17 +1,17 @@
 function init()
-  effect.setParentDirectives("fade=7733AA=0.25")
-  effect.addStatModifierGroup({{stat = "jumpModifier", amount = -0.3}})
+	effect.setParentDirectives("fade=7733AA=0.25")
+	effect.addStatModifierGroup({{stat = "jumpModifier", amount = -0.3}})
 end
 
 function update(dt)
-  mcontroller.controlModifiers({
-      ToolUsageSuppressed = true,
-      facingSuppressed = true,
-      movementSuppressed = true,
-      groundMovementModifier = 0.5,
-      speedModifier = 0.5,
-      airJumpModifier = 0.7
-    })
+	mcontroller.controlModifiers({
+		ToolUsageSuppressed = true,
+		facingSuppressed = true,
+		movementSuppressed = true,
+		groundMovementModifier = 0.5,
+		speedModifier = 0.5,
+		airJumpModifier = 0.7
+	})
 end
 
 function uninit()


### PR DESCRIPTION
added code so that shoggy cannot be spawned outside DF2. for reasons.
updated /stats/__STAT_LIST.txt
corrected several incorrect cases of stats, including some racials and the blister2 and bear set bonuses.
made further progress toward implementing hard mode dungeons

minor revision to crit.lua regarding stuns: comparisons for stunChance are now greater than, rather than greater than or equal to, due to how math.random() works with a single argument. see the script for details, near the top. this will have a minor effect, as it essentially reduces stun chance by 1%.
also commented out an unused line in the same file.

decoupled 'combo finishers' from the combo counter on fist weapons, to make them less problematic for certain 'finishers' (namely, the movement ones). finishers are now used by attacking while holding 'shift' (the run toggle)
combo counter now increases crit chance by 1%, and stun chance by 4%, per combo step. this means that the power gloves (7 step combo), absent any other bonuses, will get up to 11% (4+7) crit chance, and 28% (0+28) chance to stun.
Finishers benefit from the combo counter, but will reset it.