### PR TITLE
xeno stations fix

### DIFF
--- a/items/armors/other/mercenary/mercenary.chest.patch
+++ b/items/armors/other/mercenary/mercenary.chest.patch
@@ -48,9 +48,9 @@
 			"op": "add",
 			"path": "/statusEffects",
 			"value": [
-				    "mercenarysetbonusnew",
+				    "mercenarysetbonus",
 				{
-					"stat" : "fu_mercenarysetnew_chest",
+					"stat" : "fu_mercenaryset_chest",
 					"amount" : 1
 				}
 			]

--- a/items/armors/other/mercenary/mercenary.head.patch
+++ b/items/armors/other/mercenary/mercenary.head.patch
@@ -48,9 +48,9 @@
 			"op": "add",
 			"path": "/statusEffects",
 			"value": [
-				    "mercenarysetbonusnew",
+				    "mercenarysetbonus",
 				{
-					"stat" : "fu_mercenarysetnew_head",
+					"stat" : "fu_mercenaryset_head",
 					"amount" : 1
 				}
 			]

--- a/items/armors/other/mercenary/mercenary.legs.patch
+++ b/items/armors/other/mercenary/mercenary.legs.patch
@@ -48,9 +48,9 @@
 			"op": "add",
 			"path": "/statusEffects",
 			"value": [
-				    "mercenarysetbonusnew",
+				    "mercenarysetbonus",
 				{
-					"stat" : "fu_mercenarysetnew_legs",
+					"stat" : "fu_mercenaryset_legs",
 					"amount" : 1
 				}
 			]

--- a/objects/crafting/xenostation/xenolab.object
+++ b/objects/crafting/xenostation/xenolab.object
@@ -1,76 +1,83 @@
 {
-  "objectName" : "xenostation",
-  "colonyTags" : [ "fu", "science", "scienceoutpost", "radiation" ],
-  "rarity" : "rare",
-  "printable" : false,
-  "race" : "generic",
-  "category" : "^orange;Extraction Device^reset;",
-  "price" : 450,
-  "objectType" : "container",
-  "description" : "This station is designed to pull genes from seeds for study and experimentation.",
-  "subtitle" : "Seed Extractor",
-  "shortdescription" : "^cyan;Xeno Research Lab^white;",
-  "apexDescription" : "An Xeno Research Lab.",
-  "avianDescription" : "An Xeno Research Lab.",
-  "floranDescription" : "An Xeno Research Lab.",
-  "glitchDescription" : "Identify. An Xeno Research Lab.",
-  "humanDescription" : "An Xeno Research Lab.",
-  "hylotlDescription" : "An Xeno Research Lab.",
+	"objectName": "xenostation",
+	"colonyTags": ["fu", "science", "scienceoutpost", "radiation"],
+	"rarity": "rare",
+	"printable": false,
+	"race": "generic",
+	"category": "^orange;Extraction Device^reset;",
+	"price": 450,
+	"objectType": "container",
+	"description": "This station is designed to pull genes from seeds for study and experimentation.",
+	"subtitle": "Seed Extractor",
+	"shortdescription": "^cyan;Xeno Research Lab^white;",
+	"apexDescription": "An Xeno Research Lab.",
+	"avianDescription": "An Xeno Research Lab.",
+	"floranDescription": "An Xeno Research Lab.",
+	"glitchDescription": "Identify. An Xeno Research Lab.",
+	"humanDescription": "An Xeno Research Lab.",
+	"hylotlDescription": "An Xeno Research Lab.",
 
-  "fu_stationTechLevel": 2,
-  "fu_mintick": 1,
-  "fu_timerMod" : 1,
-  
-  "lightColor" : [60, 60, 173],
+	"fu_stationTechLevel": 2,
+	"fu_mintick": 1,
+	"fu_timerMod": 1,
 
-  "inventoryIcon" : "xenostationicon.png",
-  "orientations" : [
+	"lightColor": [60, 60, 173],
 
-    {
-      "dualImage" : "xenostation.png:<color>.<frame>",
-      "imagePosition" : [0, 0],
-      "frames" : 6,
-      "animationCycle" : 3.0,
+	"inventoryIcon": "xenostationicon.png",
+	"orientations": [
 
-      "spaceScan" : 0.1,
-      "fgAnchors" : [ [0, -1] ]
-    }
-  ],
-  
-  
-  "animation" : "xenolab.animation",
-  "animationParts" : {
-    "samplingarrayanim" : "xenostation.png"
-  },
-  "scripts" : [ "/objects/generic/xenostation_common.lua",
-                "/scripts/npcToyObject.lua" ],
-  "scriptDelta" : 25,
-  "recipeGroup" : "xenostation",
-  "openSounds" : [ "/sfx/objects/locker_open.ogg" ],
-  "slotCount" : 12,
-  "uiConfig" : "/interface/xenolab/xenolab.config",
-  "frameCooldown" : 67,
-  "autoCloseCooldown" : 3600,
+		{
+			"dualImage": "xenostation.png:<color>.<frame>",
+			"imagePosition": [0, 0],
+			"frames": 6,
+			"animationCycle": 3.0,
 
-  "inputNodes" : [ [1, 1] ],
-  "outputNodes" : [ [2, 1] ],
+			"spaceScan": 0.1,
+			"fgAnchors": [
+				[0, -1]
+			]
+		}
+	],
 
-  "npcToy" : {
-    "influence" : [
-      "sink",
-      "sinkComplete"
-    ],
-    "defaultReactions" : {
-      "sink" : [
-        [1.0, "typing"]
-      ],
-      "sinkComplete" : [
-        [1.0, "smile"]
-      ]
-    },
-    "inputSlot": 3,
-    "preciseStandPositionLeft" : [-1.0, 0.0],
-    "preciseStandPositionRight" : [1.0, 0.0],
-    "maxNpcs" : 2
-  }
+
+	"animation": "xenolab.animation",
+	"animationParts": {
+		"samplingarrayanim": "xenostation.png"
+	},
+	"scripts": ["/objects/generic/xenostation_common.lua",
+		"/scripts/npcToyObject.lua"
+	],
+	"scriptDelta": 25,
+	"recipeGroup": "xenostation",
+	"openSounds": ["/sfx/objects/locker_open.ogg"],
+	"slotCount": 12,
+	"uiConfig": "/interface/xenolab/xenolab.config",
+	"frameCooldown": 67,
+	"autoCloseCooldown": 3600,
+
+	"inputNodes": [
+		[1, 1]
+	],
+	"outputNodes": [
+		[2, 1]
+	],
+	"inputSlot": 3,
+
+	"npcToy": {
+		"influence": [
+			"sink",
+			"sinkComplete"
+		],
+		"defaultReactions": {
+			"sink": [
+				[1.0, "typing"]
+			],
+			"sinkComplete": [
+				[1.0, "smile"]
+			]
+		},
+		"preciseStandPositionLeft": [-1.0, 0.0],
+		"preciseStandPositionRight": [1.0, 0.0],
+		"maxNpcs": 2
+	}
 }

--- a/objects/crafting/xenostationadvnew/xenostationadvnew.object
+++ b/objects/crafting/xenostationadvnew/xenostationadvnew.object
@@ -1,94 +1,108 @@
 {
-  "objectName" : "xenostationadvnew",
-  "rarity" : "Legendary",
-  "objectType" : "container",
-  "tooltipKind" : "container",
-  "printable" : false,
-  "description" : "A top of the line Quantum Xeno Lab for efficiently extracting genes from seeds.",
-  "shortdescription" : "^cyan;Advanced Xenolab^white;",
-  "race" : "generic",
-  "category" : "^orange;Extraction Device^reset;",
-  "price" : 1250,
+	"objectName": "xenostationadvnew",
+	"rarity": "Legendary",
+	"objectType": "container",
+	"tooltipKind": "container",
+	"printable": false,
+	"description": "A top of the line Quantum Xeno Lab for efficiently extracting genes from seeds.",
+	"shortdescription": "^cyan;Advanced Xenolab^white;",
+	"race": "generic",
+	"category": "^orange;Extraction Device^reset;",
+	"price": 1250,
 
-  "fu_stationTechLevel": 3,
-  "fu_mintick": 1,
-  "fu_timerMod" : 0,
-  
-  "lightColor" : [31, 66, 102],
-  "lightPosition" : [0, 2],
+	"fu_stationTechLevel": 3,
+	"fu_mintick": 1,
+	"fu_timerMod": 0,
 
-  "flickerPeriod" : 0.5,
-  "flickerMinIntensity" : 0.95,
-  "flickerMaxIntensity" : 1.0,
-  "flickerPeriodVariance" : 0.0,
-  "flickerIntensityVariance" : 0.0,
+	"lightColor": [31, 66, 102],
+	"lightPosition": [0, 2],
 
-  "inventoryIcon" : "xenostationadvicon.png",
-  "orientations" : [
-    {
-      "imageLayers" : [ { "image" : "xenostationadvnewlit.png:<color>.<frame>", "fullbright" : true },{ "image" : "xenostationadvnew.png:<color>.<frame>" } ],
+	"flickerPeriod": 0.5,
+	"flickerMinIntensity": 0.95,
+	"flickerMaxIntensity": 1.0,
+	"flickerPeriodVariance": 0.0,
+	"flickerIntensityVariance": 0.0,
 
-      "imagePosition" : [0, 0],
-      "frames" : 4,
-      "animationCycle" : 0.75,
-      
-      "direction" : "left",
-      "flipImages" : true,
+	"inventoryIcon": "xenostationadvicon.png",
+	"orientations": [{
+			"imageLayers": [{
+				"image": "xenostationadvnewlit.png:<color>.<frame>",
+				"fullbright": true
+			}, {
+				"image": "xenostationadvnew.png:<color>.<frame>"
+			}],
 
-      "spaceScan" : 0.1,
-      "anchors" : [ "bottom" ]
-    },
-    {
-      "imageLayers" : [ { "image" : "xenostationadvnewlit.png:<color>.<frame>", "fullbright" : true },{ "image" : "xenostationadvnew.png:<color>.<frame>" } ],
+			"imagePosition": [0, 0],
+			"frames": 4,
+			"animationCycle": 0.75,
 
-      "imagePosition" : [0, 0],
-      "frames" : 4,
-      "animationCycle" : 0.75,
-      
-      "direction" : "right",
+			"direction": "left",
+			"flipImages": true,
 
-      "spaceScan" : 0.1,
-      "anchors" : [ "bottom" ]
-    }
-  ],
-  
-  "animation" : "xenostationadvnew.animation",
-  "animationParts" : {
-    "samplingarrayanim" : "xenostationadvnewlit.png"
-  },
-  
-  "uiConfig" : "/interface/xenolab/xenolab.config",
-  "statusEffects" : [ ],
+			"spaceScan": 0.1,
+			"anchors": ["bottom"]
+		},
+		{
+			"imageLayers": [{
+				"image": "xenostationadvnewlit.png:<color>.<frame>",
+				"fullbright": true
+			}, {
+				"image": "xenostationadvnew.png:<color>.<frame>"
+			}],
 
-  "scripts" : [ "/objects/generic/xenostation_common.lua",
-                "/scripts/npcToyObject.lua" ],
-  "scriptDelta" : 12,
-  "recipeGroup" : "xenostation",
-  "openSounds" : [ "/sfx/objects/locker_open.ogg" ],
-  "slotCount" : 12,
-  "frameCooldown" : 67,
-  "autoCloseCooldown" : 3600,
-  
-  "inputNodes" : [ [1, 1] ],
-  "outputNodes" : [ [2, 1] ],
+			"imagePosition": [0, 0],
+			"frames": 4,
+			"animationCycle": 0.75,
 
-  "npcToy" : {
-    "influence" : [
-      "sink",
-      "sinkComplete"
-    ],
-    "defaultReactions" : {
-      "sink" : [
-        [1.0, "typing"]
-      ],
-      "sinkComplete" : [
-        [1.0, "smile"]
-      ]
-    },
-    "inputSlot": 3,
-    "preciseStandPositionLeft" : [-1.0, 0.0],
-    "preciseStandPositionRight" : [1.0, 0.0],
-    "maxNpcs" : 2
-  }
+			"direction": "right",
+
+			"spaceScan": 0.1,
+			"anchors": ["bottom"]
+		}
+	],
+
+	"animation": "xenostationadvnew.animation",
+	"animationParts": {
+		"samplingarrayanim": "xenostationadvnewlit.png"
+	},
+
+	"uiConfig": "/interface/xenolab/xenolab.config",
+	"statusEffects": [],
+
+	"scripts": ["/objects/generic/xenostation_common.lua",
+		"/scripts/npcToyObject.lua"
+	],
+	"scriptDelta": 12,
+	"recipeGroup": "xenostation",
+	"openSounds": ["/sfx/objects/locker_open.ogg"],
+	"slotCount": 12,
+	"frameCooldown": 67,
+	"autoCloseCooldown": 3600,
+
+	"inputNodes": [
+		[1, 1]
+	],
+	"outputNodes": [
+		[2, 1]
+	],
+	"inputSlot": 3,
+
+	"npcToy": {
+		"influence": [
+			"sink",
+			"sinkComplete"
+		],
+		"defaultReactions": {
+			"sink": [
+				[1.0, "typing"]
+			],
+			"sinkComplete": [
+				[1.0, "smile"]
+			]
+		},
+		"preciseStandPositionLeft": [-1.0, 0.0],
+		"preciseStandPositionRight": [1.0, 0.0],
+		"maxNpcs": 2
+	}
 
 }

--- a/stats/deprecated/mysterioussetbonuseffectnew.statuseffect
+++ b/stats/deprecated/mysterioussetbonuseffectnew.statuseffect
@@ -1,0 +1,10 @@
+{
+	"name" : "mysterioussetbonuseffectnew",
+	"defaultDuration" : 15,
+
+	"scripts" : [
+		
+		"deprecated.lua"
+	],
+	"scriptDelta": 60
+}

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/other/mercenarysetbonus.statuseffect
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/other/mercenarysetbonus.statuseffect
@@ -1,7 +1,7 @@
 {
-  "name" : "mercenarysetbonusnew",
+  "name" : "mercenarysetbonus",
   "defaultDuration" : 15,
-  "effectConfig":{"setName":"fu_mercenarysetnew","setStatEffects":["mercenarysetbonuseffectnew"]},
+  "effectConfig":{"setName":"fu_mercenaryset","setStatEffects":["mercenarysetbonuseffect"]},
 
   "scripts":["/stats/effects/fu_armoreffects/setbonuses_generichandler.lua"],
   "scriptDelta": 60

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/other/mercenarysetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/other/mercenarysetbonuseffect.lua
@@ -1,5 +1,5 @@
 require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
-setName="fu_mercenarysetnew"
+setName="fu_mercenaryset"
 
 weaponBonus={
 	{stat = "powerMultiplier", effectiveMultiplier = 1.05}

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/other/mercenarysetbonuseffect.statuseffect
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/other/mercenarysetbonuseffect.statuseffect
@@ -1,10 +1,9 @@
 {
-	"name" : "mysterioussetbonuseffectnew",
+	"name" : "mercenarysetbonuseffect",
 	"defaultDuration" : 15,
 
 	"scripts" : [
-		
-		"mysterioussetbonuseffect.lua"
+		"mercenarysetbonuseffect.lua"
 	],
 	"scriptDelta": 60,
 


### PR DESCRIPTION
moved 'inputslotcount' from within 'npctoy' config section in (advanced) xeno station object parameters. 

fixed vanilla mercenary set's bonus