### PR TITLE
Restored some unused vanilla items.

### DIFF
--- a/recipes/furniture1/caveart3.recipe
+++ b/recipes/furniture1/caveart3.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "leather", "count" : 10 },
+    { "item" : "coalore", "count" : 2 }
+  ],
+  "output" : { "item" : "caveart3", "count" : 1 },
+  "groups" : [ "craftingfurniture", "decoration", "all" ]
+}

--- a/recipes/furniture1/ironbed.recipe
+++ b/recipes/furniture1/ironbed.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "ironbar", "count" : 12 },
+    { "item" : "fabric", "count" : 2}
+  ],
+  "output" : { "item" : "ironbed", "count" : 1 },
+  "groups" : [ "craftingfurniture", "beds", "all" ]
+}

--- a/recipes/furniture1/irondoor.recipe
+++ b/recipes/furniture1/irondoor.recipe
@@ -1,0 +1,7 @@
+{
+  "input" : [
+    { "item" : "ironbar", "count" : 4 }
+  ],
+  "output" : { "item" : "irondoor", "count" : 1 },
+  "groups" : [ "craftingfurniture", "doors", "all" ]
+}

--- a/recipes/furniture1/ironlight.recipe
+++ b/recipes/furniture1/ironlight.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "ironbar", "count" : 2 },
+    { "item" : "smallbattery", "count" : 1 }
+  ],
+  "output" : { "item" : "ironlight", "count" : 1 },
+  "groups" : [ "craftingfurniture", "lights", "all" ]
+}

--- a/recipes/furniture1/irontable.recipe
+++ b/recipes/furniture1/irontable.recipe
@@ -1,0 +1,7 @@
+{
+  "input" : [
+    { "item" : "ironbar", "count" : 6 }
+  ],
+  "output" : { "item" : "irontable", "count" : 1 },
+  "groups" : [ "craftingfurniture", "decoration", "all" ]
+}

--- a/recipes/furniture1/irontoilet.recipe
+++ b/recipes/furniture1/irontoilet.recipe
@@ -1,0 +1,7 @@
+{
+  "input" : [
+    { "item" : "ironbar", "count" : 6 }
+  ],
+  "output" : { "item" : "irontoilet", "count" : 1 },
+  "groups" : [ "craftingfurniture", "decoration", "all" ]
+}

--- a/recipes/furniture1/locker1.recipe
+++ b/recipes/furniture1/locker1.recipe
@@ -1,0 +1,7 @@
+{
+  "input" : [
+     { "item" : "ironbar", "count" : 2 }
+  ],
+  "output" : { "item" : "locker1", "count" : 1 },
+  "groups" : [ "craftingfurniture", "storage", "all" ]
+}

--- a/recipes/furniture1/locker2.recipe
+++ b/recipes/furniture1/locker2.recipe
@@ -1,0 +1,7 @@
+{
+  "input" : [
+     { "item" : "ironbar", "count" : 4 }
+  ],
+  "output" : { "item" : "locker2", "count" : 1 },
+  "groups" : [ "craftingfurniture", "storage", "all" ]
+}

--- a/recipes/furniture1/markergroundplaque.recipe
+++ b/recipes/furniture1/markergroundplaque.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "ironbar", "count" : 2 },
+    { "item" : "concretematerial", "count" : 6 }
+  ],
+  "output" : { "item" : "markergroundplaque", "count" : 1 },
+  "groups" : [ "craftingfurniture", "decoration", "all" ]
+}

--- a/recipes/furniture1/porthole.recipe
+++ b/recipes/furniture1/porthole.recipe
@@ -1,0 +1,7 @@
+{
+  "input" : [
+    { "item" : "tungstenbar", "count" : 2 }
+ 		  ],
+  "output" : { "item" : "porthole", "count" : 1 },
+  "groups" : [ "craftingfurniture", "decoration", "all" ]
+}

--- a/recipes/furniture1/woodenstand1.recipe
+++ b/recipes/furniture1/woodenstand1.recipe
@@ -1,0 +1,7 @@
+{
+  "input" : [
+    { "item" : "logblock", "count" : 1 }
+  ],
+  "output" : { "item" : "woodenstand1", "count" : 1 },
+  "groups" : [ "craftingfurniture", "decoration", "all" ]
+}

--- a/recipes/furniture1/woodenstand2.recipe
+++ b/recipes/furniture1/woodenstand2.recipe
@@ -1,0 +1,7 @@
+{
+  "input" : [
+    { "item" : "logblock", "count" : 2 }
+  ],
+  "output" : { "item" : "woodenstand2", "count" : 1 },
+  "groups" : [ "craftingfurniture", "decoration", "all" ]
+}

--- a/recipes/painting/paintingscream.recipe
+++ b/recipes/painting/paintingscream.recipe
@@ -1,0 +1,9 @@
+{
+  "input" : [
+    { "item" : "darkwoodmaterial", "count" : 5 },
+    { "item" : "canvas", "count" : 1 },
+    { "item" : "reddye", "count" : 1 }
+  ],
+  "output" : { "item" : "paintingscream", "count" : 1 },
+  "groups" : [ "paintingeasel", "all" ]
+}

--- a/recipes/wiringstation/mechanics/hylotlredalert.recipe
+++ b/recipes/wiringstation/mechanics/hylotlredalert.recipe
@@ -1,0 +1,9 @@
+{
+  "input" : [
+    { "item" : "siliconboard", "count" : 1 },
+    { "item" : "tungstenbar", "count" : 1 },
+    { "item" : "glass", "count" : 1 }
+  ],
+  "output" : { "item" : "hylotlredalert", "count" : 1 },
+  "groups" : [ "craftingwiring", "mechanics", "all" ]
+}

--- a/recipes/wiringstation/mechanics/redalert.recipe
+++ b/recipes/wiringstation/mechanics/redalert.recipe
@@ -1,0 +1,9 @@
+{
+  "input" : [
+    { "item" : "siliconboard", "count" : 1 },
+    { "item" : "goldbar", "count" : 1 },
+    { "item" : "glass", "count" : 1 }
+  ],
+  "output" : { "item" : "redalert", "count" : 1 },
+  "groups" : [ "craftingwiring", "mechanics", "all" ]
+}

--- a/recipes/wiringstation/switches/hylotlswitch.recipe
+++ b/recipes/wiringstation/switches/hylotlswitch.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "tungstenbar", "count" : 1 },
+    { "item" : "ironbar", "count" : 1 }
+  ],
+  "output" : { "item" : "hylotlswitch", "count" : 1 },
+  "groups" : [ "craftingwiring", "switches" ]
+}

--- a/zb/researchTree/fu_craftsmanship.config
+++ b/zb/researchTree/fu_craftsmanship.config
@@ -153,7 +153,7 @@
                 "position" : [160, -80],
                 "children" : [ ],
                 "price" : [["fuscienceresource", 300],["canvas", 2],["blackdye", 3]],
-                "unlocks" : [ "painteasel", "paintingrandom" ]
+                "unlocks" : [ "painteasel", "paintingrandom", "paintingscream" ]
             },
             "colony2" : {
                 "icon" : "/objects/colonysystem2/addons/hiddencameras/hiddencamerasicon.png",
@@ -174,14 +174,14 @@
                 "position" : [-80, 0],
                 "children" : [ "workbenchcopper", "workbenchiron", "workbenchbamboo", "workbenchbees", "workbenchgoodwood", "workbenchplants", "workbenchfenerox", "workbenchmantizi", "workbenchslime", "workbenchfloran", "workbenchbone", "workbenchelduu", "workbenchatropus", "workbenchskath" ],
                 "price" : [ ["fuscienceresource", 200],["darkwoodmaterial", 5],["cobblestonematerial", 5]],
-                "unlocks" : [ "craftingfurniture", "painttoolfu", "generalgoodsstore", "woodenbed", "woodenchair", "woodsupport", "woodtable", "woodendoor", "woodenverticaldoor", "woodengate", "woodencrate1", "woodencrate2", "fugallows", "fugoldstorage", "fuhaypilewheelbarrow", "fuhayrollwheelbarrow", "fuhaystackwheelbarrow", "fulargewoodencrate2", "fuokeaglitchwagon", "fuwoodstorage", "fuwoodstorage2", "fufoodstorage", "fufarmstorage", "fuwheelbarrow", "fumerchantcart", "futransportcart", "eggstraclock",  "fupoisonbox", "rockbrickmaterial", "cobblestonebrick", "darksmoothstonematerial", "fence", "crosshatch", "woodenwindow1", "woodenwindow2", "slopedstainedglass", "glassmaterial", "packeddirt", "thatch", "wicker", "wickersupport", "cabinroofing", "brickmaterial", "rooftiles", "fullwood1", "fullwood2", "woodpanelling", "woodbridge", "iceblock", "fuslopedblackglass", "fuslopedglass", "totempole1", "totempole2", "totempole3", "woodenlectoral", "retexgreenhouse", "fufeneroxstairs", "fufeneroxsupport" ]
+                "unlocks" : [ "craftingfurniture", "painttoolfu", "generalgoodsstore", "woodenbed", "woodenchair", "woodsupport", "woodtable", "woodendoor", "woodenverticaldoor", "woodengate", "woodencrate1", "woodencrate2", "fugallows", "fugoldstorage", "fuhaypilewheelbarrow", "fuhayrollwheelbarrow", "fuhaystackwheelbarrow", "fulargewoodencrate2", "fuokeaglitchwagon", "fuwoodstorage", "fuwoodstorage2", "fufoodstorage", "fufarmstorage", "fuwheelbarrow", "fumerchantcart", "futransportcart", "eggstraclock",  "fupoisonbox", "rockbrickmaterial", "cobblestonebrick", "darksmoothstonematerial", "fence", "crosshatch", "woodenwindow1", "woodenwindow2", "slopedstainedglass", "glassmaterial", "packeddirt", "thatch", "wicker", "wickersupport", "cabinroofing", "brickmaterial", "rooftiles", "fullwood1", "fullwood2", "woodpanelling", "woodbridge", "iceblock", "fuslopedblackglass", "fuslopedglass", "totempole1", "totempole2", "totempole3", "woodenlectoral", "retexgreenhouse", "fufeneroxstairs", "fufeneroxsupport", "woodenstand1", "woodenstand2" ]
             },
             "workbenchiron" : {
                 "icon" : "/objects/tiered/tier1chair/tier1chairicon.png",
                 "position" : [-120, 20],
                 "children" : [ "workbenchtungsten", "workbenchtelebrium" ],
                 "price" : [ ["fuscienceresource", 150],["ironbar", 3]],
-                "unlocks" : [ "tier1chair", "tier1door",  "concretematerial", "rustyportcullis", "tier1light", "tier1spotlight", "tier1table", "tier1bed", "ironblock", "girdermaterial", "girdirplatform", "fugirder", "blacksteelblock", "irongrating", "bars", "techhull1", "furustediron", "ebonblockmaterial", "fuironornatechandelier", "fudarkironbars", "fudarkironfence", "fudarkmetalroof", "fuglassfence", "fumetalfloortile", "fumetalgrating", "fumetalgreytile", "fumetalstairs", "furivetsupport", "fusolidsupport", "fumetalwalkway" ]
+                "unlocks" : [ "tier1chair", "tier1door",  "concretematerial", "rustyportcullis", "tier1light", "tier1spotlight", "tier1table", "tier1bed", "ironblock", "girdermaterial", "girdirplatform", "fugirder", "blacksteelblock", "irongrating", "bars", "techhull1", "furustediron", "ebonblockmaterial", "fuironornatechandelier", "fudarkironbars", "fudarkironfence", "fudarkmetalroof", "fuglassfence", "fumetalfloortile", "fumetalgrating", "fumetalgreytile", "fumetalstairs", "furivetsupport", "fusolidsupport", "fumetalwalkway", "ironbed", "irondoor", "ironlight", "irontable", "irontoilet", "markergroundplaque", "locker1", "locker2" ]
             },
             "workbenchcopper" : {
                 "icon" : "/objects/generic/fu_copperCog/fu_copperCogA.png",
@@ -202,7 +202,7 @@
                 "position" : [-160, 0],
                 "children" : [ "workbenchtitanium", "workbenchprecious", "workbenchlunari" ],
                 "price" : [ ["fuscienceresource", 150],["tungstenbar", 3]],
-                "unlocks" : [ "fulabslopedtile", "tier2chair", "tier2door", "steelgirdir2", "fujaildoor", "fufrozendoor", "retexironblock", "tier2light", "apexshiplight", "tier2table", "tier2bed", "fridge", "minifridge", "futoolbox1", "futoolbox2", "platematerial", "smoothmetal", "mediummetal", "fusteelgirdirmaterial", "chain", "fuslopedhazard", "tungstenplatform", "fuslopedtintedglass", "apexshipdetails", "slopedhullpanel", "apexshipwall", "apexshipsupport", "tinylocker", "fu_NFPA_gasoline", "fu_NFPA_precursor_fluid", "fu_NFPA_sulfuric", "fu_NFPA_uranium", "fu_staythefuckoutsign", "asphalt", "glowglassmaterial", "slopedglowglass", "slopedtintedglowglass", "retexironpipe", "fumetalpipe", "metallicbrick", "metallicbrick2", "metallicbrick3", "metallicslab", "fukirhosgirdir", "fukirhosgirdir2", "fukirhosmetalfloor", "fukirhosmetaltile", "fukirhosmetalwall", "fukirhosroof", "fukirhosstairs", "fukirhosstairs2", "fukirhossupport", "fukirhoswall", "fumetalbaseboard", "fukirhosslopedpanel", "outpostairlockrailhatchsmall", "protectorateplatform" ]
+                "unlocks" : [ "fulabslopedtile", "tier2chair", "tier2door", "steelgirdir2", "fujaildoor", "fufrozendoor", "retexironblock", "tier2light", "apexshiplight", "tier2table", "tier2bed", "fridge", "minifridge", "futoolbox1", "futoolbox2", "platematerial", "smoothmetal", "mediummetal", "fusteelgirdirmaterial", "chain", "fuslopedhazard", "tungstenplatform", "fuslopedtintedglass", "apexshipdetails", "slopedhullpanel", "apexshipwall", "apexshipsupport", "tinylocker", "fu_NFPA_gasoline", "fu_NFPA_precursor_fluid", "fu_NFPA_sulfuric", "fu_NFPA_uranium", "fu_staythefuckoutsign", "asphalt", "glowglassmaterial", "slopedglowglass", "slopedtintedglowglass", "retexironpipe", "fumetalpipe", "metallicbrick", "metallicbrick2", "metallicbrick3", "metallicslab", "fukirhosgirdir", "fukirhosgirdir2", "fukirhosmetalfloor", "fukirhosmetaltile", "fukirhosmetalwall", "fukirhosroof", "fukirhosstairs", "fukirhosstairs2", "fukirhossupport", "fukirhoswall", "fumetalbaseboard", "fukirhosslopedpanel", "outpostairlockrailhatchsmall", "protectorateplatform", "hylotlredalert", "hylotlswitch", "porthole" ]
             },
             "workbenchprecious" : {
                 "icon" : "/items/materials/treasurehoard.png",
@@ -223,7 +223,7 @@
                 "position" : [-220, -120],
                 "children" : [ ],
                 "price" : [ ["fuscienceresource", 150],["titaniumbar", 2],["goldbar", 2]],
-                "unlocks" : [ "slopedavianhullpanel", "avianmetalceiling", "avianmetalfloor", "avianmetaltrim", "avianmetaltrim2", "fukluexstatue", "fukluexstatue2", "fukluexstatue3", "fukluexstatue4", "fukluexstatue5", "fukluexstatue6"]
+                "unlocks" : [ "slopedavianhullpanel", "avianmetalceiling", "avianmetalfloor", "avianmetaltrim", "avianmetaltrim2", "fukluexstatue", "fukluexstatue2", "fukluexstatue3", "fukluexstatue4", "fukluexstatue5", "fukluexstatue6", "redalert"]
             },
             "workbenchdurasteel" : {
                 "icon" : "/objects/tiered/tier4chair/tier4chairIcon.png",
@@ -427,7 +427,7 @@
                 "position" : [-60, -25],
                 "children" : [ "workbenchthelusian" ],
                 "price" : [ ["fuscienceresource", 150],["darkwoodmaterial", 200],["goldbar", 2]],
-                "unlocks" : [ "fufloranbed", "fufloranchair", "fufloransofa", "fuflorantable", "rainforestchest", "rainforestchest2", "fufloranbath", "fufloranlamp", "fuflorandoor", "floranarmchair", "floranbed", "floranbench", "floranbookcase", "florancabinet1", "florancabinet2", "florancabinet3", "floranchandelier", "florancouch", "florancorner", "florancrate", "florancurtain", "florandesk", "florandoor", "floranlamp1", "floranlight", "floranshelf", "floransmalltable", "florantable1", "florantable2", "florantoilet" ] 
+                "unlocks" : [ "fufloranbed", "fufloranchair", "fufloransofa", "fuflorantable", "rainforestchest", "rainforestchest2", "fufloranbath", "fufloranlamp", "fuflorandoor", "floranarmchair", "floranbed", "floranbench", "floranbookcase", "florancabinet1", "florancabinet2", "florancabinet3", "floranchandelier", "florancouch", "florancorner", "florancrate", "florancurtain", "florandesk", "florandoor", "floranlamp1", "floranlight", "floranshelf", "floransmalltable", "florantable1", "florantable2", "florantoilet", "caveart3" ] 
             },
             "workbenchthelusian" : {
                 "icon" : "/objects/thelusian/thelusianbookcase/thelusianbookcaseicon.png",
@@ -685,7 +685,7 @@
     },
 
     "versions":{
-        "fu_craftsmanship" : "0.215"
+        "fu_craftsmanship" : "0.216"
     },
     "initiallyResearched" : {
         "fu_craftsmanship" : [ "BASICTRAINING" ]


### PR DESCRIPTION
Restored some unused vanilla items to be craftable.
Unlocked through Iron, Tungsten, Avian, Floran, Painting research nodes.
Some of the items have racial tags.

Workbench:
-Commemorative Marker
-Figure Cave Art (Floran)
-Flat Locker
-Porthole (Hylotl)
-Sharp bed
-Sharp door
-Sharp light
-Sharp table
-Sharp toiler
-Tall Locker
-Thin Wooden Stand
-Wide Wooden Stand

Wiring Station:
-Blue alert (Hylotl)
-Standard Lever (Hylotl)
-Warning Light (Avian)

Painting Easel:
-Screaming Painting (Human)

workbenchtungsten: "hylotlredalert", "hylotlswitch", "porthole"
workbenchiron: "ironbed", "irondoor", "ironlight", "irontable", "irontoilet", "markergroundplaque", "locker1", "locker2"
workbench1: "woodenstand1", "woodenstand2"
workbenchavian: "redalert"
workbenchfloran: "caveart3"
painting: "paintingscream"