### PR TITLE
block

### DIFF
--- a/items/active/unsorted/pocketanchor/pocketanchor.lua
+++ b/items/active/unsorted/pocketanchor/pocketanchor.lua
@@ -2,21 +2,25 @@ require "/scripts/util.lua"
 require "/scripts/vec2.lua"
 
 function init()
-  self.timer = 3
-  self.fireOffset = config.getParameter("fireOffset")
-  script.setUpdateDelta(10)
+	self.timer = 3
+	self.fireOffset = config.getParameter("fireOffset")
+	script.setUpdateDelta(10)
 end
 
 function update(dt, fireMode, shiftHeld, moves)
-      status.addEphemeralEffect("pocketanchorstat", 1)
-     mcontroller.controlModifiers({
-      speedModifier = self.boostAmount,
-      liquidJumpModifier = 0,
-      liquidForce = 300,
-      liquidImpedance = 0.1
-    })
+	if ((mcontroller and mcontroller.zeroG()) or (0==world.gravity(entity.position()))) then
+		status.removeEphemeralEffect("pocketanchorstat")
+	else
+		status.addEphemeralEffect("pocketanchorstat", 1)
+		mcontroller.controlModifiers({
+			speedModifier = self.boostAmount,
+			liquidJumpModifier = 0,
+			liquidForce = 300,
+			liquidImpedance = 0.1
+		})
+	end
 end
 
 function uninit()
-  status.removeEphemeralEffect("pocketanchorstat")
+	status.removeEphemeralEffect("pocketanchorstat")
 end

--- a/items/armors/backitems/tw_spacepunkback/tw_spacepunk.back
+++ b/items/armors/backitems/tw_spacepunkback/tw_spacepunk.back
@@ -4,7 +4,7 @@
   "inventoryIcon" : "/items/armors/tier3/tw_spacepunk/icons.png:back",
   "rarity" : "Rare",
 
-  "description" : "Generates a protective field that grants 5% to Shadow, Radiation, Cosmic and Physical Resists, and provides an Oxygen recycler.",
+  "description" : "Generates a protective field that grants +5% Shadow, Rad., Cosmic, & Phys. Res., and provides an Oxygen recycler. ^cyan;+10% Physical & Knockback Res^reset;.",
   "shortdescription" : "Spacepunk Tank",
   "tooltipKind" : "baseaugment",
 

--- a/items/augments/back/resistances/physicalresistance.augment
+++ b/items/augments/back/resistances/physicalresistance.augment
@@ -4,7 +4,7 @@
   "rarity" : "Uncommon",
   "category" : "eppAugment",
   "inventoryIcon" : "physicalresist.png",
-  "description" : "An EPP module that resists the Physical element.\n^green;+10% Physical Resist,\n+10% Knockback Resist^reset;.",
+  "description" : "An EPP module that resists the Physical element.\n^cyan;+10% Physical & Knockback Res.^reset;.",
   "shortdescription" : "Physical Barrier",
   "tooltipKind" : "eppaugment",
   "augment" : {

--- a/items/generic/drinks/beer/thelusianwine.consumable
+++ b/items/generic/drinks/beer/thelusianwine.consumable
@@ -4,7 +4,7 @@
   "category": "drink",
   "price": 600,
   "inventoryIcon": "thelusianwine.png",
-  "description": "One of the strongest known alcohols.\n^cyan;+^white;10% ^pink;Physical ^gray;& ^cyan;+^white;20% ^pink;Ice ^cyan;Res^gray;, ^pink;Frost ^cyan;Immunity^gray;, ^white;35% ^red;Slow ^gray;, ^red;Hammered ^gray;(^white;30s^gray;)^reset;",
+  "description": "One of the strongest known alcohols.\n^cyan;+10% Physical & Knockback Res.^reset; & ^cyan;+^white;20% ^pink;Ice ^cyan;Res^gray;, ^pink;Frost ^cyan;Immunity^gray;, ^white;35% ^red;Slow^gray;, ^red;Hammered^gray; (^white;30s^gray;)^reset;",
   "shortdescription": "Thelusian Fire Wine",
   "handPosition": [0, -4],
   "tooltipKind": "food",

--- a/items/generic/produce/bloodroot.consumable
+++ b/items/generic/produce/bloodroot.consumable
@@ -6,7 +6,7 @@
 	"price": 10,
 
 	"tooltipKind": "food",
-	"description": "^yellow;^reset;^cyan;+10% Physical & Knockback Res^reset;: 2m",
+	"description": "^yellow;^reset;^cyan;+10% Physical & Knockback Res.^reset;: 2m",
 	"shortdescription": "Blood Root",
 
 	"effects": [

--- a/items/generic/produce/teratomato.consumable
+++ b/items/generic/produce/teratomato.consumable
@@ -6,7 +6,7 @@
 	"price": 5,
 
 	"tooltipKind": "food",
-	"description": "^yellow;^reset;^cyan;+30% Physical & Knockback Res^reset;: 2m",
+	"description": "^yellow;^reset;^cyan;+30% Physical & Knockback Res.^reset;: 2m",
 	"shortdescription": "Teratomato",
 
 	"effects": [

--- a/monsters/boss/alienboss/alienboss.monstertype
+++ b/monsters/boss/alienboss/alienboss.monstertype
@@ -222,6 +222,9 @@
 				"poisonStatusImmunity": {
 					"baseValue": 1.0
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1.0
+				},
 				"fireStatusImmunity": {
 					"baseValue": 1.0
 				},

--- a/monsters/boss/ancientsentry/kluexsentry2.monstertype
+++ b/monsters/boss/ancientsentry/kluexsentry2.monstertype
@@ -259,6 +259,9 @@
 				"powerMultiplier": {
 					"baseValue": 1.12
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1.0
+				},
 				"fireStatusImmunity": {
 					"baseValue": 1.0
 				},

--- a/monsters/boss/apeboss/apeboss.monstertype.patch
+++ b/monsters/boss/apeboss/apeboss.monstertype.patch
@@ -36,6 +36,13 @@
   }, 
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },   
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/biooozeImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/apebossprojector/apebossprojector.monstertype.patch
+++ b/monsters/boss/apebossprojector/apebossprojector.monstertype.patch
@@ -36,6 +36,13 @@
   }, 
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },   
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/biooozeImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/crystalboss/crystalboss.monstertype.patch
+++ b/monsters/boss/crystalboss/crystalboss.monstertype.patch
@@ -31,6 +31,13 @@
 	},
 	{
 		"op": "add",
+		"path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+		"value": {
+			"baseValue": 1
+		}
+	},
+	{
+		"op": "add",
 		"path": "/baseParameters/statusSettings/stats/shadowImmunity",
 		"value": {
 			"baseValue": 1

--- a/monsters/boss/cultistboss/cultistboss.monstertype.patch
+++ b/monsters/boss/cultistboss/cultistboss.monstertype.patch
@@ -36,6 +36,13 @@
   }, 
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },   
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/biooozeImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/cultistboss/cultistbossend.monstertype.patch
+++ b/monsters/boss/cultistboss/cultistbossend.monstertype.patch
@@ -36,6 +36,13 @@
   }, 
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },  
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/biooozeImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/dollboss/dollboss.monstertype
+++ b/monsters/boss/dollboss/dollboss.monstertype
@@ -166,6 +166,9 @@
 			"penaltyBlock" : {
 			  "baseValue" : 1.0
 			},
+			"bluoplasmaStatusImmunity" : {
+			  "baseValue" : 1.0
+			},
 			"critImmunity" : {
 			  "baseValue" : 1.0
 			},

--- a/monsters/boss/dragonboss/dragonboss.monstertype.patch
+++ b/monsters/boss/dragonboss/dragonboss.monstertype.patch
@@ -29,6 +29,13 @@
   }, 
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  }, 
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/protoImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/eyeboss/eyeboss.monstertype.patch
+++ b/monsters/boss/eyeboss/eyeboss.monstertype.patch
@@ -52,6 +52,13 @@
 	},
 	{
 		"op": "add",
+		"path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+		"value": {
+			"baseValue": 1
+		}
+	},
+	{
+		"op": "add",
 		"path": "/baseParameters/statusSettings/stats/radiationburnImmunity",
 		"value": {
 			"baseValue": 1

--- a/monsters/boss/guardianboss/electricfuguardianboss.monstertype
+++ b/monsters/boss/guardianboss/electricfuguardianboss.monstertype
@@ -304,6 +304,9 @@
 				"akkimariacidStatusImmunity": {
 					"baseValue": 1
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1
+				},
 				"ucObliteratingBurnImmunity": {
 					"baseValue": 1
 				},

--- a/monsters/boss/guardianboss/electricguardianboss.monstertype.patch
+++ b/monsters/boss/guardianboss/electricguardianboss.monstertype.patch
@@ -92,6 +92,13 @@
   },
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/ffextremeheatImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/guardianboss/firefuguardianboss.monstertype
+++ b/monsters/boss/guardianboss/firefuguardianboss.monstertype
@@ -298,6 +298,9 @@
 				"akkimariacidStatusImmunity": {
 					"baseValue": 1
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1
+				},
 				"ucObliteratingBurnImmunity": {
 					"baseValue": 1
 				},

--- a/monsters/boss/guardianboss/fireguardianboss.monstertype.patch
+++ b/monsters/boss/guardianboss/fireguardianboss.monstertype.patch
@@ -29,6 +29,13 @@
   },
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/insanityImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/guardianboss/icefuguardianboss.monstertype
+++ b/monsters/boss/guardianboss/icefuguardianboss.monstertype
@@ -244,6 +244,9 @@
 				"powerMultiplier": {
 					"baseValue": 1.0
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1.0
+				},
 				"physicalResistance": {
 					"baseValue": 0.0
 				},

--- a/monsters/boss/guardianboss/iceguardianboss.monstertype.patch
+++ b/monsters/boss/guardianboss/iceguardianboss.monstertype.patch
@@ -29,6 +29,13 @@
   },
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/insanityImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/guardianboss/poisonfuguardianboss.monstertype
+++ b/monsters/boss/guardianboss/poisonfuguardianboss.monstertype
@@ -277,6 +277,9 @@
 				"healingStatusImmunity": {
 					"baseValue": 1.0
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1.0
+				},
 				"stunImmunity": {
 					"baseValue": 1.0
 				}

--- a/monsters/boss/guardianboss/poisonguardianboss.monstertype.patch
+++ b/monsters/boss/guardianboss/poisonguardianboss.monstertype.patch
@@ -92,6 +92,13 @@
   },
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/ffextremeheatImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/guardianboss/shadowfuguardianboss.monstertype
+++ b/monsters/boss/guardianboss/shadowfuguardianboss.monstertype
@@ -309,6 +309,9 @@
 				"akkimariacidStatusImmunity": {
 					"baseValue": 0.25
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1
+				},
 				"ucObliteratingBurnImmunity": {
 					"baseValue": 1
 				},

--- a/monsters/boss/guardianboss/shadowguardianboss.monstertype
+++ b/monsters/boss/guardianboss/shadowguardianboss.monstertype
@@ -279,6 +279,9 @@
 				"specialStatusImmunity": {
 					"baseValue": 1.0
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1.0
+				},
 				"healingStatusImmunity": {
 					"baseValue": 1.0
 				},

--- a/monsters/boss/guardianminion/fuguardianminion.monstertype
+++ b/monsters/boss/guardianminion/fuguardianminion.monstertype
@@ -112,36 +112,39 @@
         "stunImmunity" : {
           "baseValue" : 1.0
         },
-	"shadowResistance": {
-		"baseValue": 1
-	},
-	"cosmicResistance": {
-		"baseValue": 0.5
-	},
-	"radioactiveResistance": {
-		"baseValue": 0.25
-	},
-	"bleedingImmunity": {
-		"baseValue": 1
-	},
-	"linerifleStatusImmunity": {
-		"baseValue": 1
-	},
-	"centensianenergyStatusImmunity": {
-		"baseValue": 0.9
-	},
-	"xanafianStatusImmunity": {
-		"baseValue": 1
-	},
-	"akkimariacidStatusImmunity": {
-		"baseValue": 0.25
-	},
-	"ucObliteratingBurnImmunity": {
-		"baseValue": 1
-	},
-	"ignoreInvisibilityEffects": {
-		"baseValue": 1
-	} 
+		"shadowResistance": {
+			"baseValue": 1
+		},
+		"cosmicResistance": {
+			"baseValue": 0.5
+		},
+		"radioactiveResistance": {
+			"baseValue": 0.25
+		},
+		"bleedingImmunity": {
+			"baseValue": 1
+		},
+		"linerifleStatusImmunity": {
+			"baseValue": 1
+		},
+		"centensianenergyStatusImmunity": {
+			"baseValue": 0.9
+		},
+		"xanafianStatusImmunity": {
+			"baseValue": 1
+		},
+		"akkimariacidStatusImmunity": {
+			"baseValue": 0.25
+		},
+		"bluoplasmaStatusImmunity": {
+			"baseValue": 1
+		},
+		"ucObliteratingBurnImmunity": {
+			"baseValue": 1
+		},
+		"ignoreInvisibilityEffects": {
+			"baseValue": 1
+		} 
       },
 
       "resources" : {

--- a/monsters/boss/guardianminion/shadowrangedminion.monstertype
+++ b/monsters/boss/guardianminion/shadowrangedminion.monstertype
@@ -129,36 +129,39 @@
         "stunImmunity" : {
           "baseValue" : 1.0
         },
-	"shadowResistance": {
-		"baseValue": 1
-	},
-	"cosmicResistance": {
-		"baseValue": 0.5
-	},
-	"radioactiveResistance": {
-		"baseValue": 0.25
-	},
-	"bleedingImmunity": {
-		"baseValue": 1
-	},
-	"linerifleStatusImmunity": {
-		"baseValue": 1
-	},
-	"centensianenergyStatusImmunity": {
-		"baseValue": 0.9
-	},
-	"xanafianStatusImmunity": {
-		"baseValue": 1
-	},
-	"akkimariacidStatusImmunity": {
-		"baseValue": 0.25
-	},
-	"ucObliteratingBurnImmunity": {
-		"baseValue": 1
-	},
-	"ignoreInvisibilityEffects": {
-		"baseValue": 1
-	} 
+		"shadowResistance": {
+			"baseValue": 1
+		},
+		"cosmicResistance": {
+			"baseValue": 0.5
+		},
+		"radioactiveResistance": {
+			"baseValue": 0.25
+		},
+		"bleedingImmunity": {
+			"baseValue": 1
+		},
+		"linerifleStatusImmunity": {
+			"baseValue": 1
+		},
+		"centensianenergyStatusImmunity": {
+			"baseValue": 0.9
+		},
+		"xanafianStatusImmunity": {
+			"baseValue": 1
+		},
+		"akkimariacidStatusImmunity": {
+			"baseValue": 0.25
+		},
+		"bluoplasmaStatusImmunity": {
+			"baseValue": 1
+		},
+		"ucObliteratingBurnImmunity": {
+			"baseValue": 1
+		},
+		"ignoreInvisibilityEffects": {
+			"baseValue": 1
+		} 
       },
 
       "resources" : {

--- a/monsters/boss/infernusbot/infernusdroid.monstertype
+++ b/monsters/boss/infernusbot/infernusdroid.monstertype
@@ -365,7 +365,8 @@
         "akkimariacidResistance" : { "baseValue" : 0.9 },
         "akkimariacidStatusImmunity" : { "baseValue" : 1 },
         "ucObliteratingBurnImmunity" : { "baseValue" : 1 },
-	"specialStatusImmunity" : {"baseValue" : 1.0},
+		"bluoplasmaStatusImmunity" : {"baseValue" : 1.0},
+		"specialStatusImmunity" : {"baseValue" : 1.0},
         "ignoreInvisibilityEffects" : { "baseValue" : 1 }       
       },
 

--- a/monsters/boss/kluexboss/kluexboss.monstertype.patch
+++ b/monsters/boss/kluexboss/kluexboss.monstertype.patch
@@ -19,28 +19,35 @@
     "value": {
       "baseValue": 1
     }
-  },  
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/shadowImmunity",
     "value": {
       "baseValue": 1
     }
-  }, 
+  },
+  {
+    "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/protoImmunity",
     "value": {
       "baseValue": 1
     }
-  }, 
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/biooozeImmunity",
     "value": {
       "baseValue": 1
     }
-  },   
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/radiationburnImmunity",

--- a/monsters/boss/kluexbossstatue/kluexbossstatue.monstertype.patch
+++ b/monsters/boss/kluexbossstatue/kluexbossstatue.monstertype.patch
@@ -19,28 +19,35 @@
     "value": {
       "baseValue": 1
     }
-  },  
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/shadowImmunity",
     "value": {
       "baseValue": 1
     }
-  }, 
+  },
+  {
+    "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/protoImmunity",
     "value": {
       "baseValue": 1
     }
-  }, 
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/biooozeImmunity",
     "value": {
       "baseValue": 1
     }
-  },   
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/radiationburnImmunity",

--- a/monsters/boss/megaspider/bighairyfrankboss.monstertype
+++ b/monsters/boss/megaspider/bighairyfrankboss.monstertype
@@ -415,6 +415,9 @@
 				"ucObliteratingBurnImmunity": {
 					"baseValue": 1
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1.0
+				},
 				"specialStatusImmunity": {
 					"baseValue": 1.0
 				},

--- a/monsters/boss/megaspiderbaby/bighairyfrankbaby.monstertype
+++ b/monsters/boss/megaspiderbaby/bighairyfrankbaby.monstertype
@@ -181,10 +181,13 @@
         "poisonStatusImmunity" : {
           "baseValue" : 1.0
         },
-	"pusImmunity" : {
+		"pusImmunity" : {
           "baseValue" : 1.0
         },
-	"webstickImmunity" : {
+		"bluoplasmaStatusImmunity" : {
+          "baseValue" : 1.0
+        },
+		"webstickImmunity" : {
           "baseValue" : 1.0
         },
         "shadowResistance" : {

--- a/monsters/boss/megaspiderradbaby/bighairyfrankbabyrad.monstertype
+++ b/monsters/boss/megaspiderradbaby/bighairyfrankbabyrad.monstertype
@@ -180,10 +180,13 @@
         "poisonStatusImmunity" : {
           "baseValue" : 1.0
         },
-	"pusImmunity" : {
+		"pusImmunity" : {
           "baseValue" : 1.0
         },
-	"webstickImmunity" : {
+		"webstickImmunity" : {
+          "baseValue" : 1.0
+        },
+		"bluoplasmaStatusImmunity" : {
           "baseValue" : 1.0
         },
         "shadowResistance" : {

--- a/monsters/boss/penguinUfo/penguinUfo.monstertype.patch
+++ b/monsters/boss/penguinUfo/penguinUfo.monstertype.patch
@@ -43,6 +43,13 @@
   },   
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },   
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/radiationburnImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/precursorwarbot/precursorwarbot.monstertype
+++ b/monsters/boss/precursorwarbot/precursorwarbot.monstertype
@@ -507,6 +507,9 @@
 				"ucObliteratingBurnImmunity": {
 					"baseValue": 1
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1.0
+				},
 				"specialStatusImmunity": {
 					"baseValue": 1.0
 				},

--- a/monsters/boss/robotboss/robotboss.monstertype.patch
+++ b/monsters/boss/robotboss/robotboss.monstertype.patch
@@ -36,6 +36,13 @@
   }, 
   {
     "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },   
+  {
+    "op": "add",
     "path": "/baseParameters/statusSettings/stats/biooozeImmunity",
     "value": {
       "baseValue": 1

--- a/monsters/boss/shoggoth/shoggoth.monstertype
+++ b/monsters/boss/shoggoth/shoggoth.monstertype
@@ -293,6 +293,9 @@
 				"linerifleResistance": {
 					"baseValue": 0.9
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1
+				},
 				"linerifleStatusImmunity": {
 					"baseValue": 1
 				},

--- a/monsters/boss/shoggoth2/shoggoth2.monstertype
+++ b/monsters/boss/shoggoth2/shoggoth2.monstertype
@@ -260,6 +260,7 @@
         "physicalResistance" : { "baseValue" : 0.25 },
         "shadowResistance" : { "baseValue" : 0.9 },
         "radioactiveResistance" : { "baseValue" : 1 },
+        "bluoplasmaStatusImmunity" : { "baseValue" : 1 },
         "cosmicResistance" : { "baseValue" : 0.9 },
 		"specialStatusImmunity" : {"baseValue" : 1.0},
         "ucObliteratingBurnImmunity" : { "baseValue" : 1 }

--- a/monsters/boss/spiderboss/spiderboss.monstertype.patch
+++ b/monsters/boss/spiderboss/spiderboss.monstertype.patch
@@ -19,28 +19,35 @@
     "value": {
       "baseValue": 1
     }
-  },  
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/shadowImmunity",
     "value": {
       "baseValue": 1
     }
-  }, 
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/protoImmunity",
     "value": {
       "baseValue": 1
     }
-  }, 
+  },
+  {
+    "op": "add",
+    "path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+    "value": {
+      "baseValue": 1
+    }
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/biooozeImmunity",
     "value": {
       "baseValue": 1
     }
-  },   
+  },
   {
     "op": "add",
     "path": "/baseParameters/statusSettings/stats/radiationburnImmunity",

--- a/monsters/boss/swansong/swansong.monstertype.patch
+++ b/monsters/boss/swansong/swansong.monstertype.patch
@@ -39,6 +39,13 @@
 	},
 	{
 		"op": "add",
+		"path": "/baseParameters/statusSettings/stats/bluoplasmaStatusImmunity",
+		"value": {
+			"baseValue": 1.0
+		}
+	},
+	{
+		"op": "add",
 		"path": "/baseParameters/statusSettings/stats/radioactiveResistance",
 		"value": {
 			"baseValue": 0.6

--- a/monsters/boss/tentacleboss/tentaclecomet.monstertype
+++ b/monsters/boss/tentacleboss/tentaclecomet.monstertype
@@ -78,6 +78,7 @@
           "baseValue" : 1.0
         },
 		"specialStatusImmunity" : {"baseValue" : 1.0},
+		"bluoplasmaStatusImmunity" : {"baseValue" : 1.0},
         "healthRegen" : {
           "baseValue" : 0.0
         }

--- a/monsters/boss/warbot/warbot.monstertype
+++ b/monsters/boss/warbot/warbot.monstertype
@@ -424,6 +424,9 @@
 				"akkimariacidStatusImmunity": {
 					"baseValue": 1
 				},
+				"bluoplasmaStatusImmunity": {
+					"baseValue": 1
+				},
 				"ucObliteratingBurnImmunity": {
 					"baseValue": 1
 				},

--- a/monsters/boss/warbot/warbot2.monstertype
+++ b/monsters/boss/warbot/warbot2.monstertype
@@ -369,6 +369,7 @@
         "physicalResistance" : { "baseValue" : 0.35 },
         "shadowResistance" : { "baseValue" : 0.5 },
         "cosmicResistance" : { "baseValue" : 0.3 },
+        "bluoplasmaStatusImmunity" : { "baseValue" : 1 },
         "radioactiveResistance" : { "baseValue" : 1 },
         "ucObliteratingBurnImmunity" : { "baseValue" : 1 }
       },

--- a/scripts/unifiedGravMod.lua
+++ b/scripts/unifiedGravMod.lua
@@ -51,10 +51,11 @@ function unifiedGravMod.refreshGrav(dt)
 		local newGrav=(gravMod*self.gravMult2*(1+gravBaseMod))--new effective gravity
 		local gravNorm=((status.statPositive("fuswimming") and 0.0) or 1.0) * status.stat("gravityNorm")
 		local newGravNorm=(gravNorm~=0.0) and (((status.statPositive("fuswimming") and 0.0) or 1.0)) or 0.0
+		local createGravity=status.statPositive("createGravity")
 
-		if self.gravFlightOverride or status.statPositive("gravFlightOverride") or ((mcontroller and mcontroller.zeroG()) or (0==world.gravity(entity.position()))) then
+		if self.gravFlightOverride or status.statPositive("gravFlightOverride") or ((not createGravity) and ((mcontroller and mcontroller.zeroG()) or (0==world.gravity(entity.position())))) then
 			--nothing
-		elseif self.flying then
+		elseif createGravity or self.flying then
 			local fishbowl=((0==world.gravity(entity.position())) and 80) or (world.gravity(entity.position()))
 			--dbg("uGM.rG","Flying entity!")
 			mcontroller.addMomentum({0,-0.2*fishbowl*newGrav*dt})

--- a/scripts/unifiedGravMod.lua
+++ b/scripts/unifiedGravMod.lua
@@ -47,11 +47,11 @@ function unifiedGravMod.refreshGrav(dt)
 	if not self.ghosting then --ignore effect if ghost
 		local gravMod=(self.gravFlightOverride and -1.0) or (status.statPositive("gravFlightOverride") and 0.0) or status.stat("gravityMod")--most multipliers are gonna be this. this is where gravity increases and decreases go.
 		local gravBaseMod=status.stat("gravityBaseMod")--stuff that directly affects how much gravity effects will affect a creature.
-		--dbg("uGM.rG@first: ",{flying=self.flying,ghosting=self.ghosting,gravMod=gravMod,gravMult2=self.gravMult2,gravBaseMod=gravBaseMod,gravAt=world.gravity(entity.position())})
 		local newGrav=(gravMod*self.gravMult2*(1+gravBaseMod))--new effective gravity
 		local gravNorm=((status.statPositive("fuswimming") and 0.0) or 1.0) * status.stat("gravityNorm")
 		local newGravNorm=(gravNorm~=0.0) and (((status.statPositive("fuswimming") and 0.0) or 1.0)) or 0.0
 		local createGravity=status.statPositive("createGravity")
+		--dbg("uGM.rG@first: ",{flying=self.flying,ghosting=self.ghosting,gravMod=gravMod,gravMult2=self.gravMult2,gravBaseMod=gravBaseMod,gravAt=world.gravity(entity.position()),newGrav=newGrav,gravNorm=gravNorm,newGravNorm=newGravNorm,createGravity=createGravity})
 
 		if self.gravFlightOverride or status.statPositive("gravFlightOverride") or ((not createGravity) and ((mcontroller and mcontroller.zeroG()) or (0==world.gravity(entity.position())))) then
 			--nothing

--- a/scripts/unifiedGravMod.lua
+++ b/scripts/unifiedGravMod.lua
@@ -50,23 +50,28 @@ function unifiedGravMod.refreshGrav(dt)
 		--dbg("uGM.rG@first: ",{flying=self.flying,ghosting=self.ghosting,gravMod=gravMod,gravMult2=self.gravMult2,gravBaseMod=gravBaseMod,gravAt=world.gravity(entity.position())})
 		local newGrav=(gravMod*self.gravMult2*(1+gravBaseMod))--new effective gravity
 		local gravNorm=((status.statPositive("fuswimming") and 0.0) or 1.0) * status.stat("gravityNorm")
-		local newGravNorm=((status.statPositive("fuswimming") and 0.0) or 1.0)
+		local newGravNorm=(gravNorm~=0.0) and (((status.statPositive("fuswimming") and 0.0) or 1.0)) or 0.0
 
-		if self.gravFlightOverride or status.statPositive("gravFlightOverride") then
+		if self.gravFlightOverride or status.statPositive("gravFlightOverride") or ((mcontroller and mcontroller.zeroG()) or (0==world.gravity(entity.position()))) then
 			--nothing
-		elseif self.flying or (0==world.gravity(entity.position())) then
+		elseif self.flying then
 			local fishbowl=((0==world.gravity(entity.position())) and 80) or (world.gravity(entity.position()))
-			--dbg("uGM.rG","FLOATING!")
+			--dbg("uGM.rG","Flying entity!")
 			mcontroller.addMomentum({0,-0.2*fishbowl*newGrav*dt})
 		else
 			--reduce effect of gravity modifiers if gravity normalization is in effect
-			newGravNorm=newGravNorm*(newGrav*(1.0-(0.5*math.abs(gravNorm))))*-1
+			newGravNorm=newGravNorm*(((newGravNorm~=0.0) and ((newGrav*(1.0-(0.5*math.abs(gravNorm))))*-1)) or 0)
 			newGrav=newGrav+newGravNorm+gravNorm+1.5
 			mcontroller.controlParameters({gravityMultiplier = newGrav})
 		end
 		--dbg("uGM.rG@end",{flying=self.flying,ghosting=self.ghosting,gravMod=gravMod,newGrav=newGrav,gravNorm=gravNorm,gravMult2=self.gravMult2,gravBaseMod=gravBaseMod,newGravNorm=newGravNorm})
 	end
 end
+
+--[[
+[18:11:15.833] [Info] uGM.rG@first: : {flying: false, gravAt: 80, gravMod: -0.5, gravMult2: 1, ghosting: false, gravBaseMod: 0}
+[18:11:15.833] [Info] uGM.rG@end: {flying: false, newGravNorm: 0.5, newGrav: 1.5, gravMod: -0.5, gravBaseMod: 0, gravMult2: 1, ghosting: false, gravNorm: 0}
+]]
 
 -- F(x)=IF(x>80,-1,IF(x<80,1,0))*120/x, F(22)=80
 function unifiedGravMod.applyGravNormalization()

--- a/stats/effects/physicalblock/physicalblock.statuseffect
+++ b/stats/effects/physicalblock/physicalblock.statuseffect
@@ -17,6 +17,6 @@
 		"/stats/effects/fu_genericStatApplier.lua"
 	],
 
-  "label" : "10% Physical Resistance",
+  "label" : "10% Physical & Knockback Resistance",
   "icon" : "/interface/statuses/defensephysical.png"
 }

--- a/stats/effects/physicalblock/physicalblock2.statuseffect
+++ b/stats/effects/physicalblock/physicalblock2.statuseffect
@@ -17,6 +17,6 @@
 		"/stats/effects/fu_genericStatApplier.lua"
 	],
 
-  "label" : "20% Physical Resistance",
+  "label" : "20% Physical & Knockback Resistance",
   "icon" : "/interface/statuses/defensephysical.png"
 }

--- a/stats/effects/physicalblock/physicalblock3.statuseffect
+++ b/stats/effects/physicalblock/physicalblock3.statuseffect
@@ -17,6 +17,6 @@
 		"/stats/effects/fu_genericStatApplier.lua"
 	],
 
-  "label" : "30% Physical Resistance",
+  "label" : "30% Physical & Knockback Resistance",
   "icon" : "/interface/statuses/defensephysical.png"
 }


### PR DESCRIPTION
added blocking stats for mkiotnt's bluoplasma status effect, which grants -1.0 (-100%) to all vanilla resistances, to bosses in FU/vanilla. stupid cheese.

updated shared cyan text (usage: nonstacking modifiers) for users of physicalblock status effect. added this shared text  to the spacepunk backpack, since it uses this status effect (saying it only grants 5% phys resistance is thus inaccurate). reduced the size of the original text somewhat to ensure this text fits.

updated physical block series' labels to indicate their knockback resistance component.

pocket anchor no longer works in 0g

further revision to unifiedGravMod. gravity modifiers no longer work if there in 0g. added handling for a 'createGravity' stat for later...but too tired to implement anything using it.