### PR TITLE
derp

### DIFF
--- a/stats/effects/fu_tileeffects/specialty_effects/insanity/insanity.lua
+++ b/stats/effects/fu_tileeffects/specialty_effects/insanity/insanity.lua
@@ -39,7 +39,7 @@ function update(dt)
 		self.tickTimer = self.tickTime
 		status.applySelfDamageRequest({
 			damageType = "IgnoresDef",
-			effect.addStatModifierGroup({{stat = "protection", amount = baseValue }}),
+			--effect.addStatModifierGroup({{stat = "protection", amount = baseValue }}),
 			damage = math.floor(status.resourceMax("health") * self.tickDamagePercentage) + 1,
 			damageSourceKind = "poison",
 			sourceEntityId = entity.id(),


### PR DESCRIPTION
comented out the usage of a var in insanity.lua deep within tileeffects (whose assignment was commented out due to a default of 0 and no modifier being set in the statuses, thus result in a null change) to fix the script erroring for certain insanity effects. oops.