### PR TITLE
bugfixes

### DIFF
--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -145,7 +145,7 @@ function masteries.apply(args)
 				table.insert(masteryBuffer,{stat="bowEnergyBonus", amount=(1/2)*masteries.stats.bowMastery*handMultiplier})
 				table.insert(masteryBuffer,{stat="powerMultiplier", effectiveMultiplier=1+(masteries.stats.bowMastery*handMultiplier) })
 				table.insert(masteryBuffer,{stat="arrowSpeedMultiplier", effectiveMultiplier=1+(masteries.stats.bowMastery*handMultiplier) })
-				table.insert(masteries.vars.controlModifiers,{speedModifier=1+(masteries.stats.bowMastery*handMultiplier/16) })
+				table.insert(masteries.vars.controlModifiers,{speedModifier=1+(masteries.stats.bowMastery*handMultiplier/8) })
 			end
 
 			--whips: damage, crit chance/damage
@@ -416,6 +416,7 @@ function masteries.apply(args)
 				end
 			end
 			--sb.logInfo("buffer %s %s",currentHand,masteries.declutter(masteryBuffer))
+			--sb.logInfo("%s ephemeralEffects %s controlModifiers %s",currentHand,masteries.vars.ephemeralEffects,masteries.vars.controlModifiers)
 			status.setPersistentEffects("masteryBonus"..currentHand,masteries.declutter(masteryBuffer))
 		end
 	end
@@ -573,6 +574,7 @@ function masteries.listenerBonuses(notifications,dt)
 		world.sendEntityMessage(entity.id(),"recordFUPersistentEffect","listenerMasteryBonus")
 	end
 end
+--end listener bonuses
 
 function masteries.load(dt)
 	--load mastery stats by forced lowercase tag (tagCaching forces lowercase). streamlines shit.

--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -415,7 +415,7 @@ function masteries.apply(args)
 					table.insert(masteryBuffer,{stat="powerMultiplier", effectiveMultiplier=1+(masteries.stats.broadswordMastery*handMultiplier/3) })
 				end
 			end
-			--sb.logInfo("buffer %s %s",currentHand,masteries.declutter(masteryBuffer))
+			--sb.logInfo("%s masteryBuffer (decluttered) %s",currentHand,masteries.declutter(masteryBuffer))
 			--sb.logInfo("%s ephemeralEffects %s controlModifiers %s",currentHand,masteries.vars.ephemeralEffects,masteries.vars.controlModifiers)
 			status.setPersistentEffects("masteryBonus"..currentHand,masteries.declutter(masteryBuffer))
 		end

--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -618,19 +618,19 @@ function masteries.update(dt)
 
 	--if weapon changed, then the script will do more update stuff
 	if (tagCaching.primaryTagCacheItemChanged)then
-		sb.logInfo("primary changed to %s",tagCaching.primaryTagCacheItem)
+		--sb.logInfo("primary changed to %s",tagCaching.primaryTagCacheItem)
 		masteries.clearHand("primary")
 		args.primaryChanged=true
 	elseif (masteries.vars.primaryComboStepOld~=masteries.vars.primaryComboStep) then
-		sb.logInfo("primary combo step changed to %s from %s",masteries.vars.primaryComboStepOld,masteries.vars.primaryComboStep)
+		--sb.logInfo("primary combo step changed to %s from %s",masteries.vars.primaryComboStepOld,masteries.vars.primaryComboStep)
 		args.primaryChanged=true
 	end
 	if (tagCaching.altTagCacheItemChanged) then
-		sb.logInfo("alt changed to %s",tagCaching.altTagCacheItem)
+		--sb.logInfo("alt changed to %s",tagCaching.altTagCacheItem)
 		args.altChanged=true
 		masteries.clearHand("alt")
 	elseif (masteries.vars.altComboStepOld~=masteries.vars.altComboStep) then
-		sb.logInfo("alt combo step changed to %s from %s",masteries.vars.altComboStepOld,masteries.vars.altComboStep)
+		--sb.logInfo("alt combo step changed to %s from %s",masteries.vars.altComboStepOld,masteries.vars.altComboStep)
 		args.altChanged=true
 	end
 	masteries.load(dt)

--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -515,7 +515,7 @@ function masteries.listenerBonuses(notifications,dt)
 			end
 
 			if tagCaching.mergedCache["dagger"] then
-				masteryCalcBuffer=masteryCalcBuffer+masteries.stats.longswordMastery
+				masteryCalcBuffer=masteryCalcBuffer+masteries.stats.daggerMastery
 				masteryCounts=masteryCounts+1
 			end
 


### PR DESCRIPTION
implemented masteries.vars.ephemeralEffects and masteries.vars.controlModifiers, to hold onto sets of temporary status effects and control modifiers to apply when weapons havent changed recently
corrected a dagger section that was using longsword mastery
removed mastery multiplier from runboost duration, as it is pointless on a 0.02 second duration (and would require a bit more overhead anyway)
reduced divisor on bow mastery movespeed. bow mastery will now grant 2.5% movespeed per 20% mastery instead of 1.125%.

note: may need to implement hand multiplier on katana/dagger speed boosts, as they -do- stack. which can result in a sizable speed increase.