### PR TITLE
Novakid guards

### DIFF
--- a/npcs/villageguard.npctype.patch
+++ b/npcs/villageguard.npctype.patch
@@ -904,5 +904,55 @@
         }
       ]
     ]
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/0/primary/0",
+    "value": "swtjc_ewg_npcrevolver"
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/0/sheathedprimary/0",
+    "value": "npcdagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/1/primary/0",
+    "value": "swtjc_ewg_npcrevolver"
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/1/sheathedprimary/0",
+    "value": "npcdagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/2/primary/0",
+    "value": "swtjc_ewg_npcrevolver"
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/2/sheathedprimary/0",
+    "value": "npcdagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/3/primary/0",
+    "value": "swtjc_ewg_npcrevolver"
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/3/sheathedprimary/0",
+    "value": "npcdagger"
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/4/primary/0",
+    "value": "swtjc_ewg_npcrevolver"
+  },
+  {
+    "op": "replace",
+    "path": "/items/novakid/0/1/4/sheathedprimary/0",
+    "value": "npcdagger"
   }
 ]


### PR DESCRIPTION
Novakid villageguards use revolvers and daggers instead of machinepistols and broadswords to fit their race theme better.
Novakid Villageguardcaptians (sherrifs) use revolvers, sawn off shotguns, or shotguns and daggers instead of machinepistols and broadswords to fit their theme better.