### PR TITLE
qwark

### DIFF
--- a/items/active/weapons/bow/abilities/bowshot.lua
+++ b/items/active/weapons/bow/abilities/bowshot.lua
@@ -47,13 +47,14 @@ end
 function BowShot:reset()
 	animator.setGlobalTag("drawFrame", "0")
 	self.weapon:setStance(self.stances.idle)
+	status.setStatusProperty(activeItem.hand().."Firing",nil)
 end
 
 function BowShot:draw()
 	self.weapon:setStance(self.stances.draw)
 
 	animator.playSound("draw")
-
+	status.setStatusProperty(activeItem.hand().."Firing",true)
 	while self.fireMode == (self.activatingFireMode or self.abilitySlot) do
 		if self.walkWhileFiring then mcontroller.controlModifiers({runningSuppressed = true}) end
 
@@ -104,6 +105,7 @@ function BowShot:fire()
 	end
 
 	self.cooldownTimer = self.cooldownTime
+	status.setStatusProperty(activeItem.hand().."Firing",false)
 end
 
 function BowShot:perfectTiming()

--- a/items/active/weapons/bow/abilities/rngbows/enhancedbowshot.lua
+++ b/items/active/weapons/bow/abilities/rngbows/enhancedbowshot.lua
@@ -8,11 +8,9 @@ NebBowShot = WeaponAbility:new()
 function NebBowShot:init()
 	self.energyPerShot = self.energyPerShot or 0
 
-	self.drawTimer= 0
-	self.bonusSpeed = math.max(-0.99,status.stat("bowDrawTimeBonus"))
-	self.bonusSpeedMult=1/(1+self.bonusSpeed)
+	self.drawTimer=0
 	self.baseDrawTime=self.drawTime
-	self.modifiedDrawTime = math.max(script.updateDt(),self.baseDrawTime*self.bonusSpeedMult)
+	self.modifiedDrawTime = math.max(script.updateDt(),self.baseDrawTime*(1/(1+math.max(-0.99,status.stat("bowDrawTimeBonus")))))
 	animator.setGlobalTag("drawFrame", "0")
 	animator.setAnimationState("bow", "idle")
 	self.cooldownTimer = 0
@@ -56,6 +54,7 @@ function NebBowShot:reset()
 	animator.stopAllSounds("draw")
 	animator.stopAllSounds("ready")
 	self.weapon:setStance(self.stances.idle)
+	status.setStatusProperty(activeItem.hand().."Firing",nil)
 end
 
 function NebBowShot:draw()
@@ -65,7 +64,8 @@ function NebBowShot:draw()
 	animator.setSoundPitch("draw", 1, self.modifiedDrawTime)
 	animator.playSound("draw", -1)
 	local readySoundPlayed = false
-
+	self.modifiedDrawTime = math.max(script.updateDt(),self.baseDrawTime*(1/(1+math.max(-0.99,status.stat("bowDrawTimeBonus")))))
+	status.setStatusProperty(activeItem.hand().."Firing",true)
 	while self.fireMode == (self.activatingFireMode or self.abilitySlot) and not status.resourceLocked("energy") do
 		if self.walkWhileFiring then
 			mcontroller.controlModifiers({runningSuppressed = true})
@@ -151,7 +151,7 @@ function NebBowShot:fire()
 	else
 		animator.setGlobalTag("drawFrame", "0")
 	end
-
+	status.setStatusProperty(activeItem.hand().."Firing",false)
 	self.cooldownTimer = self.cooldownTime
 end
 

--- a/items/active/weapons/bow/abilities/rngbows/rngbowshot.lua
+++ b/items/active/weapons/bow/abilities/rngbows/rngbowshot.lua
@@ -12,11 +12,9 @@ function NebRNGBowShot:init()
 	self.elementalType = config.getParameter("elementalType")
 	self.arrowVariant = config.getParameter("animationParts")
 
-	self.drawTimer= 0
-	self.bonusSpeed = math.max(-0.99,status.stat("bowDrawTimeBonus"))
-	self.bonusSpeedMult=1/(1+self.bonusSpeed)
+	self.drawTimer=0
 	self.baseDrawTime=self.drawTime
-	self.modifiedDrawTime = math.max(script.updateDt(),self.baseDrawTime*self.bonusSpeedMult)
+	self.modifiedDrawTime = math.max(script.updateDt(),self.baseDrawTime*(1/(1+math.max(-0.99,status.stat("bowDrawTimeBonus")))))
     
 	animator.setAnimationState("bow", "idle")
 	self.cooldownTimer = 0
@@ -60,6 +58,7 @@ function NebRNGBowShot:reset()
 	animator.stopAllSounds("draw")
 	animator.stopAllSounds("ready")
 	self.weapon:setStance(self.stances.idle)
+	status.setStatusProperty(activeItem.hand().."Firing",nil)
 end
 
 function NebRNGBowShot:draw()
@@ -71,6 +70,7 @@ function NebRNGBowShot:draw()
 	animator.playSound("draw", -1)
 	local readySoundPlayed = false
 
+	status.setStatusProperty(activeItem.hand().."Firing",true)
 	while self.fireMode == (self.activatingFireMode or self.abilitySlot) and not status.resourceLocked("energy") do
 		if self.walkWhileFiring then
 			mcontroller.controlModifiers({runningSuppressed = true})
@@ -184,6 +184,7 @@ function NebRNGBowShot:fire()
 	self.projectileParameters.periodicActions = nil
 	self.cooldownTimer = self.cooldownTime
 	animator.setGlobalTag("directives", "")
+	status.setStatusProperty(activeItem.hand().."Firing",false)
 end
 
 --Call this to check if the bow was released at the perfect moment. Bows can be configured to not use perfect timing mechanics

--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -158,10 +158,16 @@ function masteries.apply(args)
 			--daggers:dodge tech and damage boost, combo based protection and crit chance.
 			--also: when paired with another melee of any kind, grants a speed boost status effect. (why? why not just apply a control modifier?)
 			if tagCaching[currentHand.."TagCache"]["dagger"] then
+				local protectionModifier=(masteries.stats.daggerMastery/2)
+				local critModifier=0
+				if masteries.vars[currentHand.."Firing"] then
+					protectionModifier=protectionModifier+(1/(math.max(1,masteries.vars[currentHand.."ComboStep"])*4))
+					critModifier=masteries.vars[currentHand.."ComboStep"]*(1+(masteries.stats.daggerMastery*handMultiplier))
+				end
 				table.insert(masteryBuffer,{stat="dodgetechBonus", amount=0.25*(1+(masteries.stats.daggerMastery*handMultiplier)) })
 				table.insert(masteryBuffer,{stat="powerMultiplier", effectiveMultiplier=1+(masteries.stats.daggerMastery*handMultiplier/4) })
-				table.insert(masteryBuffer,{stat="protection", effectiveMultiplier=1+(((1/(math.max(1,masteries.vars[currentHand.."ComboStep"] or 1)*4))*handMultiplier)/2) })
-				table.insert(masteryBuffer,{stat="critChance", amount=(masteries.vars[currentHand.."ComboStep"] or 1)*(1+(masteries.stats.daggerMastery*handMultiplier)) })
+				table.insert(masteryBuffer,{stat="protection", effectiveMultiplier=1+(protectionModifier*handMultiplier)})
+				table.insert(masteryBuffer,{stat="critChance", amount=critModifier })
 				if tagCaching[otherHand.."TagCache"]["melee"] then
 					table.insert(masteries.vars.ephemeralEffects,{{effect="runboost5", duration=0.02}})
 				end
@@ -186,7 +192,7 @@ function masteries.apply(args)
 				local protectionModifier=0
 
 				--combo started, first hit got the crit bonus and now it resets.
-				if masteries.vars[currentHand.."ComboStep"] and (masteries.vars[currentHand.."ComboStep"] > 1) then
+				if masteries.vars[currentHand.."Firing"] and (masteries.vars[currentHand.."ComboStep"] > 1) then
 					mastery.vars[currentHand.."rapierTimerBonus"]=0
 				end
 
@@ -232,13 +238,13 @@ function masteries.apply(args)
 
 			--scythe: combo based crit damage and crit chance.
 			if tagCaching[currentHand.."TagCache"]["scythe"] then
-				table.insert(masteryBuffer,{stat="critDamage", amount=(0.05+((masteries.vars[currentHand.."ComboStep"] or 1)*0.1))*(1+masteries.stats.scytheMastery)*handMultiplier })
-				table.insert(masteryBuffer,{stat="critChance", amount=((masteries.vars[currentHand.."ComboStep"] or 0)*(1+masteries.stats.scytheMastery))*handMultiplier })
+				table.insert(masteryBuffer,{stat="critDamage", amount=(0.05+((masteries.vars[currentHand.."Firing"] and masteries.vars[currentHand.."ComboStep"] or 0)*0.1))*(1+masteries.stats.scytheMastery)*handMultiplier })
+				table.insert(masteryBuffer,{stat="critChance", amount=((masteries.vars[currentHand.."Firing"] and masteries.vars[currentHand.."ComboStep"] or 0)*(1+masteries.stats.scytheMastery))*handMultiplier })
 			end
 
 			--longswords: no baseline value, like shortspears, due to fart.
 			if tagCaching[currentHand.."TagCache"]["longsword"] then
-				if masteries.vars[currentHand.."ComboStep"] and (masteries.vars[currentHand.."ComboStep"] >=3) then
+				if masteries.vars[currentHand.."Firing"]and (masteries.vars[currentHand.."ComboStep"] >=3) then
 					table.insert(masteryBuffer,{stat="critDamage", amount=0.15*(1+masteries.stats.longswordMastery)*handMultiplier})
 				end
 				-- longsword solo, no other items: attack speed.
@@ -273,7 +279,7 @@ function masteries.apply(args)
 
 			--shortswords: combo based crit chance. other stats based on wield state.
 			if tagCaching[currentHand.."TagCache"]["shortsword"] then
-				table.insert(masteryBuffer, {stat="critChance", amount=(1+((masteries.vars[currentHand.."ComboStep"] or 1)*(1+masteries.stats.shortswordMastery)))*handMultiplier})
+				table.insert(masteryBuffer, {stat="critChance", amount=(1+((masteries.vars[currentHand.."Firing"] and masteries.vars[currentHand.."ComboStep"] or 0)*(1+masteries.stats.shortswordMastery)))*handMultiplier})
 				local powerModifier=masteries.stats.shortswordMastery*handMultiplier
 				local dodgeModifier=masteries.stats.shortswordMastery*handMultiplier
 				local dashModifier=masteries.stats.shortswordMastery*handMultiplier
@@ -307,7 +313,7 @@ function masteries.apply(args)
 			end
 
 			if tagCaching[currentHand.."TagCache"]["katana"] then
-				if masteries.vars[currentHand.."ComboStep"] and (masteries.vars[currentHand.."ComboStep"] >=1) then -- combos higher than 1 move
+				if masteries.vars[currentHand.."Firing"] and (masteries.vars[currentHand.."ComboStep"] >1) then -- combos higher than 1 move
 					table.insert(masteries.vars.controlModifiers,{speedModifier=1+((masteries.vars[currentHand.."ComboStep"]/10)*(1+masteries.stats.katanaMastery/48)) })
 				end
 				-- holding one katana with no other item: increase  defense techs, damage, protection and crit chance
@@ -341,7 +347,7 @@ function masteries.apply(args)
 				table.insert(masteryBuffer,{stat="stunChance", amount=2*masteries.stats.hammerMastery*handMultiplier})
 				table.insert(masteryBuffer,{stat="critDamage", amount=2*masteries.stats.hammerMastery*handMultiplier/2})
 				-- increased power after first strike in combo.
-				if  masteries.vars[currentHand.."ComboStep"] and (masteries.vars[currentHand.."ComboStep"] > 1) then
+				if masteries.vars[currentHand.."Firing"] and (masteries.vars[currentHand.."ComboStep"] > 1) then
 					table.insert(masteryBuffer,{stat="powerMultiplier", effectiveMultiplier=1+(0.01+(masteries.stats.hammerMastery*handMultiplier/3)) })
 				end
 				if tagCaching[otherHand.."TagCache"]["shield"] then -- if using a shield: shield bash, defense.
@@ -361,7 +367,8 @@ function masteries.apply(args)
 			if tagCaching[currentHand.."TagCache"]["fist"] or tagCaching[currentHand.."TagCache"]["fistweapon"] or tagCaching[currentHand.."TagCache"]["gauntlet"] then
 				--I hate stupid people.
 				if not masteries.stats.fistMastery then masteries.stats.fistMastery=status.stat("fistMastery") end
-				local comboStep=math.max(masteries.vars[otherHand.."ComboStep"] and (masteries.vars[otherHand.."ComboStep"]) or 0,masteries.vars[currentHand.."ComboStep"] and (masteries.vars[currentHand.."ComboStep"]) or 0)
+				--for some reason fist combos start at 0, unlike meleecombo
+				local comboStep=math.max(masteries.vars[otherHand.."ComboStep"],masteries.vars[currentHand.."ComboStep"])
 				table.insert(masteryBuffer,{stat="powerMultiplier",effectiveMultiplier=1+(masteries.stats.fistMastery*handMultiplier/2) })
 				table.insert(masteryBuffer,{stat="critChance", amount=((1*comboStep)+(2*masteries.stats.fistMastery))*handMultiplier})
 				table.insert(masteryBuffer,{stat="stunChance", amount=((4*comboStep)+(2*masteries.stats.fistMastery))*handMultiplier})
@@ -409,7 +416,7 @@ function masteries.apply(args)
 
 			--broadswords
 			if tagCaching[currentHand.."TagCache"]["broadsword"] then
-				if masteries.vars[currentHand.."ComboStep"] and (masteries.vars[currentHand.."ComboStep"] > 2) then
+				if masteries.vars[currentHand.."Firing"] and (masteries.vars[currentHand.."ComboStep"] > 2) then
 					table.insert(masteryBuffer,{stat="powerMultiplier", effectiveMultiplier=1+(masteries.stats.broadswordMastery*handMultiplier/2) })
 				else
 					table.insert(masteryBuffer,{stat="powerMultiplier", effectiveMultiplier=1+(masteries.stats.broadswordMastery*handMultiplier/3) })
@@ -417,6 +424,7 @@ function masteries.apply(args)
 			end
 			--sb.logInfo("%s masteryBuffer (decluttered) %s",currentHand,masteries.declutter(masteryBuffer))
 			--sb.logInfo("%s ephemeralEffects %s controlModifiers %s",currentHand,masteries.vars.ephemeralEffects,masteries.vars.controlModifiers)
+			--sb.logInfo("mvars %s, mpersistvars %s",masteries.vars,masteries.persistentVars)
 			status.setPersistentEffects("masteryBonus"..currentHand,masteries.declutter(masteryBuffer))
 		end
 	end
@@ -587,6 +595,7 @@ function masteries.load(dt)
 		masteries.stats.ammoMastery=status.stat("ammoMastery")
 	end
 	if not masteries.vars.heartbeat then masteries.vars.heartbeat=0 end
+
 	masteries.vars.loaded=true
 end
 
@@ -597,8 +606,15 @@ function masteries.update(dt)
 	--update tracking of combo steps for each weapon.
 	masteries.vars.primaryComboStepOld=masteries.vars.primaryComboStep
 	masteries.vars.altComboStepOld=masteries.vars.altComboStep
-	masteries.vars.primaryComboStep=status.statusProperty("primaryComboStep")
-	masteries.vars.altComboStep=status.statusProperty("altComboStep")
+	--assume default of 1 globally for combo step, as if a weapon is a combo weapon, that is the initial step. current only exception: fists. because wtf?
+	masteries.vars.primaryComboStep=status.statusProperty("primaryComboStep") or 1
+	masteries.vars.altComboStep=status.statusProperty("altComboStep") or 1
+
+	--update tracking of firing state for each weapon.
+	masteries.vars.primaryFiringOld=masteries.vars.primaryFiring
+	masteries.vars.altFiringOld=masteries.vars.altFiring
+	masteries.vars.primaryFiring=status.statusProperty("primaryFiring")
+	masteries.vars.altFiring=status.statusProperty("altFiring")
 
 	--if this segment fires i'm going to shoot someone with rusty nails from a shotgun.
 	local pType=type(masteries.vars.primaryComboStep)
@@ -618,13 +634,19 @@ function masteries.update(dt)
 		masteries.vars.altComboStep=nil
 	end
 
-	--if weapon changed, then the script will do more update stuff
+	--if weapon state changed, then the script will do more update stuff
+	--typically, weapons set combo state to 1 (Exception: below), on init, and when finishing a combo.
+	--note that fist weapons don't set their firing state. instead, their combo step sets itself to 0 when they're not attacking.
+	--firing state is only set in primary fire modes
 	if (tagCaching.primaryTagCacheItemChanged)then
 		--sb.logInfo("primary changed to %s",tagCaching.primaryTagCacheItem)
 		masteries.clearHand("primary")
 		args.primaryChanged=true
 	elseif (masteries.vars.primaryComboStepOld~=masteries.vars.primaryComboStep) then
-		--sb.logInfo("primary combo step changed to %s from %s",masteries.vars.primaryComboStepOld,masteries.vars.primaryComboStep)
+		--sb.logInfo("primary combo step changed from %s to %s",masteries.vars.primaryComboStepOld,masteries.vars.primaryComboStep)
+		args.primaryChanged=true
+	elseif (masteries.vars.primaryFiringOld~=masteries.vars.primaryFiring) then
+		--sb.logInfo("primary firing state changed from %s to %s",masteries.vars.primaryFiringOld,masteries.vars.primaryFiring)
 		args.primaryChanged=true
 	end
 	if (tagCaching.altTagCacheItemChanged) then
@@ -632,7 +654,10 @@ function masteries.update(dt)
 		args.altChanged=true
 		masteries.clearHand("alt")
 	elseif (masteries.vars.altComboStepOld~=masteries.vars.altComboStep) then
-		--sb.logInfo("alt combo step changed to %s from %s",masteries.vars.altComboStepOld,masteries.vars.altComboStep)
+		--sb.logInfo("alt combo step changed from %s to %s",masteries.vars.altComboStepOld,masteries.vars.altComboStep)
+		args.altChanged=true
+	elseif (masteries.vars.altFiringOld~=masteries.vars.altFiring) then
+		--sb.logInfo("alt firing state changed from %s to %s",masteries.vars.altFiringOld,masteries.vars.altFiring)
 		args.altChanged=true
 	end
 	masteries.load(dt)

--- a/items/active/weapons/melee/abilities/axe/axecleave.lua
+++ b/items/active/weapons/melee/abilities/axe/axecleave.lua
@@ -77,9 +77,6 @@ end
 function AxeCleave:fire()
 	self.weapon:setStance(self.stances.fire)
 	self.weapon:updateAim()
-	self.hitsListener:update()
-	self.damageListener:update()
-	self.killListener:update()
 	animator.setAnimationState("swoosh", "fire")
 	if animator.hasSound("fire") then
 		animator.playSound("fire")

--- a/items/active/weapons/melee/abilities/greataxe/greataxesmash.lua
+++ b/items/active/weapons/melee/abilities/greataxe/greataxesmash.lua
@@ -37,6 +37,7 @@ function GreataxeSmash:windup(windupProgress)
 	local windupProgress = windupProgress or 0
 	local bounceProgress = 0
 	while self.fireMode == "primary" and (self.allowHold ~= false or windupProgress < 1) do
+		status.setStatusProperty(activeItem.hand().."Firing",true)
 		if windupProgress < 1 then
 			windupProgress = math.min(1, windupProgress + (self.dt / self.stances.windup.duration))
 			self.weapon.relativeWeaponRotation, self.weapon.relativeArmRotation = self:windupAngle(windupProgress)
@@ -61,7 +62,8 @@ function GreataxeSmash:windup(windupProgress)
 			else
 				if self.timerGreataxe < 100 then --otherwise, add bonus
 					self.timerGreataxe = self.timerGreataxe + 0.5
-					status.setPersistentEffects("greataxeMasteryBonus", {{stat = "critChance", amount = ((self.timerGreataxe * 1.05) + (self.greataxeMastery/2)) },{stat = "critDamage", amount = (self.timerGreataxe/100) + (self.greataxeMastery/100)}})
+					local greataxeMastery=1+status.stat("greataxeMastery")
+					status.setPersistentEffects("greataxeMasteryBonus", {{stat = "critChance", amount = ((self.timerGreataxe * 1.05) + (greataxeMastery/2)) },{stat = "critDamage", amount = (self.timerGreataxe/100) + (greataxeMastery/100)}})
 					world.sendEntityMessage(activeItem.ownerEntityId(),"recordFUPersistentEffect","greataxeMasteryBonus")
 				end
 				if self.timerGreataxe == 100 then	--at 101, play a sound
@@ -114,9 +116,11 @@ function GreataxeSmash:winddown(windupProgress)
 		coroutine.yield()
 		self.timerGreataxe = 0
 	end
+	status.setStatusProperty(activeItem.hand().."Firing",false)
 end
 
 function GreataxeSmash:fire()
+	status.setStatusProperty(activeItem.hand().."Firing",true)
 	self.weapon:setStance(self.stances.fire)
 	self.weapon:updateAim()
 
@@ -240,4 +244,5 @@ function GreataxeSmash:uninit()
 		self.helper:clearPersistent()
 	end
 	self.blockCount = 0
+	status.setStatusProperty(activeItem.hand().."Firing",nil)
 end

--- a/items/active/weapons/melee/abilities/hammer/hammersmash.lua
+++ b/items/active/weapons/melee/abilities/hammer/hammersmash.lua
@@ -37,6 +37,7 @@ function HammerSmash:windup(windupProgress)
 	local windupProgress = windupProgress or 0
 	local bounceProgress = 0
 	while self.fireMode == "primary" and (self.allowHold ~= false or windupProgress < 1) do
+		status.setStatusProperty(activeItem.hand().."Firing",true)
 		if windupProgress < 1 then
 			windupProgress = math.min(1, windupProgress + (self.dt / self.stances.windup.duration))
 			self.weapon.relativeWeaponRotation, self.weapon.relativeArmRotation = self:windupAngle(windupProgress)
@@ -61,7 +62,8 @@ function HammerSmash:windup(windupProgress)
 			else
 				if self.timerHammer < 100 then --otherwise, add bonus
 					self.timerHammer = self.timerHammer + 0.5
-					status.setPersistentEffects("hammerMasteryBonus", {{stat = "stunChance", amount = ((self.timerHammer * 1.2) * self.hammerMastery) },{stat = "critChance", amount = (self.timerHammer * self.hammerMastery)}})
+					local hammerMastery=1+status.stat("hammerMastery")
+					status.setPersistentEffects("hammerMasteryBonus", {{stat = "stunChance", amount = ((self.timerHammer * 1.2) * hammerMastery) },{stat = "critChance", amount = (self.timerHammer * hammerMastery)}})
 					world.sendEntityMessage(activeItem.ownerEntityId(),"recordFUPersistentEffect","hammerMasteryBonus")
 				end
 				if self.timerHammer == 100 then	--at 101, play a sound
@@ -114,9 +116,11 @@ function HammerSmash:winddown(windupProgress)
 		coroutine.yield()
 		self.timerHammer = 0
 	end
+	status.setStatusProperty(activeItem.hand().."Firing",false)
 end
 
 function HammerSmash:fire()
+	status.setStatusProperty(activeItem.hand().."Firing",true)
 	self.weapon:setStance(self.stances.fire)
 	self.weapon:updateAim()
 
@@ -241,4 +245,5 @@ function HammerSmash:uninit()
 		self.helper:clearPersistent()
 	end
 	self.blockCount = 0
+	status.setStatusProperty(activeItem.hand().."Firing",nil)
 end

--- a/items/active/weapons/melee/meleecombo.lua
+++ b/items/active/weapons/melee/meleecombo.lua
@@ -121,9 +121,11 @@ function MeleeCombo:windup()
 	if (status.resource("energy") <= 1) or (not status.consumeResource("energy",self.energyTotal)) then
 		self.comboStep = 1
 		status.setStatusProperty(activeItem.hand().."ComboStep",self.comboStep)
+		status.setStatusProperty(activeItem.hand().."Firing",true)
 	else
 		self.comboStep=self.comboStep or 1
 		status.setStatusProperty(activeItem.hand().."ComboStep",self.comboStep)
+		status.setStatusProperty(activeItem.hand().."Firing",true)
 	end
 
 	local stance = self.stances["windup"..self.comboStep]
@@ -177,6 +179,7 @@ function MeleeCombo:wait()
 	end
 	self.comboStep = 1
 	status.setStatusProperty(activeItem.hand().."ComboStep",self.comboStep)
+	status.setStatusProperty(activeItem.hand().."Firing",false)
 end
 
 -- State: preslash
@@ -321,6 +324,7 @@ end
 function MeleeCombo:uninit()
 	self.comboStep = nil
 	status.setStatusProperty(activeItem.hand().."ComboStep",self.comboStep)
+	status.setStatusProperty(activeItem.hand().."Firing",nil)
 
 	if self.helper then
 		self.helper:clearPersistent()

--- a/items/active/weapons/melee/meleeslash.lua
+++ b/items/active/weapons/melee/meleeslash.lua
@@ -42,7 +42,7 @@ end
 -- State: windup
 function MeleeSlash:windup()
 	self.energyMax = math.max(status.resourceMax("energy"),0) -- due to weather and other cases it is possible to have a maximum of under 0.
-
+	status.setStatusProperty(activeItem.hand().."Firing",true)
 	local item
 	if world.entityType(activeItem.ownerEntityId()) then
 		item=world.entityHandItemDescriptor(activeItem.ownerEntityId(),activeItem.hand())
@@ -140,6 +140,7 @@ function MeleeSlash:fire()
 
 	-- FR cooldown modifiers
 	self.cooldownTimer = math.max(0, self.cooldownTimer * attackSpeedUp )	-- subtract FR bonus from total
+	status.setStatusProperty(activeItem.hand().."Firing",nil)
 end
 
 function MeleeSlash:cooldownTime()
@@ -148,4 +149,5 @@ end
 
 function MeleeSlash:uninit()--this function is almost never called. so persistent status effects based on it are...dodo.
 	self.weapon:setDamage()
+	status.setStatusProperty(activeItem.hand().."Firing",nil)
 end


### PR DESCRIPTION
bugfix for axes, listener updates now removed.

implemented current hand 'firing' status properties for bowshot (normal, enh, rng), meleecombo, meleeslash, greataxe/hammer smash. will not implement for fists (see documentation). 
combo-based stat modifiers now only take effect while firing, as they should