### PR TITLE
Crafting recipes

### DIFF
--- a/player.config.patch
+++ b/player.config.patch
@@ -644,6 +644,7 @@
 	[ { "op": "add", "path": "/defaultBlueprints/tier1/-", "value": { "item" : "swtjc_wp_advancedswitch" } } ],
 	[ { "op": "add", "path": "/defaultBlueprints/tier1/-", "value": { "item" : "swtjc_wp_advancedswitch_nolatch" } } ],
 	[ { "op": "add", "path": "/defaultBlueprints/tier1/-", "value": { "item" : "swtjc_wp_advancedswitch_noninteractive" } } ],
+	[ { "op": "add", "path": "/defaultBlueprints/tier1/-", "value": { "item" : "keypad" } } ],
 
 	//Sequencers
 

--- a/recipes/prototyper/furniture/mechplatform.recipe
+++ b/recipes/prototyper/furniture/mechplatform.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
-	{ "item" : "titaniumbar", "count" : 5 },
-	{ "item" : "electromagnet", "count" : 2 },
-	{ "item" : "powercore", "count" : 1 },
+	{ "item" : "densiniumbar", "count" : 5 },
+	{ "item" : "ff_focusingarray", "count" : 2 },
+	{ "item" : "particlecore", "count" : 1 },
 	{ "item" : "upgrademodule", "count" : 1 }
   ],
   "output" : {

--- a/recipes/wiringstation/switches/keypad.recipe
+++ b/recipes/wiringstation/switches/keypad.recipe
@@ -1,0 +1,9 @@
+{
+  "input" : [
+    { "item" : "cpu", "count" : 1 },
+    { "item" : "stickofram", "count" : 2 },
+    { "item" : "wire", "count" : 2 }
+  ],
+  "output" : { "item" : "keypad", "count" : 1 },
+  "groups" : [ "craftingwiring", "switches" ]
+}

--- a/zb/researchTree/fu_engineering.config
+++ b/zb/researchTree/fu_engineering.config
@@ -343,7 +343,7 @@
                 "position" : [95, -80],
                 "children" : [ "mechsbody1", "mechsmobility1", "mechsweapons1", "mechsmodules1" ],
                 "price" : [["fuscienceresource", 300], ["tungstenbar", 5], ["liquidoil", 20]],
-                "unlocks" : [ "mechcraftingtable", "mechassemblystation", "mechplatform", "mechdefensefield", "mechenergyfield", "mechmobility", "mechrepairpod", "furepairgun", "mechlegssimpleupgrade", "mechlegssimpleupgrade2", "mechboostersimpleupgrade", "mechboostersimpleupgrade2", "mecharmshielddrone0", "mecharmsinshotgun", "mecharmpointdefense", "fuflamearm", "fuicearm", "mecharmdrill", "mechbodybrute", "mechbodyheavy", "mechbodyfuexplorer", "mechlegsfuexplorer", "mechlegsheavy"]
+                "unlocks" : [ "mechcraftingtable", "mechassemblystation", "mechdefensefield", "mechenergyfield", "mechmobility", "mechrepairpod", "furepairgun", "mechlegssimpleupgrade", "mechlegssimpleupgrade2", "mechboostersimpleupgrade", "mechboostersimpleupgrade2", "mecharmshielddrone0", "mecharmsinshotgun", "mecharmpointdefense", "fuflamearm", "fuicearm", "mecharmdrill", "mechbodybrute", "mechbodyheavy", "mechbodyfuexplorer", "mechlegsfuexplorer", "mechlegsheavy"]
             },
             "mechsbody1" : {
                 "icon" : "/items/generic/mechparts/body/mechbodybrute.png",
@@ -434,7 +434,7 @@
                 "position" : [95, -200],
                 "children" : [ ],
                 "price" : [["fuscienceresource", 14000], ["solariumstar", 5]],
-                "unlocks" : ["mechbodyfuorbus", "fumechchainsword", "mechdefensefield5", "mechenergyfield5", "mechmobility5", "mechmasscancel4"]//"mecharmmegacannon", "fugrenadearm",
+                "unlocks" : ["mechplatform", "mechbodyfuorbus", "fumechchainsword", "mechdefensefield5", "mechenergyfield5", "mechmobility5", "mechmasscancel4"]//"mecharmmegacannon", "fugrenadearm",
             },
             
             "spaceftl2" : {
@@ -675,7 +675,7 @@
 
             "mechsmodules3": [ "Superior Mech Modules", "^orange;Tier 5^reset;\n\nYou can make incredibly powerful mech modules."],
     
-            "mechsbest": [ "Peerless Mech Crafting", "^orange;Tier 6^reset;\n\nYou know everything there is to know about modular mechs. You can make extremely amazing mech parts that blow the competition away."],
+            "mechsbest": [ "Peerless Mech Crafting", "^orange;Tier 6^reset;\n\nYou know everything there is to know about modular mechs. You can make extremely amazing mech parts that blow the competition away, and summon your mech to you in the field."],
             
             "spaceftl2": [ "Improved FTL Tech", "^orange;Tier 3^reset;\n\nYou've improved on your FTL design, allowing for the creation of bigger, more powerful engines and a way to further purify and enhance your ship's fuel."],
 
@@ -709,7 +709,7 @@
     },
 
     "versions":{
-      "fu_engineering" : "0.148"
+      "fu_engineering" : "0.149"
     },
     "initiallyResearched" : {
         "fu_engineering" : [ "BASICTRAINING" ]


### PR DESCRIPTION
- Vanilla keypads can now be crafted in the Wiring Station.
- Adjusted the recipe and unlock node of the Mech Platform to reflect its utility.