### PR TITLE
e

### DIFF
--- a/items/active/weapons/crits.lua
+++ b/items/active/weapons/crits.lua
@@ -32,6 +32,8 @@ function Crits:setCritDamage(damage)
     local critBonus = config.getParameter("critBonus", 0) + status.stat("critBonus")     --  flat damage bonus to critical hits
     local critDamage = status.stat("critDamage")  -- % increase to crit damage multiplier (0.10 == +10% or 110% total additional damage)
 	--status.stat ONLY accepts ONE argument. and returns 0.0 if it is not found
+	
+	--sb.logInfo("crits.lua: crit chance: %s, crit bonus %s, crit damage %s",critChance,critBonus,critDamage)
 	local heldItem = world.entityHandItem(activeItem.ownerEntityId(), activeItem.hand())
     -- Magnorbs get an inherent +1% crit chance
     if heldItem and root.itemHasTag(heldItem, "magnorb") then

--- a/items/active/weapons/staff/abilities/cloudburst/cloudburst.lua
+++ b/items/active/weapons/staff/abilities/cloudburst/cloudburst.lua
@@ -37,7 +37,7 @@ end
 
 function CloudBurst:charge()
 	self.weapon:setStance(self.stances.charge)
-	self.stances.charge.duration = self.stances.charge.duration * self.chargeTimerBonus
+	self.stances.charge.duration = self.stances.charge.duration
 	animator.playSound(self.elementalType.."charge")
 	animator.setAnimationState("charge", "charge")
 	animator.setParticleEmitterActive(self.elementalType .. "charge", true)


### PR DESCRIPTION
fixed cloudburst.lua erroring

fully fixed single rapier bonus/mastery. this required a specific new implementation (see below) due to the 'event' based implementation of mastery. 
implemented proper timer system into masteries. documentation is provided in the lua file. summary: system takes a table assigned to a specific key, with each hand having their own table. table upon declaration sets initial value, direction(multiplier), and bounding value. timer tables reset when their related hands are changed; 'primary' and 'both'  reset when the primary weapon changes. 'alt' and 'both' when the alt weapon changes.