### PR TITLE
Removed interface chips from SAIL recipe

### DIFF
--- a/recipes/fu_shipcraftingtable/functional/fu_byostechstation.recipe
+++ b/recipes/fu_shipcraftingtable/functional/fu_byostechstation.recipe
@@ -1,7 +1,8 @@
 {
   "input" : [
 	{ "item" : "tungstenbar", "count" : 3 },
-	{ "item" : "salvagetier4", "count" : 1 }
+	{ "item" : "siliconboard", "count" : 2 },
+	{ "item" : "stickofram", "count" : 1 }
   ],
   "output" : {
     "item" : "fu_byostechstation",

--- a/recipes/fu_shipcraftingtable/functional/fu_byostechstationdeco.recipe
+++ b/recipes/fu_shipcraftingtable/functional/fu_byostechstationdeco.recipe
@@ -1,7 +1,8 @@
 {
   "input" : [
 	{ "item" : "tungstenbar", "count" : 3 },
-	{ "item" : "salvagetier4", "count" : 1 }
+	{ "item" : "siliconboard", "count" : 2 },
+	{ "item" : "stickofram", "count" : 1 }
   ],
   "output" : {
     "item" : "fu_byostechstationdeco",


### PR DESCRIPTION
- SAIL consoles no longer require interface chips to craft.