### PR TITLE
Bounty Quest Unknown World Ban

### DIFF
--- a/quests/bounty/generator.config.patch
+++ b/quests/bounty/generator.config.patch
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "add",
+    "path": "/excludePlanetTypes/-",
+    "value": "ffunknown"
+  }
+]


### PR DESCRIPTION
Bounty Quests are now banned from taking place on Unknown Worlds, as (especially on early tiers) it makes some bounties impossible to complete.