### PR TITLE
fuzz

### DIFF
--- a/debug.macros.patch
+++ b/debug.macros.patch
@@ -1,191 +1,191 @@
 [
- [
-  {
-   "op": "test",
-   "path": "/quickstart",
-   "inverse": true
-  },
-  {
-   "op": "add",
-   "path": "/quickstart",
-   "value": [
-    "/startquest '\"combatmaneuvering1\"'",
-    "/completequest combatmaneuvering1",
-    "/startquest '\"longjump0\"'",
-    "/completequest longjump0",
-    "/startquest '\"fudistortionsphere\"'",
-    "/completequest fudistortionsphere",
-   
-    "/spawnitem craftingfarm",
-    "/spawnitem craftingfurnace",
-    "/spawnitem prototyper",
-    "/spawnitem wire",
-    "/spawnitem electromagnet",
-    "/spawnitem fu_stldrive",
-    "/spawnitem fuscienceresource 1200",
-   
-    "/giveessentialitem scanmode inspectiontool",
-   
-    "/startquest '\"fu_scienceoutpost\"'",
-    "/completequest fu_scienceoutpost",
-   
-    "/warp instanceworld:outpost"
-   ]
-  }
- ],
- [
-  {
-   "op": "test",
-   "path": "/adminstart",
-   "inverse": true
-  },
-  {
-   "op": "add",
-   "path": "/adminstart",
-   "value": [
-    "/completequest gaterepair",
-    "/startquest '\"create_matterassembler\"'",
-    "/completequest create_matterassembler",
-    "/startquest '\"outpostclue\"'",
-    "/completequest outpostclue",
-   
-    "/startquest '\"combatmaneuvering1\"'",
-    "/completequest combatmaneuvering1",
-    "/startquest '\"longjump0\"'",
-    "/completequest longjump0",
-    "/startquest '\"fudistortionsphere\"'",
-    "/completequest fudistortionsphere",
-   
-    "/startquest '\"techscientist1\"'",
-    "/completequest techscientist1",
-    "/startquest '\"techscientist2\"'",
-    "/completequest techscientist2",
-    "/startquest '\"techscientist3\"'",
-    "/completequest techscientist3",
-   
-    "/startquest '\"techscientist4\"'",
-    "/completequest techscientist4",
-    "/startquest '\"techscientist5\"'",
-    "/completequest techscientist5",
-    "/startquest '\"techscientist6\"'",
-    "/completequest techscientist6",
-   
-    "/startquest '\"human_mission1\"'",
-    "/completequest human_mission1",
-    "/startquest '\"floran_mission1\"'",
-    "/completequest floran_mission1",
-    "/startquest '\"floran_mission2\"'",
-    "/completequest floran_mission2",
-    "/startquest '\"hylotl_mission1\"'",
-    "/completequest hylotl_mission1",
-    "/startquest '\"hylotl_mission2\"'",
-    "/completequest hylotl_mission2",
-    "/startquest '\"avian_mission1\"'",
-    "/completequest avian_mission1",
-    "/startquest '\"avian_mission2\"'",
-    "/completequest avian_mission2",
-    "/startquest '\"apex_mission1\"'",
-    "/completequest apex_mission1",
-    "/startquest '\"apex_mission2\"'",
-    "/completequest apex_mission2",
-    "/startquest '\"glitch_mission1\"'",
-    "/completequest glitch_mission1",
-    "/startquest '\"glitch_mission2\"'",
-    "/completequest glitch_mission2",
-    "/startquest '\"destroyruin\"'",
-    "/completequest destroyruin",
-    "/startquest '\"mastermanipulator\"'",
-    "/completequest mastermanipulator",
-   
-    "/startquest '\"mechunlock\"'",
-    "/completequest mechunlock",
-    "/startquest '\"mechupgrade1\"'",
-    "/completequest mechupgrade1",
-    "/startquest '\"mechupgrade2\"'",
-    "/completequest mechupgrade2",
-   
-    "/startquest '\"penguin1\"'",
-    "/completequest penguin1",
-    "/startquest '\"penguin2\"'",
-    "/completequest penguin2",
-   
-    "/startquest '\"precursor_unlock\"'",
-    "/completequest precursor_unlock",
-    "/startquest '\"shoggoth_unlocknew\"'",
-    "/completequest shoggoth_unlocknew",
-   
-    "/startquest '\"alienjungle.gearup\"'",
-    "/completequest alienjungle.gearup",
-    "/startquest '\"ancienttemple.gearup\"'",
-    "/completequest ancienttemple.gearup",
-    "/startquest '\"avianhydro.gearup\"'",
-    "/completequest avianhydro.gearup",
-    "/startquest '\"evernight.gearup\"'",
-    "/completequest evernight.gearup",
-    "/startquest '\"forestoffae.gearup\"'",
-    "/completequest forestoffae.gearup",
-    "/startquest '\"grandarena.gearup\"'",
-    "/completequest grandarena.gearup",
-    "/startquest '\"infiltration.gearup\"'",
-    "/completequest infiltration.gearup",
-    "/startquest '\"japaneseruins.gearup\"'",
-    "/completequest japaneseruins.gearup",
-    "/startquest '\"letheiafacility.gearup\"'",
-    "/completequest letheiafacility.gearup",
-    "/startquest '\"lethialabs.gearup\"'",
-    "/completequest lethialabs.gearup",
-    "/startquest '\"magickaforest.gearup\"'",
-    "/completequest magickaforest.gearup",
-    "/startquest '\"pavillion.gearup\"'",
-    "/completequest pavillion.gearup",
-    "/startquest '\"penguinhighway.gearup\"'",
-    "/completequest penguinhighway.gearup",
-    "/startquest '\"skytemple.gearup\"'",
-    "/completequest skytemple.gearup",
-    "/startquest '\"snowcrash.gearup\"'",
-    "/completequest snowcrash.gearup",
-    "/startquest '\"sunsetriders.gearup\"'",
-    "/completequest sunsetriders.gearup",
-    "/startquest '\"towerinvincible.gearup\"'",
-    "/completequest towerinvincible.gearup",
-    "/startquest '\"verdantruins.gearup\"'",
-    "/completequest verdantruins.gearup",
-   
-    "/setuniverseflag outpost_mission1",
-    "/setuniverseflag outpost_mission2",
-    "/setuniverseflag outpost_mission3",
-    "/setuniverseflag outpost_mission4",
-    "/setuniverseflag outpost_mission5",
-    "/setuniverseflag outpost_mission6",
-    "/setuniverseflag outpost_techscientist1",
-    "/setuniverseflag outpost_techscientist2",
-    "/setuniverseflag outpostpenguinscientist",
-    "/setuniverseflag iamadeveloperoracheater",
-   
-    "/giveessentialitem fumastermanipulator beamaxe",
-    "/giveessentialitem wiretool wiretool",
-    "/giveessentialitem painttool painttool",
-    "/giveessentialitem scanmode inspectiontool",
-   
-    "/startquest '\"fu_scienceoutpost\"'",
-    "/completequest fu_scienceoutpost",
-   
-    "/warp instanceworld:outpost"
-   ]
-  }
- ],
- [
-  {
-   "op": "test",
-   "path": "/scienceoutpost",
-   "inverse": true
-  },
-  {
-   "op": "add",
-   "path": "/scienceoutpost",
-   "value": [
-    "/warp instanceworld:scienceoutpost"
-   ]
-  }
- ]
+	[
+		{
+			"op": "test",
+			"path": "/fuquickstart",
+			"inverse": true
+		},
+		{
+			"op": "add",
+			"path": "/fuquickstart",
+			"value": [
+				"/startquest '\"combatmaneuvering1\"'",
+				"/completequest combatmaneuvering1",
+				"/startquest '\"longjump0\"'",
+				"/completequest longjump0",
+				"/startquest '\"fudistortionsphere\"'",
+				"/completequest fudistortionsphere",
+
+				"/spawnitem craftingfarm",
+				"/spawnitem craftingfurnace",
+				"/spawnitem prototyper",
+				"/spawnitem wire",
+				"/spawnitem electromagnet",
+				"/spawnitem fu_stldrive",
+				"/spawnitem fuscienceresource 1200",
+
+				"/giveessentialitem scanmode inspectiontool",
+
+				"/startquest '\"fu_scienceoutpost\"'",
+				"/completequest fu_scienceoutpost",
+
+				"/warp instanceworld:outpost"
+			]
+		}
+	],
+	[
+		{
+			"op": "test",
+			"path": "/fuadminstart",
+			"inverse": true
+		},
+		{
+			"op": "add",
+			"path": "/fuadminstart",
+			"value": [
+				"/completequest gaterepair",
+				"/startquest '\"create_matterassembler\"'",
+				"/completequest create_matterassembler",
+				"/startquest '\"outpostclue\"'",
+				"/completequest outpostclue",
+
+				"/startquest '\"combatmaneuvering1\"'",
+				"/completequest combatmaneuvering1",
+				"/startquest '\"longjump0\"'",
+				"/completequest longjump0",
+				"/startquest '\"fudistortionsphere\"'",
+				"/completequest fudistortionsphere",
+
+				"/startquest '\"techscientist1\"'",
+				"/completequest techscientist1",
+				"/startquest '\"techscientist2\"'",
+				"/completequest techscientist2",
+				"/startquest '\"techscientist3\"'",
+				"/completequest techscientist3",
+
+				"/startquest '\"techscientist4\"'",
+				"/completequest techscientist4",
+				"/startquest '\"techscientist5\"'",
+				"/completequest techscientist5",
+				"/startquest '\"techscientist6\"'",
+				"/completequest techscientist6",
+
+				"/startquest '\"human_mission1\"'",
+				"/completequest human_mission1",
+				"/startquest '\"floran_mission1\"'",
+				"/completequest floran_mission1",
+				"/startquest '\"floran_mission2\"'",
+				"/completequest floran_mission2",
+				"/startquest '\"hylotl_mission1\"'",
+				"/completequest hylotl_mission1",
+				"/startquest '\"hylotl_mission2\"'",
+				"/completequest hylotl_mission2",
+				"/startquest '\"avian_mission1\"'",
+				"/completequest avian_mission1",
+				"/startquest '\"avian_mission2\"'",
+				"/completequest avian_mission2",
+				"/startquest '\"apex_mission1\"'",
+				"/completequest apex_mission1",
+				"/startquest '\"apex_mission2\"'",
+				"/completequest apex_mission2",
+				"/startquest '\"glitch_mission1\"'",
+				"/completequest glitch_mission1",
+				"/startquest '\"glitch_mission2\"'",
+				"/completequest glitch_mission2",
+				"/startquest '\"destroyruin\"'",
+				"/completequest destroyruin",
+				"/startquest '\"mastermanipulator\"'",
+				"/completequest mastermanipulator",
+
+				"/startquest '\"mechunlock\"'",
+				"/completequest mechunlock",
+				"/startquest '\"mechupgrade1\"'",
+				"/completequest mechupgrade1",
+				"/startquest '\"mechupgrade2\"'",
+				"/completequest mechupgrade2",
+
+				"/startquest '\"penguin1\"'",
+				"/completequest penguin1",
+				"/startquest '\"penguin2\"'",
+				"/completequest penguin2",
+
+				"/startquest '\"precursor_unlock\"'",
+				"/completequest precursor_unlock",
+				"/startquest '\"shoggoth_unlocknew\"'",
+				"/completequest shoggoth_unlocknew",
+
+				"/startquest '\"alienjungle.gearup\"'",
+				"/completequest alienjungle.gearup",
+				"/startquest '\"ancienttemple.gearup\"'",
+				"/completequest ancienttemple.gearup",
+				"/startquest '\"avianhydro.gearup\"'",
+				"/completequest avianhydro.gearup",
+				"/startquest '\"evernight.gearup\"'",
+				"/completequest evernight.gearup",
+				"/startquest '\"forestoffae.gearup\"'",
+				"/completequest forestoffae.gearup",
+				"/startquest '\"grandarena.gearup\"'",
+				"/completequest grandarena.gearup",
+				"/startquest '\"infiltration.gearup\"'",
+				"/completequest infiltration.gearup",
+				"/startquest '\"japaneseruins.gearup\"'",
+				"/completequest japaneseruins.gearup",
+				"/startquest '\"letheiafacility.gearup\"'",
+				"/completequest letheiafacility.gearup",
+				"/startquest '\"lethialabs.gearup\"'",
+				"/completequest lethialabs.gearup",
+				"/startquest '\"magickaforest.gearup\"'",
+				"/completequest magickaforest.gearup",
+				"/startquest '\"pavillion.gearup\"'",
+				"/completequest pavillion.gearup",
+				"/startquest '\"penguinhighway.gearup\"'",
+				"/completequest penguinhighway.gearup",
+				"/startquest '\"skytemple.gearup\"'",
+				"/completequest skytemple.gearup",
+				"/startquest '\"snowcrash.gearup\"'",
+				"/completequest snowcrash.gearup",
+				"/startquest '\"sunsetriders.gearup\"'",
+				"/completequest sunsetriders.gearup",
+				"/startquest '\"towerinvincible.gearup\"'",
+				"/completequest towerinvincible.gearup",
+				"/startquest '\"verdantruins.gearup\"'",
+				"/completequest verdantruins.gearup",
+
+				"/setuniverseflag outpost_mission1",
+				"/setuniverseflag outpost_mission2",
+				"/setuniverseflag outpost_mission3",
+				"/setuniverseflag outpost_mission4",
+				"/setuniverseflag outpost_mission5",
+				"/setuniverseflag outpost_mission6",
+				"/setuniverseflag outpost_techscientist1",
+				"/setuniverseflag outpost_techscientist2",
+				"/setuniverseflag outpostpenguinscientist",
+				"/setuniverseflag iamadeveloperoracheater",
+
+				"/giveessentialitem fumastermanipulator beamaxe",
+				"/giveessentialitem wiretool wiretool",
+				"/giveessentialitem painttool painttool",
+				"/giveessentialitem scanmode inspectiontool",
+
+				"/startquest '\"fu_scienceoutpost\"'",
+				"/completequest fu_scienceoutpost",
+
+				"/warp instanceworld:outpost"
+			]
+		}
+	],
+	[
+		{
+			"op": "test",
+			"path": "/scienceoutpost",
+			"inverse": true
+		},
+		{
+			"op": "add",
+			"path": "/scienceoutpost",
+			"value": [
+				"/warp instanceworld:scienceoutpost"
+			]
+		}
+	]
 ]

--- a/items/active/shields/cuteshield.activeitem
+++ b/items/active/shields/cuteshield.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Cute Shield",
   "category" : "shield",
   "tooltipKind" : "shieldnew",
-  "description" : "^green;+5% Energy Regen, +2 Protection, Immunity: Insanity^reset;",
+  "description" : "^green;+5% Energy Regen, +2 Defense, Immunity: Insanity^reset;",
   "twoHanded" : false,
   "itemTags" : ["shield", "upgradeableWeapon", "cute","cosmic"],
 

--- a/items/active/shields/eldershield.activeitem
+++ b/items/active/shields/eldershield.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Elder Shield",
   "category" : "shield",
   "tooltipKind" : "shieldnew",  
-  "description" : "^green;+8% Energy Regen, +2 Protection, Immunity: Bio-Ooze^reset;",
+  "description" : "^green;+8% Energy Regen, +2 Defense, Immunity: Bio-Ooze^reset;",
   "twoHanded" : false,
   "itemTags" : ["shield", "upgradeableWeapon","elder"],
 

--- a/items/active/shields/fubeeshield.activeitem
+++ b/items/active/shields/fubeeshield.activeitem
@@ -7,7 +7,7 @@
   "shortdescription" : "Queen's Shield",
   "category" : "shield",
   "tooltipKind" : "shieldnew",
-  "description" : "^green;+0.07% HP Regen, +5 Protection, Immunity: Bee Sting^reset;",
+  "description" : "^green;+0.07% HP Regen, +5 Defense, Immunity: Bee Sting^reset;",
   "twoHanded" : false,
   "itemTags" : ["shield", "upgradeableWeapon","bees"],
 

--- a/items/active/shields/gladiatorshield.activeitem
+++ b/items/active/shields/gladiatorshield.activeitem
@@ -5,7 +5,7 @@
   "level" : 3,
   "rarity" : "uncommon",
   "tooltipKind" : "shieldnew", 
-  "description" : "^green;+4 protection^reset;",
+  "description" : "^green;+4 Defense^reset;",
   "shortdescription" : "Gladiator Shield",
   "category" : "shield",
   "twoHanded" : false,

--- a/items/active/shields/shadowshield.activeitem
+++ b/items/active/shields/shadowshield.activeitem
@@ -5,7 +5,7 @@
   "level" : 5,
   "rarity" : "rare",
   "tooltipKind" : "shieldnew", 
-  "description" : "^green;+3 protection^reset;
+  "description" : "^green;+3 Defense^reset;
 ^cyan;Acid Immunity^reset;",
   "shortdescription" : "Shadow Shield",
   "category" : "shield",

--- a/items/armors/backitems/turtleshell/turtleshell.back.patch
+++ b/items/armors/backitems/turtleshell/turtleshell.back.patch
@@ -31,6 +31,6 @@
   {
     "op": "replace",
     "path": "/description",
-    "value": "A turtle shell. It's quite spacious inside! Increases protection."
+    "value": "A turtle shell. It's quite spacious inside! Increases Defense."
   }
 ]

--- a/items/augments/back/peacekeeper1.augment.patch
+++ b/items/augments/back/peacekeeper1.augment.patch
@@ -2,7 +2,7 @@
  {
   "op": "replace",
   "path": "/description",
-  "value": "An EPP module that grants +^green;2^reset; Protection and a soft light."
+  "value": "An EPP module that grants +^green;2^reset; Defense and a soft light."
  },
  {
   "op": "replace",

--- a/items/augments/back/peacekeeper2.augment.patch
+++ b/items/augments/back/peacekeeper2.augment.patch
@@ -2,7 +2,7 @@
  {
   "op": "replace",
   "path": "/description",
-  "value": "An EPP module that grants +^green;4^reset; Protection and a soft light."
+  "value": "An EPP module that grants +^green;4^reset; Defense and a soft light."
  },
  {
   "op": "replace",

--- a/items/augments/back/peacekeeper3.augment.patch
+++ b/items/augments/back/peacekeeper3.augment.patch
@@ -2,7 +2,7 @@
  {
   "op": "replace",
   "path": "/description",
-  "value": "An EPP module that grants +^green;6^reset; Protection and a soft light."
+  "value": "An EPP module that grants +^green;6^reset; Defense and a soft light."
  },
  {
   "op": "replace",

--- a/items/augments/quest/glitchartifact.augment
+++ b/items/augments/quest/glitchartifact.augment
@@ -5,7 +5,7 @@
   "category" : "eppAugment",
   "inventoryIcon" : "glitchartifacticon.png",
   "description" : "^green;+5%^reset; Shield Bash 
-^green;+12%^reset; Protection
+Defense x^green;1.2^reset;
 ^orange;Immunity to Poison^reset;",
   "shortdescription" : "The Royal Medallion",
   "tooltipKind" : "eppaugment",

--- a/items/generic/produce/neuropod.consumable
+++ b/items/generic/produce/neuropod.consumable
@@ -6,7 +6,7 @@
 	"price": 95,
 
 	"tooltipKind": "food",
-	"description": "Ingesting this 'fruit' alters your brain chemistry for a short time at the expense of defense. \n^yellow;^reset;^cyan;Research Bonus^reset;: ^cyan;+5 ^reset;,^yellow;^reset;^cyan;-50% Protection^reset;: 300s",
+	"description": "Ingesting this 'fruit' alters your brain chemistry for a short time at the expense of defense. \n^yellow;^reset;^cyan;Research Bonus^reset;: ^cyan;+5 ^reset;,^yellow;^reset;^cyan;Defense x0.5^reset;: 300s",
 	"shortdescription": "Neuropod Bulb",
 
 	"effects": [

--- a/radiomessages/fu_exploration.radiomessages
+++ b/radiomessages/fu_exploration.radiomessages
@@ -1,19 +1,19 @@
 {
   "researchBonus1" : {
     "unique" : false,
-    "text" : "You've gained a +^green;1^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will disable if you are AFK^reset;."
+    "text" : "You've gained a +^green;1^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
   },    
   "researchBonus2" : {
     "unique" : false,
-    "text" : "You've gained a +^green;2^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will disable if you are AFK^reset;."
+    "text" : "You've gained a +^green;2^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
   },
   "researchBonus3" : {
     "unique" : false,
-    "text" : "You've gained a +^green;3^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will disable if you are AFK^reset;."
+    "text" : "You've gained a +^green;3^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
   }, 
   "researchBonus4" : {
     "unique" : false,
-    "text" : "You've gained a +^green;4^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will disable if you are AFK^reset;."
+    "text" : "You've gained a +^green;4^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
   },     
   "upgrade_station" : {
     "type" : "quest",

--- a/species/apex.species.patch
+++ b/species/apex.species.patch
@@ -14,8 +14,8 @@
   ^cyan;Immune^reset;: Jungle and Mud
 
 ^orange;Environment^reset;:
-  ^green;Jungle, Primeval, Forest, Rainforest, Snow^reset; biomes: Protection x^green;1.15^reset;, Health x^green;1.1^reset;
-  ^red;Deserts, Red Desert^reset; biomes: Protection x^red;0.85^reset;, Health x^red;0.85^reset;
+  ^green;Jungle, Primeval, Forest, Rainforest, Snow^reset; biomes: Defense x^green;1.15^reset;, Health x^green;1.1^reset;
+  ^red;Deserts, Red Desert^reset; biomes: Defense x^red;0.85^reset;, Health x^red;0.85^reset;
 
 ^orange;Weapons^reset;:
   none

--- a/species/avian.species.patch
+++ b/species/avian.species.patch
@@ -17,7 +17,7 @@
   When airborne: Damage x^green;1.12^reset;
   Low to moderate wind: Air mobility
   Low wind: Health x^green;1.15^reset;, Defense x^green;1.1^reset;
-  ^red;Irradiated, Scorched, Tidewater^reset; biomes: x^red;0.8^reset; protection
+  ^red;Irradiated, Scorched, Tidewater^reset; biomes: x^red;0.8^reset; Defense
 ^orange;Weapons^reset;:
   Wand/Staff: Damage x^green;1.2^reset;, +^green;15^reset;% Resist in equipped element
   Wand + Dagger: Can fire Cosmic Blasts (^green;Energy/16^reset; dmg)

--- a/species/cat.species
+++ b/species/cat.species
@@ -22,7 +22,7 @@
   Fists, Daggers, Shortswords: +^green;1^reset;% Crit Chance
   Thrown Weapons/Grenades: Damage x^green;1.25^reset;
   Magnorb: +^green;2^reset;% Crit Chance
-  Arm Cannon: Protection & Damage  x^green;1.15^reset;
+  Arm Cannon: Defense & Damage  x^green;1.15^reset;
 
 ^red;Weaknesses^reset;:
   ^red;Resist^reset;: -^red;20^reset;% Cosmic and Electric"

--- a/species/cat.species.patch
+++ b/species/cat.species.patch
@@ -19,7 +19,7 @@
   Fists, Daggers, Shortswords: +^green;1^reset;% Crit Chance
   Thrown Weapons/Grenades: Damage x^green;1.25^reset;
   Magnorb: +^green;2^reset;% Crit Chance
-  Arm Cannon: Protection & Damage  x^green;1.15^reset;
+  Arm Cannon: Defense & Damage  x^green;1.15^reset;
 
 ^red;Weaknesses^reset;:
   ^red;Resist^reset;: -^red;20^reset;% Cosmic and Electric"

--- a/species/elunite.species.patch
+++ b/species/elunite.species.patch
@@ -21,7 +21,7 @@
 
 ^orange;Weapons^reset;:
   Boomerang/Chakram: Damage x^green;1.125^reset;
-  Swords and Daggers: +^green;2^reset; Protection
+  Swords and Daggers: +^green;2^reset; Defense
 
 ^red;Weaknesses^reset;:
   Health x^red;0.85^reset;,

--- a/species/familiar.species.patch
+++ b/species/familiar.species.patch
@@ -19,7 +19,7 @@
 
 ^orange;Weapons^reset;:
   Wand: Damage x^green;1.1^reset;, Defense x^green;1.05^reset;
-  Staff: Damage and Protection x^green;1.15^reset;
+  Staff: Damage and Defense x^green;1.15^reset;
 
 ^red;Weaknesses^reset;:
   Health x^red;0.8^reset;

--- a/species/fenerox.species.patch
+++ b/species/fenerox.species.patch
@@ -17,7 +17,7 @@
 ^orange;Environment^reset;:
   ^green;Savannah^reset;: Damage x^green;1.15^reset;
   At night, if well fed, gain +^green;15^reset;% Physical Resist and +^green;2^reset; Defense
-  ^red;Sulphuric,Slime and Tar biomes^reset;: Defense x^red;0.80^reset;
+  ^red;Sulphuric,Slime and Tar biomes^reset;: Defense x^red;0.8^reset;
 
 ^orange;Weapons^reset;:
   Spear Mastery +^green;25^reset;%

--- a/species/fenerox.species.patch
+++ b/species/fenerox.species.patch
@@ -17,7 +17,7 @@
 ^orange;Environment^reset;:
   ^green;Savannah^reset;: Damage x^green;1.15^reset;
   At night, if well fed, gain +^green;15^reset;% Physical Resist and +^green;2^reset; Defense
-  ^red;Sulphuric,Slime and Tar biomes^reset;: Protection x^red;0.80^reset;
+  ^red;Sulphuric,Slime and Tar biomes^reset;: Defense x^red;0.80^reset;
 
 ^orange;Weapons^reset;:
   Spear Mastery +^green;25^reset;%

--- a/species/floran.species.patch
+++ b/species/floran.species.patch
@@ -13,7 +13,7 @@
 
 ^orange;Environment^reset;:
   In ^green;forest-like^reset; biomes: Energy x^green;1.15^reset;
-  In ^red;barren, corrosive and frozen^reset; biomes: Protection x^red;0.8^reset;
+  In ^red;barren, corrosive and frozen^reset; biomes: Defense x^red;0.8^reset;
 
 ^orange;Weapons^reset;:
   Bow Mastery +^green;20^reset;%

--- a/species/fumantizi.species
+++ b/species/fumantizi.species
@@ -9,7 +9,7 @@
 ^orange;Diet^reset;: Omnivore
 
 ^orange;Perks^reset;:
-  +^green;20^reset; Health, +^green;5^reset; Protection, Max Food x^green;1.5^reset;
+  +^green;20^reset; Health, +^green;5^reset; Defense, Max Food x^green;1.5^reset;
   ^green;Resist^reset;: +^cyan;15^reset;% Physical,+^cyan;10^reset;% Fire, Poison & Electric, +^cyan;5^reset;% Radioactive
 
 ^orange;Environment^reset;:

--- a/species/glitch.species.patch
+++ b/species/glitch.species.patch
@@ -13,7 +13,7 @@
 
 ^orange;Environment^reset;:
   ^green;Oil/Liquid Proto/Erchius^reset;: Health & E. Regen, Energy x^green;1.25^reset;
-  ^red;Mountainous^reset; biomes: Defense x^red;0.80^reset;
+  ^red;Mountainous^reset; biomes: Defense x^red;0.8^reset;
 
 ^orange;Weapons^reset;:
   Hammer Mastery: +^green;25^reset;

--- a/species/glitch.species.patch
+++ b/species/glitch.species.patch
@@ -13,13 +13,13 @@
 
 ^orange;Environment^reset;:
   ^green;Oil/Liquid Proto/Erchius^reset;: Health & E. Regen, Energy x^green;1.25^reset;
-  ^red;Mountainous^reset; biomes: Protection x^red;0.80^reset;
+  ^red;Mountainous^reset; biomes: Defense x^red;0.80^reset;
 
 ^orange;Weapons^reset;:
   Hammer Mastery: +^green;25^reset;
   Bow Mastery: +^green;10^reset;
   1h combos increase defense by +^green;2^reset;
-  Shield (Raised): +^green;3^reset; Protection
+  Shield (Raised): +^green;3^reset; Defense
   Perfect Blocks ^green;increase damage^reset; (stacks)
   Shield Bashes ^green;restore health^reset;
 

--- a/species/hylotl.species.patch
+++ b/species/hylotl.species.patch
@@ -15,7 +15,7 @@
   In water: +^green;1500^reset; oxygen, +^green;8^reset;% Physical Resistance, Health x^green;1.12^reset;
   Rain grants slight regeneration.
   ^cyan;Swim Boost 1^reset;
-  ^red;Deserts, Red Desert^reset; biomes: Defense x^red;0.80^reset;, Health x^red;0.80^reset;
+  ^red;Deserts, Red Desert^reset; biomes: Defense x^red;0.8^reset;, Health x^red;0.8^reset;
 
 ^orange;Weapons^reset;:
   Swords: +^green;2^reset;% Crit Chance when above ^green;75^reset;% health

--- a/species/hylotl.species.patch
+++ b/species/hylotl.species.patch
@@ -15,7 +15,7 @@
   In water: +^green;1500^reset; oxygen, +^green;8^reset;% Physical Resistance, Health x^green;1.12^reset;
   Rain grants slight regeneration.
   ^cyan;Swim Boost 1^reset;
-  ^red;Deserts, Red Desert^reset; biomes: Protection x^red;0.80^reset;, Health x^red;0.80^reset;
+  ^red;Deserts, Red Desert^reset; biomes: Defense x^red;0.80^reset;, Health x^red;0.80^reset;
 
 ^orange;Weapons^reset;:
   Swords: +^green;2^reset;% Crit Chance when above ^green;75^reset;% health

--- a/species/juux.species
+++ b/species/juux.species
@@ -10,7 +10,7 @@
 
 ^orange;Perks^reset;:
   Energy x^green;1.1^reset;
-  ^green;Resist^reset;: +^cyan;30^reset;% Mental Protection, +^cyan;20^reset;% Fire & Electric, +^cyan;15^reset;% Cosmic & Radioactive 
+  ^green;Resist^reset;: +^cyan;30^reset;% Mental Defense, +^cyan;20^reset;% Fire & Electric, +^cyan;15^reset;% Cosmic & Radioactive 
   ^cyan;Immune^reset;: Burning
   Tech: ^green;Psionic Wave^reset;
 

--- a/species/juux.species
+++ b/species/juux.species
@@ -10,7 +10,7 @@
 
 ^orange;Perks^reset;:
   Energy x^green;1.1^reset;
-  ^green;Resist^reset;: +^cyan;30^reset;% Mental Defense, +^cyan;20^reset;% Fire & Electric, +^cyan;15^reset;% Cosmic & Radioactive 
+  ^green;Resist^reset;: +^cyan;30^reset;% Mental, +^cyan;20^reset;% Fire & Electric, +^cyan;15^reset;% Cosmic & Radioactive 
   ^cyan;Immune^reset;: Burning
   Tech: ^green;Psionic Wave^reset;
 

--- a/species/kineptic.species.patch
+++ b/species/kineptic.species.patch
@@ -11,6 +11,6 @@
   +^green;10% Speed, +10% Jump, +20% Ice Resist, +20% Poison Resist^reset;
   ^green;During the night, shadowy power restores your health^reset;
   Wand/Staff: +^green;25% Damage. Also gain E. Regen increase^reset;
-  Quarterstaff: +^green;15% Damage , +3 Protection^reset;"
+  Quarterstaff: +^green;15% Damage , +3 Defense^reset;"
     }
 ]

--- a/species/kineptic.species.patch
+++ b/species/kineptic.species.patch
@@ -10,7 +10,7 @@
   -^red;5% Energy, 25% Weakness: Shadow, 15% Weakness: Electric^reset;
   +^green;10% Speed, +10% Jump, +20% Ice Resist, +20% Poison Resist^reset;
   ^green;During the night, shadowy power restores your health^reset;
-  Wand/Staff: +^green;25% Damage. Also gain E. Regen increase^reset;
-  Quarterstaff: +^green;15% Damage , +3 Defense^reset;"
+  Wand/Staff: +^green;25^reset;% Damage & E. Regen, -^reset;50^reset;% E. Regen Block 
+  Quarterstaff: +^green;15^reset;% Damage, +^green;3^reset; Defense"
     }
 ]

--- a/species/kyani.species.patch
+++ b/species/kyani.species.patch
@@ -7,7 +7,7 @@
 Diet: Anything
 
 ^orange;Perks^reset;:
-^green;+15%^reset; Health, ^green;+35%^reset; Energy, ^green;+8^reset; Protection
+^green;+15%^reset; Health, ^green;+35%^reset; Energy, ^green;+8^reset; Defense
 Resists: ^green;+30%^reset; Physical, ^green;+40%^reset; Fire, ^green;+10%^reset; Poison resistances.
 Immune: Burning, Oxygen
 

--- a/species/mantid.species.patch
+++ b/species/mantid.species.patch
@@ -21,7 +21,7 @@
 
 ^orange;Weapons^reset;:
   Fist: Damage x^green;1.2^reset;, +^green;50^reset;% Knockback Resist
-  Dual Fist: +^green;2.5^reset;% Crit Chance, +^green;5^reset; Protection
+  Dual Fist: +^green;2.5^reset;% Crit Chance, +^green;5^reset; Defense
   Shotgun: Damage x^green;1.15^reset;, Energy x^green;1.25^reset;
 
 ^red;Weaknesses^reset;:

--- a/species/mantizi.species.patch
+++ b/species/mantizi.species.patch
@@ -6,7 +6,7 @@
 ^orange;Diet^reset;: Omnivore
 
 ^orange;Perks^reset;:
-  +^green;20^reset; Health, +^green;5^reset; Protection, Max Food x^green;1.5^reset;
+  +^green;20^reset; Health, +^green;5^reset; Defense, Max Food x^green;1.5^reset;
   ^green;Resist^reset;: +^cyan;15^reset;% Physical,+^cyan;10^reset;% Fire, Poison & Electric, +^cyan;5^reset;% Radioactive
 
 ^orange;Environment^reset;:

--- a/species/merrkin.species.patch
+++ b/species/merrkin.species.patch
@@ -18,7 +18,7 @@
 
 ^orange;Weapons^reset;:
   Spear/Trident: Damage x^green;1.2^reset; when above ^green;75^reset;% health
-  Spear/Trident/Shortspear: +^green;8^reset;% Speed, +^green;4^reset; Protection, +^green;1^reset;% Crit
+  Spear/Trident/Shortspear: +^green;8^reset;% Speed, +^green;4^reset; Defense, +^green;1^reset;% Crit
 
 
 ^red;Weaknesses^reset;:

--- a/species/nightar.species
+++ b/species/nightar.species
@@ -73,7 +73,7 @@
 	    { "item" : "yorunoyumi" },
 	    { "item" : "nightarhealingaugment" },
 	    { "item" : "nightarhealthaugment" },
-	    { "item" : "nightarheatprotectionback" },
+	    { "item" : "nightarheatDefenseback" },
       { "item" : "glitchtier1head" },
       { "item" : "glitchtier1chest" },
       { "item" : "glitchtier1pants" },

--- a/species/radien.species
+++ b/species/radien.species
@@ -9,7 +9,7 @@
 ^orange;Diet^reset;: Any, including prepared Isotopes.
 
 ^orange;Perks^reset;:
-  Health x^green;1.1^reset;, Energy x^green;1.2^reset;, Protection x^green;1.03^reset;
+  Health x^green;1.1^reset;, Energy x^green;1.2^reset;, Defense x^green;1.03^reset;
   ^green;Resist^reset;: +^cyan;35^reset;% Radiation, +^cyan;10^reset;% Poison, +^cyan;5^reset;% Mental, +^cyan;5^reset;% Cosmic
   Tech: Seed Bulb
   ^cyan;Immune^reset;: Radiation Burn

--- a/species/remorian.species.patch
+++ b/species/remorian.species.patch
@@ -28,7 +28,7 @@
   Wands/Staves: Damage & Energy x^green;1.08^reset;
   Broadswords/Shortswords/Daggers: Damage x^green;1.15^reset;, +^green;5^reset;% Crit Chance
   Dual Wield Daggers: +^green;8^reset;% Crit Chance, +^green;25^reset;% Crit Damage, +^green;8^reset;% Speed
-  Shortsword + Shield: +^green;8^reset; Protection, -^red;10^reset;% Speed
+  Shortsword + Shield: +^green;8^reset; Defense, -^red;10^reset;% Speed
 
 ^red;Weaknesses^reset;:
   Health x^red;0.95^reset;, Defense x^red;0.9^reset;, +^red;5^reset;% Hunger Drain

--- a/species/shade.species.patch
+++ b/species/shade.species.patch
@@ -15,8 +15,8 @@
 ^orange;Environment^reset;:
   ^green;Dark^reset; biomes grant +^green;2^reset; Crit Chance, Energy x^green;1.15^reset;
   Glows in Dark
-  Darkness increases power and protection. Light reduces it.
-  ^red;Chromatic^reset; biomes: x^red;0.8^reset;% Protection, x^red;0.75^reset;% Health
+  Darkness increases power and Defense. Light reduces it.
+  ^red;Chromatic^reset; biomes: x^red;0.8^reset;% Defense, x^red;0.75^reset;% Health
 
 ^orange;Weapons^reset;:
   Scythe Mastery: +^green;25^reset;%

--- a/species/shade.species.patch
+++ b/species/shade.species.patch
@@ -16,7 +16,7 @@
   ^green;Dark^reset; biomes grant +^green;2^reset; Crit Chance, Energy x^green;1.15^reset;
   Glows in Dark
   Darkness increases power and Defense. Light reduces it.
-  ^red;Chromatic^reset; biomes: x^red;0.8^reset;% Defense, x^red;0.75^reset;% Health
+  ^red;Chromatic^reset; biomes: Defense x^red;0.8^reset;, Health x^red;0.75^reset;
 
 ^orange;Weapons^reset;:
   Scythe Mastery: +^green;25^reset;%

--- a/species/shadow.species.patch
+++ b/species/shadow.species.patch
@@ -15,8 +15,8 @@
 ^orange;Environment^reset;:
   ^green;Dark^reset; biomes grant +^green;2^reset; Crit Chance, Energy x^green;1.15^reset;
   Glows in Dark
-  Darkness increases power and protection. Light reduces it.
-  ^red;Chromatic^reset; biomes: x^red;0.8^reset;% Protection, x^red;0.75^reset;% Health
+  Darkness increases power and Defense. Light reduces it.
+  ^red;Chromatic^reset; biomes: x^red;0.8^reset;% Defense, x^red;0.75^reset;% Health
 
 ^orange;Weapons^reset;:
   Scythe Mastery: +^green;25^reset;%

--- a/species/shadow.species.patch
+++ b/species/shadow.species.patch
@@ -16,7 +16,7 @@
   ^green;Dark^reset; biomes grant +^green;2^reset; Crit Chance, Energy x^green;1.15^reset;
   Glows in Dark
   Darkness increases power and Defense. Light reduces it.
-  ^red;Chromatic^reset; biomes: x^red;0.8^reset;% Defense, x^red;0.75^reset;% Health
+  ^red;Chromatic^reset; biomes: Defense x^red;0.8^reset;, Health x^red;0.75^reset;
 
 ^orange;Weapons^reset;:
   Scythe Mastery: +^green;25^reset;%

--- a/species/skath.species
+++ b/species/skath.species
@@ -8,7 +8,7 @@
   ^orange;Diet^reset;: Omnivore
 
 ^orange;Perks^reset;:
-  Energy x^green;1.05^reset;, +^green;5^reset; Protection, +^green;500^reset; Breath
+  Energy x^green;1.05^reset;, +^green;5^reset; Defense, +^green;500^reset; Breath
   ^green;Resist^reset;: +^cyan;20^reset;% Ice, +^cyan;10^reset;% Radioactive
   ^cyan;Swim Boost 2^reset;
 

--- a/species/thelusian.species
+++ b/species/thelusian.species
@@ -9,7 +9,7 @@
 ^orange;Diet^reset;: Carnivore
 
 ^orange;Perks^reset;:
-  Health x^green;1.25^reset;, +^green;8^reset; Protection, Fall Damage x^green;0.4^reset;
+  Health x^green;1.25^reset;, +^green;8^reset; Defense, Fall Damage x^green;0.4^reset;
   ^green;Resist^reset;: +^cyan;30^reset;% Mental, +^cyan;15^reset;% Physical, +^cyan;20^reset;% Radiaoactive
   ^cyan;Immune^reset;: Insanity
   Tech: ^green;Warrior Instincts^reset;

--- a/species/vulpes.species.patch
+++ b/species/vulpes.species.patch
@@ -16,7 +16,7 @@
   ^cyan;Immune^reset;: Jungle Dirt
 
 ^orange;Weapons^reset;:
-  Dagger/Shortsword/Broadsword: +^green;2^reset; Protection
+  Dagger/Shortsword/Broadsword: +^green;2^reset; Defense
   Whip: Damage x^green;1.12^reset;
   Gun: Damage x^green;1.08^reset;
   Perfect Block: Grants Damage and Defense

--- a/species/woggle.species.patch
+++ b/species/woggle.species.patch
@@ -15,8 +15,8 @@
   Atropus biomes: Health x^red;0.8^reset; and -^red;20^reset;% E. Regen
 
 ^orange;Weapons^reset;:
-  Wands: Damage & Protection x^green;1.05^reset;
-  Staves: Damage & Protection x^green;1.1^reset;
+  Wands: Damage & Defense x^green;1.05^reset;
+  Staves: Damage & Defense x^green;1.1^reset;
 
 ^red;Weaknesses^reset;:
   ^red;Resist^reset;: -^red;10^reset;% Electric, -^red;50^reset;% Shadow, -^red;20^reset;% Physical.


### PR DESCRIPTION
prefixed quickstart and adminstart commands with 'fu', to stave off potential future conflicts

changed 'protection' term usage to 'defense' in racial descriptions, (in keeping with an earlier change that was done for text space) to maintain consistent usage. juux 'mental protection' is now just 'mental', matching other resistances (including mental on other species).
replaced 4 instances of x0.80 with x0.8, the 0 at the end was extraneous.