### PR TITLE
changed upgrade scaling for high-level items

### DIFF
--- a/interface/scripted/fu_multiupgrade/fu_multiupgrade.lua
+++ b/interface/scripted/fu_multiupgrade/fu_multiupgrade.lua
@@ -271,6 +271,7 @@ function upgradeWeapon(upgradeItem,price)
 			if consumedCurrency then
 				local mergeBuffer={}
 				local itemConfig = root.itemConfig(upgradedItem)
+				local defaultLvl = (itemConfig.config.level or 1)
 				local categoryLower=string.lower(mergeBuffer.category or itemConfig.parameters.category or itemConfig.config.category or "")
 
 				mergeBuffer.level = (itemConfig.parameters.level or itemConfig.config.level or 1) + 1
@@ -278,24 +279,24 @@ function upgradeWeapon(upgradeItem,price)
 				local oldRarity=(itemConfig.parameters and itemConfig.parameters.rarity) or (itemConfig.config and itemConfig.config.rarity)
 				mergeBuffer.rarity=oldRarity
 
-				if (itemConfig.config.upgradeParametersTricorder) and (mergeBuffer.level >= 1) then
+				if (itemConfig.config.upgradeParametersTricorder) and (mergeBuffer.level > 1) then
 					mergeBuffer = util.mergeTable(copy(mergeBuffer), copy(itemConfig.config.upgradeParametersTricorder))
 					mergeBuffer.rarity=highestRarity(mergeBuffer.rarity,oldRarity)
 					oldRarity=mergeBuffer.rarity
 				end
 
-				if (itemConfig.config.upgradeParameters) and (mergeBuffer.level > 4) then
+				if (itemConfig.config.upgradeParameters) and (mergeBuffer.level > math.max(defaultLvl, 4)) then
 					mergeBuffer = util.mergeTable(copy(mergeBuffer), copy(itemConfig.config.upgradeParameters))
 					mergeBuffer.rarity=highestRarity(mergeBuffer.rarity,oldRarity)
 					oldRarity=mergeBuffer.rarity
 				end
 
-				if (itemConfig.config.upgradeParameters2) and (mergeBuffer.level > 5) then
+				if (itemConfig.config.upgradeParameters2) and (mergeBuffer.level > math.max(defaultLvl+1, 5)) then
 					mergeBuffer = util.mergeTable(copy(mergeBuffer), copy(itemConfig.config.upgradeParameters2))
 					mergeBuffer.rarity=highestRarity(mergeBuffer.rarity,oldRarity)
 					oldRarity=mergeBuffer.rarity
 				end
-				if (itemConfig.config.upgradeParameters3) and (mergeBuffer.level > 6) then
+				if (itemConfig.config.upgradeParameters3) and (mergeBuffer.level > math.max(defaultLvl+2, 6)) then
 					mergeBuffer = util.mergeTable(copy(mergeBuffer), copy(itemConfig.config.upgradeParameters3))
 					mergeBuffer.rarity=highestRarity(mergeBuffer.rarity,oldRarity)
 					oldRarity=mergeBuffer.rarity

--- a/interface/scripted/fuweaponupgrade/fuweaponupgradegui.lua
+++ b/interface/scripted/fuweaponupgrade/fuweaponupgradegui.lua
@@ -384,6 +384,7 @@ function upgrade(upgradeItem,target)
 				--set level
 				local isTool=itemHasTag(itemConfig,"upgradeableTool")
 				local maxLvl=(isTool and self.upgradeLevelTool) or self.upgradeLevel
+				local defaultLvl=(itemConfig.config.level or 1)
 				--mergeBuffer.level = math.min((itemConfig.parameters.level or itemConfig.config.level or 1)+1,maxLvl)
 				mergeBuffer.level = math.min((itemConfig.parameters.level or itemConfig.config.level or 1),maxLvl)
 				if target then
@@ -391,22 +392,22 @@ function upgrade(upgradeItem,target)
 				end
 
 				--load item upgrade parameters
-				if (itemConfig.config.upgradeParametersTricorder) and (mergeBuffer.level >= 1) then
+				if (itemConfig.config.upgradeParametersTricorder) and (mergeBuffer.level > 1) then
 					mergeBuffer=util.mergeTable(mergeBuffer,copy(itemConfig.config.upgradeParametersTricorder))
 					mergeBuffer.rarity=highestRarity(mergeBuffer.rarity,oldRarity)
 					oldRarity=mergeBuffer.rarity
 				end
-				if (itemConfig.config.upgradeParameters) and (mergeBuffer.level > 4) then
+				if (itemConfig.config.upgradeParameters) and (mergeBuffer.level > math.max(defaultLvl, 4)) then
 					mergeBuffer=util.mergeTable(mergeBuffer,copy(itemConfig.config.upgradeParameters))
 					mergeBuffer.rarity=highestRarity(mergeBuffer.rarity,oldRarity)
 					oldRarity=mergeBuffer.rarity
 				end
-				if (itemConfig.config.upgradeParameters2) and (mergeBuffer.level > 5) then
+				if (itemConfig.config.upgradeParameters2) and (mergeBuffer.level > math.max(defaultLvl+1, 5)) then
 					mergeBuffer=util.mergeTable(mergeBuffer,copy(itemConfig.config.upgradeParameters2))
 					mergeBuffer.rarity=highestRarity(mergeBuffer.rarity,oldRarity)
 					oldRarity=mergeBuffer.rarity
 				end
-				if (itemConfig.config.upgradeParameters3) and (mergeBuffer.level > 6) then
+				if (itemConfig.config.upgradeParameters3) and (mergeBuffer.level > math.max(defaultLvl+2, 6)) then
 					mergeBuffer=util.mergeTable(mergeBuffer,copy(itemConfig.config.upgradeParameters3))
 					mergeBuffer.rarity=highestRarity(mergeBuffer.rarity,oldRarity)
 					oldRarity=mergeBuffer.rarity

--- a/items/active/weapons/ranged/unique/atomsmasher/atomsmasher.activeitem
+++ b/items/active/weapons/ranged/unique/atomsmasher/atomsmasher.activeitem
@@ -8,7 +8,7 @@
 ^yellow;Will decimate anything it hits.^reset;",
   "shortdescription" : "Atom Smasher",
   "category" : "energy",
-  "itemTags" : [ "weapon","ranged", "energy", "mininglaser", "upgradeableWeapon","theaUninfusable","upgradeableTool" ],
+  "itemTags" : [ "weapon","ranged", "energy", "mininglaser", "upgradeableWeapon","theaUninfusable" ],
   "twoHanded" : true,
   "tooltipKind" : "gununique",
   

--- a/items/active/weapons/ranged/unique/furepairgun.activeitem
+++ b/items/active/weapons/ranged/unique/furepairgun.activeitem
@@ -11,7 +11,7 @@
   "upmod" : 1.5,
   "tooltipKind" : "gun2",
   "weaponType" : "Energy",
-  "itemTags" : [ "ranged", "repairgun", "upgradeableTool", "upgradeableWeapon","theaUninfusable" ],
+  "itemTags" : [ "ranged", "repairgun", "upgradeableTool", "theaUninfusable" ],
   "twoHanded" : true,
   "radioMessagesOnPickup" : [ "fuRepairGun" ],
   "animation" : "/items/active/weapons/ranged/gun.animation",


### PR DESCRIPTION
Upgrades are now scaled based on the "normal" upgrade level or the item's level plus some, whichever is higher.
For example:
The Frostbringer, a tier 6 weapon, when simply "infused" with the weapon upgrade anvil, would become the Black Frost.
Now it needs to be actually upgraded to tier 7 to gain that benefit.

The Atom Smasher is no longer upgradable at the tricorder in line with the upgrade changes.