### PR TITLE
Feed-Munity description

### DIFF
--- a/items/augments/back/health/foodimmunity.augment
+++ b/items/augments/back/health/foodimmunity.augment
@@ -4,7 +4,7 @@
   "rarity" : "Uncommon",
   "category" : "eppAugment",
   "inventoryIcon" : "foodaugment1.png",
-  "description" : "EPP Module: ^green;Immune to Hunger Penalties^reset;",
+  "description" : "EPP Module: ^green;Immune to Diet Restrictions^reset;",
   "shortdescription" : "Feed-Munity Chip",
 
   "augment" : {

--- a/stats/effects/melting/melting.lua
+++ b/stats/effects/melting/melting.lua
@@ -7,6 +7,11 @@ function init()
 
 	self.tickTimer = 1.0
 	self.ticks=0
+	
+	if ( status.stat("fireResistance")	>= 1.0 ) then
+		effect.expire()
+		return
+	end
 
 	status.applySelfDamageRequest({
 		damageType = "IgnoresDef",


### PR DESCRIPTION
Changed "Immune to Hunger Penalties" into "Immune to Diet Restrictions" to better match what the augment does.

Fix for when the player has 100% fire res but not lava immunity, resulting in rapid damage ticks.