### PR TITLE
Moved robot parts to robots tab

### DIFF
--- a/recipes/madness/robotarms.recipe
+++ b/recipes/madness/robotarms.recipe
@@ -9,6 +9,6 @@
     "item" : "robotarms",
     "count" : 1
   },
-  "groups" : [ "prototyper2", "chemical","all" ],
+  "groups" : [ "prototyper2", "robot", "all" ],
   "duration" : 0.01
 }

--- a/recipes/madness/robotchest.recipe
+++ b/recipes/madness/robotchest.recipe
@@ -8,6 +8,6 @@
     "item" : "robotchest",
     "count" : 1
   },
-  "groups" : [ "prototyper2", "chemical","all" ],
+  "groups" : [ "prototyper2", "robot", "all" ],
   "duration" : 0.01
 }

--- a/recipes/madness/robothead.recipe
+++ b/recipes/madness/robothead.recipe
@@ -9,6 +9,6 @@
     "item" : "robothead",
     "count" : 1
   },
-  "groups" : [ "prototyper2", "chemical","all" ],
+  "groups" : [ "prototyper2", "robot", "all" ],
   "duration" : 0.01
 }

--- a/recipes/madness/robotlegs.recipe
+++ b/recipes/madness/robotlegs.recipe
@@ -7,6 +7,6 @@
     "item" : "robotlegs",
     "count" : 1
   },
-  "groups" : [ "prototyper2", "chemical","all" ],
+  "groups" : [ "prototyper2", "robot", "all" ],
   "duration" : 0.01
 }


### PR DESCRIPTION
- Moved the recipes for the Robot Guard's parts to the robot crafting tab of the Matter Assembler.