### PR TITLE
Elder Tenant Loot fix

### DIFF
--- a/tenants/darkkizku/cultist_temple_builder.tenant
+++ b/tenants/darkkizku/cultist_temple_builder.tenant
@@ -20,6 +20,6 @@
 
   "rent": {
     "periodRange": [1200.0, 1800.0],
-    "pool": "fueldritchtenantGift"
+    "pool": "futenantLoot"
   }
 }

--- a/tenants/darkkizku/elder.tenant
+++ b/tenants/darkkizku/elder.tenant
@@ -21,6 +21,6 @@
 
   "rent": {
     "periodRange": [900.0, 1800.0],
-    "pool": "villagerGift"
+    "pool": "futenantLoot"
   }
 }

--- a/tenants/darkkizku/elderart.tenant
+++ b/tenants/darkkizku/elderart.tenant
@@ -21,6 +21,6 @@
 
   "rent": {
     "periodRange": [1200.0, 1800.0],
-    "pool": "fueldritchtenantGift"
+    "pool": "futenantLoot"
   }
 }


### PR DESCRIPTION
Redefined Elder tenant loot as the standard FU tenant loot pool. Previously was an undefined loot pool.