### PR TITLE
Asteroids, Fixes

### DIFF
--- a/dialog/converse.config.patch
+++ b/dialog/converse.config.patch
@@ -1520,7 +1520,6 @@
 				"How are you doing?",
 				"Nice to meet you.",
 				"I hope you are well, my friend.",
-				"Big Ape is watching.",
 				"I hope you have a pleasant day.",
 				"It is good to see you.",
 				"Can I help you?",

--- a/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_dungeon_apexmining.json
+++ b/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_dungeon_apexmining.json
@@ -197,7 +197,7 @@
          "name":"objects",
          "objects":[
                 {
-                 "gid":6442,
+                 "gid":6493,
                  "height":64,
                  "id":1291,
                  "name":"",
@@ -221,7 +221,7 @@
                  "y":488
                 }, 
                 {
-                 "gid":2147490110,
+                 "gid":2147490161,
                  "height":32,
                  "id":1293,
                  "name":"",
@@ -233,7 +233,7 @@
                  "y":352
                 }, 
                 {
-                 "gid":6639,
+                 "gid":6690,
                  "height":16,
                  "id":1297,
                  "name":"",
@@ -265,7 +265,7 @@
                  "y":440
                 }, 
                 {
-                 "gid":6729,
+                 "gid":6780,
                  "height":16,
                  "id":1299,
                  "name":"",
@@ -277,7 +277,7 @@
                  "y":440
                 }, 
                 {
-                 "gid":6628,
+                 "gid":6679,
                  "height":40,
                  "id":1301,
                  "name":"",
@@ -289,7 +289,7 @@
                  "y":320
                 }, 
                 {
-                 "gid":6553,
+                 "gid":6604,
                  "height":40,
                  "id":1302,
                  "name":"",
@@ -301,7 +301,7 @@
                  "y":336
                 }, 
                 {
-                 "gid":6527,
+                 "gid":6578,
                  "height":16,
                  "id":1303,
                  "name":"",
@@ -313,7 +313,7 @@
                  "y":192
                 }, 
                 {
-                 "gid":2147490196,
+                 "gid":2147490247,
                  "height":40,
                  "id":1305,
                  "name":"",
@@ -345,7 +345,7 @@
                  "y":288
                 }, 
                 {
-                 "gid":6507,
+                 "gid":6558,
                  "height":40,
                  "id":1309,
                  "name":"",
@@ -397,7 +397,7 @@
                  "y":464
                 }, 
                 {
-                 "gid":2147490093,
+                 "gid":2147490144,
                  "height":16,
                  "id":1320,
                  "name":"",
@@ -501,7 +501,7 @@
                  "y":312
                 }, 
                 {
-                 "gid":2147490091,
+                 "gid":2147490142,
                  "height":16,
                  "id":1333,
                  "name":"",
@@ -521,7 +521,7 @@
                  "y":416
                 }, 
                 {
-                 "gid":6674,
+                 "gid":6725,
                  "height":8,
                  "id":1334,
                  "name":"",
@@ -569,7 +569,7 @@
                  "y":264
                 }, 
                 {
-                 "gid":6700,
+                 "gid":6751,
                  "height":8,
                  "id":1343,
                  "name":"",
@@ -593,7 +593,7 @@
                  "y":352
                 }, 
                 {
-                 "gid":6665,
+                 "gid":6716,
                  "height":32,
                  "id":1346,
                  "name":"",
@@ -605,7 +605,7 @@
                  "y":416
                 }, 
                 {
-                 "gid":6665,
+                 "gid":6716,
                  "height":32,
                  "id":1347,
                  "name":"",
@@ -617,7 +617,7 @@
                  "y":416
                 }, 
                 {
-                 "gid":2147490302,
+                 "gid":2147490353,
                  "height":16,
                  "id":1348,
                  "name":"",
@@ -721,7 +721,7 @@
                  "y":312
                 }, 
                 {
-                 "gid":2147490334,
+                 "gid":2147490385,
                  "height":16,
                  "id":1395,
                  "name":"",
@@ -755,6 +755,18 @@
                  "width":16,
                  "x":168,
                  "y":424
+                }, 
+                {
+                 "gid":6690,
+                 "height":16,
+                 "id":1402,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":16,
+                 "x":360,
+                 "y":360
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1139,7 +1151,7 @@
                  "visible":true,
                  "width":8,
                  "x":240,
-                 "y":328
+                 "y":336
                 }, 
                 {
                  "height":8,
@@ -1215,7 +1227,7 @@
                  "visible":true,
                  "width":8,
                  "x":176,
-                 "y":464
+                 "y":472
                 }, 
                 {
                  "height":8,
@@ -1234,7 +1246,7 @@
                  "visible":true,
                  "width":8,
                  "x":256,
-                 "y":464
+                 "y":472
                 }, 
                 {
                  "height":8,
@@ -1253,7 +1265,7 @@
                  "visible":true,
                  "width":8,
                  "x":320,
-                 "y":464
+                 "y":472
                 }, 
                 {
                  "height":8,
@@ -1274,7 +1286,7 @@
                  "visible":true,
                  "width":8,
                  "x":136,
-                 "y":328
+                 "y":336
                 }, 
                 {
                  "height":8,
@@ -1659,6 +1671,26 @@
                  "width":0,
                  "x":376,
                  "y":384
+                }, 
+                {
+                 "height":0,
+                 "id":1403,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-16,
+                         "y":-40
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":376,
+                 "y":384
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1871,7 +1903,7 @@
          "y":0
         }],
  "nextlayerid":13,
- "nextobjectid":1402,
+ "nextobjectid":1404,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.5.0",
@@ -1970,39 +2002,39 @@
          "source":"..\/..\/..\/tilesets\/fu_mastermaterials.json"
         }, 
         {
-         "firstgid":5118,
+         "firstgid":5169,
          "source":"..\/..\/..\/tilesets\/fu_masterobjects.json"
         }, 
         {
-         "firstgid":5771,
+         "firstgid":5822,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fu_proppack.json"
         }, 
         {
-         "firstgid":6214,
+         "firstgid":6265,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/railpoint.json"
         }, 
         {
-         "firstgid":6219,
+         "firstgid":6270,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/astro.json"
         }, 
         {
-         "firstgid":6233,
+         "firstgid":6284,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/industrial.json"
         }, 
         {
-         "firstgid":6244,
+         "firstgid":6295,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/lunarbase.json"
         }, 
         {
-         "firstgid":6268,
+         "firstgid":6319,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/outpost.json"
         }, 
         {
-         "firstgid":6372,
+         "firstgid":6423,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/wreck.json"
         }, 
         {
-         "firstgid":6399,
+         "firstgid":6450,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/apex.json"
         }],
  "tilewidth":8,

--- a/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_friendly_fastfood.json
+++ b/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_friendly_fastfood.json
@@ -396,6 +396,18 @@
                  "width":8,
                  "x":168,
                  "y":168
+                }, 
+                {
+                 "gid":2375,
+                 "height":16,
+                 "id":1030,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":16,
+                 "x":288,
+                 "y":72
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -520,7 +532,7 @@
                  "visible":true,
                  "width":8,
                  "x":272,
-                 "y":72
+                 "y":80
                 }, 
                 {
                  "height":8,
@@ -541,7 +553,7 @@
                  "visible":true,
                  "width":8,
                  "x":184,
-                 "y":72
+                 "y":80
                 }, 
                 {
                  "height":8,
@@ -562,7 +574,7 @@
                  "visible":true,
                  "width":8,
                  "x":248,
-                 "y":72
+                 "y":80
                 }, 
                 {
                  "height":8,
@@ -583,7 +595,28 @@
                  "visible":true,
                  "width":8,
                  "x":248,
-                 "y":160
+                 "y":168
+                }, 
+                {
+                 "height":8,
+                 "id":1032,
+                 "name":"",
+                 "properties":
+                    {
+                     "npc":"human, novakid, fupeglaci, veluu",
+                     "typeName":"fuspaceguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":8,
+                 "x":304,
+                 "y":168
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1003,6 +1036,46 @@
                  "width":0,
                  "x":208,
                  "y":64
+                }, 
+                {
+                 "height":0,
+                 "id":1028,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":8,
+                         "y":8
+                        }, 
+                        {
+                         "x":-88,
+                         "y":0
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":288,
+                 "y":56
+                }, 
+                {
+                 "height":0,
+                 "id":1029,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":8,
+                         "y":8
+                        }, 
+                        {
+                         "x":-56,
+                         "y":8
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":288,
+                 "y":56
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1287,6 +1360,25 @@
                  "width":176,
                  "x":176,
                  "y":128
+                }, 
+                {
+                 "height":192,
+                 "id":1031,
+                 "name":"",
+                 "properties":
+                    {
+                     "stagehand":"objecttracker"
+                    },
+                 "propertytypes":
+                    {
+                     "stagehand":"string"
+                    },
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":416,
+                 "x":56,
+                 "y":24
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1295,7 +1387,7 @@
          "y":0
         }],
  "nextlayerid":14,
- "nextobjectid":1026,
+ "nextobjectid":1033,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.5.0",
@@ -1426,7 +1518,7 @@
          "source":"..\/..\/..\/tilesets\/fu_mastermaterials.json"
         }, 
         {
-         "firstgid":6285,
+         "firstgid":6336,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fu_liquids.json"
         }],
  "tilewidth":8,

--- a/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_friendly_mechbay.json
+++ b/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_friendly_mechbay.json
@@ -194,7 +194,7 @@
                  "y":360
                 }, 
                 {
-                 "gid":2147489966,
+                 "gid":2147490017,
                  "height":24,
                  "id":1156,
                  "name":"",
@@ -250,7 +250,7 @@
                  "y":208
                 }, 
                 {
-                 "gid":6343,
+                 "gid":6394,
                  "height":16,
                  "id":1165,
                  "name":"",
@@ -262,7 +262,7 @@
                  "y":240
                 }, 
                 {
-                 "gid":6364,
+                 "gid":6415,
                  "height":16,
                  "id":1167,
                  "name":"",
@@ -274,7 +274,7 @@
                  "y":240
                 }, 
                 {
-                 "gid":6351,
+                 "gid":6402,
                  "height":16,
                  "id":1168,
                  "name":"",
@@ -506,7 +506,7 @@
                  "y":216
                 }, 
                 {
-                 "gid":6494,
+                 "gid":6545,
                  "height":38,
                  "id":1270,
                  "name":"",
@@ -518,7 +518,7 @@
                  "y":368
                 }, 
                 {
-                 "gid":6494,
+                 "gid":6545,
                  "height":38,
                  "id":1271,
                  "name":"",
@@ -528,6 +528,30 @@
                  "width":24,
                  "x":328,
                  "y":368
+                }, 
+                {
+                 "gid":6799,
+                 "height":16,
+                 "id":1278,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":16,
+                 "x":136,
+                 "y":216
+                }, 
+                {
+                 "gid":6799,
+                 "height":16,
+                 "id":1279,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":16,
+                 "x":496,
+                 "y":304
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -612,6 +636,27 @@
                  "visible":true,
                  "width":8,
                  "x":520,
+                 "y":344
+                }, 
+                {
+                 "height":8,
+                 "id":1276,
+                 "name":"",
+                 "properties":
+                    {
+                     "npc":"human, novakid, fupeglaci, veluu",
+                     "typeName":"fuspaceguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":8,
+                 "x":192,
                  "y":344
                 }],
          "opacity":1,
@@ -948,6 +993,86 @@
                  "width":0,
                  "x":512,
                  "y":216
+                }, 
+                {
+                 "height":0,
+                 "id":1272,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":24,
+                         "y":-40
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":480,
+                 "y":248
+                }, 
+                {
+                 "height":0,
+                 "id":1273,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":56,
+                         "y":-32
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":480,
+                 "y":248
+                }, 
+                {
+                 "height":0,
+                 "id":1280,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":16,
+                         "y":40
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":480,
+                 "y":248
+                }, 
+                {
+                 "height":0,
+                 "id":1281,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-344,
+                         "y":-48
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":480,
+                 "y":248
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1112,6 +1237,25 @@
                  "width":264,
                  "x":184,
                  "y":216
+                }, 
+                {
+                 "height":312,
+                 "id":1274,
+                 "name":"",
+                 "properties":
+                    {
+                     "stagehand":"objecttracker"
+                    },
+                 "propertytypes":
+                    {
+                     "stagehand":"string"
+                    },
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":504,
+                 "x":104,
+                 "y":72
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1120,7 +1264,7 @@
          "y":0
         }],
  "nextlayerid":13,
- "nextobjectid":1272,
+ "nextobjectid":1282,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.5.0",
@@ -1223,40 +1367,44 @@
          "source":"..\/..\/..\/tilesets\/fu_mastermaterials.json"
         }, 
         {
-         "firstgid":5166,
+         "firstgid":5217,
          "source":"..\/..\/..\/tilesets\/fu_masterobjects.json"
         }, 
         {
-         "firstgid":5819,
+         "firstgid":5870,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fu_proppack.json"
         }, 
         {
-         "firstgid":6262,
+         "firstgid":6313,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-category\/railpoint.json"
         }, 
         {
-         "firstgid":6267,
+         "firstgid":6318,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/astro.json"
         }, 
         {
-         "firstgid":6281,
+         "firstgid":6332,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/industrial.json"
         }, 
         {
-         "firstgid":6292,
+         "firstgid":6343,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/lunarbase.json"
         }, 
         {
-         "firstgid":6316,
+         "firstgid":6367,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/outpost.json"
         }, 
         {
-         "firstgid":6420,
+         "firstgid":6471,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-colonytag\/wreck.json"
         }, 
         {
-         "firstgid":6447,
+         "firstgid":6498,
          "source":"..\/..\/..\/tilesets\/extradungeons-custom\/modstuff.json"
+        }, 
+        {
+         "firstgid":6559,
+         "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/apex.json"
         }],
  "tilewidth":8,
  "type":"map",

--- a/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_friendly_stabbedthings.json
+++ b/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_friendly_stabbedthings.json
@@ -38,7 +38,7 @@
          "name":"mods",
          "objects":[
                 {
-                 "gid":6430,
+                 "gid":6482,
                  "height":24,
                  "id":1056,
                  "name":"",
@@ -50,7 +50,7 @@
                  "y":200
                 }, 
                 {
-                 "gid":6430,
+                 "gid":6482,
                  "height":24,
                  "id":1064,
                  "name":"",
@@ -110,7 +110,7 @@
                  "y":264
                 }, 
                 {
-                 "gid":2147490018,
+                 "gid":2147490069,
                  "height":56,
                  "id":1026,
                  "name":"",
@@ -122,7 +122,7 @@
                  "y":264
                 }, 
                 {
-                 "gid":6475,
+                 "gid":6527,
                  "height":16,
                  "id":1027,
                  "name":"",
@@ -134,7 +134,7 @@
                  "y":224
                 }, 
                 {
-                 "gid":6391,
+                 "gid":6443,
                  "height":25,
                  "id":1028,
                  "name":"",
@@ -143,10 +143,10 @@
                  "visible":true,
                  "width":32,
                  "x":480,
-                 "y":248
+                 "y":240
                 }, 
                 {
-                 "gid":6526,
+                 "gid":6578,
                  "height":16,
                  "id":1029,
                  "name":"",
@@ -158,7 +158,7 @@
                  "y":208
                 }, 
                 {
-                 "gid":6492,
+                 "gid":6544,
                  "height":8,
                  "id":1030,
                  "name":"",
@@ -170,7 +170,7 @@
                  "y":216
                 }, 
                 {
-                 "gid":6393,
+                 "gid":6445,
                  "height":24,
                  "id":1031,
                  "name":"",
@@ -182,7 +182,7 @@
                  "y":264
                 }, 
                 {
-                 "gid":2147490041,
+                 "gid":2147490093,
                  "height":24,
                  "id":1032,
                  "name":"",
@@ -194,7 +194,7 @@
                  "y":264
                 }, 
                 {
-                 "gid":6435,
+                 "gid":6487,
                  "height":16,
                  "id":1033,
                  "name":"",
@@ -206,7 +206,7 @@
                  "y":264
                 }, 
                 {
-                 "gid":6610,
+                 "gid":6662,
                  "height":8,
                  "id":1034,
                  "name":"",
@@ -232,7 +232,7 @@
                  "y":248
                 }, 
                 {
-                 "gid":6624,
+                 "gid":6676,
                  "height":16,
                  "id":1035,
                  "name":"",
@@ -258,7 +258,7 @@
                  "y":248
                 }, 
                 {
-                 "gid":2147490248,
+                 "gid":2147490300,
                  "height":8,
                  "id":1037,
                  "name":"",
@@ -284,7 +284,7 @@
                  "y":248
                 }, 
                 {
-                 "gid":2147490302,
+                 "gid":2147490354,
                  "height":8,
                  "id":1038,
                  "name":"",
@@ -310,7 +310,7 @@
                  "y":248
                 }, 
                 {
-                 "gid":6493,
+                 "gid":6545,
                  "height":24,
                  "id":1054,
                  "name":"",
@@ -322,7 +322,7 @@
                  "y":264
                 }, 
                 {
-                 "gid":6430,
+                 "gid":6482,
                  "height":24,
                  "id":1055,
                  "name":"",
@@ -358,7 +358,7 @@
                  "y":248
                 }, 
                 {
-                 "gid":6750,
+                 "gid":6802,
                  "height":40,
                  "id":1069,
                  "name":"",
@@ -368,6 +368,30 @@
                  "width":32,
                  "x":448,
                  "y":144
+                }, 
+                {
+                 "gid":2321,
+                 "height":8,
+                 "id":1070,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":8,
+                 "x":504,
+                 "y":240
+                }, 
+                {
+                 "gid":7054,
+                 "height":16,
+                 "id":1074,
+                 "name":"",
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":16,
+                 "x":368,
+                 "y":192
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -452,7 +476,7 @@
                  "visible":true,
                  "width":8,
                  "x":360,
-                 "y":240
+                 "y":248
                 }, 
                 {
                  "height":8,
@@ -473,7 +497,28 @@
                  "visible":true,
                  "width":8,
                  "x":296,
-                 "y":240
+                 "y":248
+                }, 
+                {
+                 "height":8,
+                 "id":1077,
+                 "name":"",
+                 "properties":
+                    {
+                     "npc":"human, novakid, fupeglaci, veluu",
+                     "typeName":"fuspaceguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":8,
+                 "x":376,
+                 "y":248
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -905,6 +950,66 @@
                  "width":0,
                  "x":256,
                  "y":184
+                }, 
+                {
+                 "height":0,
+                 "id":1071,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-256,
+                         "y":-8
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":504,
+                 "y":232
+                }, 
+                {
+                 "height":0,
+                 "id":1072,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":224,
+                         "y":0
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":280,
+                 "y":232
+                }, 
+                {
+                 "height":0,
+                 "id":1073,
+                 "name":"",
+                 "polyline":[
+                        {
+                         "x":0,
+                         "y":0
+                        }, 
+                        {
+                         "x":-136,
+                         "y":-56
+                        }],
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":504,
+                 "y":232
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1189,6 +1294,25 @@
                  "width":216,
                  "x":256,
                  "y":192
+                }, 
+                {
+                 "height":248,
+                 "id":1075,
+                 "name":"",
+                 "properties":
+                    {
+                     "stagehand":"objecttracker"
+                    },
+                 "propertytypes":
+                    {
+                     "stagehand":"string"
+                    },
+                 "rotation":0,
+                 "type":"",
+                 "visible":true,
+                 "width":416,
+                 "x":136,
+                 "y":96
                 }],
          "opacity":1,
          "type":"objectgroup",
@@ -1197,7 +1321,7 @@
          "y":0
         }],
  "nextlayerid":14,
- "nextobjectid":1070,
+ "nextobjectid":1078,
  "orientation":"orthogonal",
  "renderorder":"right-down",
  "tiledversion":"1.5.0",
@@ -1324,28 +1448,32 @@
          "source":"..\/..\/..\/tilesets\/fu_mastermaterials.json"
         }, 
         {
-         "firstgid":6272,
+         "firstgid":6323,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fu_liquids.json"
         }, 
         {
-         "firstgid":6295,
+         "firstgid":6346,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/fu_stations.json"
         }, 
         {
-         "firstgid":6385,
+         "firstgid":6437,
          "source":"..\/..\/..\/..\/..\/assets\/packed\/tilesets\/packed\/objects-by-race\/floran.json"
         }, 
         {
-         "firstgid":6580,
+         "firstgid":6632,
          "source":"..\/..\/..\/tilesets\/FoodiesFurniture-custom\/foods.json"
         }, 
         {
-         "firstgid":6651,
+         "firstgid":6703,
          "source":"..\/..\/..\/tilesets\/FoodiesFurniture-custom\/drinks.json"
         }, 
         {
-         "firstgid":6679,
+         "firstgid":6731,
          "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/BYOS_ShipParts.json"
+        }, 
+        {
+         "firstgid":6814,
+         "source":"..\/..\/..\/tilesets\/frackinuniverse-custom\/apex.json"
         }],
  "tilewidth":8,
  "type":"map",

--- a/npcs/fuspaceguard.npctype
+++ b/npcs/fuspaceguard.npctype
@@ -1,0 +1,132 @@
+{
+  "type" : "fuspaceguard",
+  "baseType" : "villageguard",
+
+  "scriptConfig" : {
+    "dialog" : {
+      "greeting" : {
+        "human" : {
+          "default" : [
+            "I always dreamed of working in space. I figured I'd have a home to go back to, though.",
+            "Working in space isn't so bad, once you get used to hotbunking with your boss.",
+            "Hey, are you a Protector? I thought you all went down with the ship. Guess you were too busy that day"
+          ]
+        },
+        "novakid" : {
+          "default" : [
+            "Howdy partner. Take care you don't disturb my flock here or we'll have a little fallin' out, if you catch my drift.",
+            "Howdy there. Have a chat with the head honcho if you're here for business.",
+            "You flew in on that rustbucket? You're braver than this cowboy.",
+            "Keepin' safe, or safely keepin'? Hang on, that don't make sense."
+          ]
+        },
+        "fupeglaci" : {
+          "default" : [
+            "Keep your weapons holstered, please. I've seen enough violence lately.",
+            "I really need a new job. I wonder if Letheia are hiring?",
+            "Good to meet you. I hope you're not here to cause trouble.",
+            "It feels like hundreds of kelvin in here, is it this hot for everyone or just me?"
+          ]
+        },
+        "veluu" : {
+          "default" : [
+            "Hey there. You're not going to cause trouble, right?",
+            "Hey friend. Speak to the boss if you're here on business.",
+            "You here about the job advert? They picked me, sorry.",
+            "I never believed how big space was till I saw it for myself."
+          ]
+        }
+      },
+      "converse" : {
+        "human" : {
+          "default" : [
+            "I always dreamed of working in space. I figured I'd have a home to go back to, though.",
+            "Working in space isn't so bad, once you get used to hotbunking with your boss.",
+            "Hey, are you a Protector? I thought you all went down with the ship. Guess you were too busy that day"
+          ]
+        },
+        "novakid" : {
+          "default" : [
+            "Howdy partner. Take care you don't disturb my flock here or we'll have a little fallin' out, if you catch my drift.",
+            "Howdy there. Have a chat with the head honcho if you're here for business.",
+            "You flew in on that rustbucket? You're braver than this cowboy.",
+            "Keepin' safe, or safely keepin'? Hang on, that don't make sense."
+          ]
+        },
+        "fupeglaci" : {
+          "default" : [
+            "Keep your weapons holstered, please. I've seen enough violence lately.",
+            "I really need a new job. I wonder if Letheia are hiring?",
+            "Good to meet you. I hope you're not here to cause trouble.",
+            "It feels like hundreds of kelvin in here, is it this hot for everyone or just me?"
+          ]
+        },
+        "veluu" : {
+          "default" : [
+            "Hey there. You're not going to cause trouble, right?",
+            "Hey friend. Speak to the boss if you're here on business.",
+            "You here about the job advert? They picked me, sorry."
+          ]
+        }
+      }
+    }
+  },
+
+  "items" : {
+    "human" : [
+      [1, [
+          {
+            "head" : [ "" ],
+            "chest" : [ { "name" : "fubountyhunterchest" } ],
+            "legs" : [ { "name" : "fubountyhunterpants" } ],
+            "back" : [ { "name" : "tw_spacesuitback" } ],
+            "primary" : [
+              "energyassault", "weaponminer", "fucarbonhandcannon", "carbonshotgun"
+            ]
+          }
+        ] ]
+    ],
+    "novakid" : [
+      [1, [
+          {
+            "head" : [ { "name" : "novatier2head" } ],
+            "chest" : [ { "name" : "novatier2chest" } ],
+            "legs" : [ { "name" : "novatier2pants" } ],
+            "primary" : [
+              "funomadassaultrifle", "durasteelrevolver", "pistoleffigiumfu", "gravitonpistol"
+            ],
+            "secondary" : [
+              "titaniumshield", "titaniumrevolver"
+            ]
+          }
+        ] ]
+    ],
+    "fupeglaci" : [
+      [1, [
+          {
+            "head" : [ "premierhead", "", "" ],
+            "chest" : [ { "name" : "premierchest" } ],
+            "legs" : [ { "name" : "premierpants" } ],
+            "primary" : [
+              "frostcannonarm", "fufreezecannon", "fubeamgun"
+            ]
+          }
+        ] ]
+    ],
+    "veluu" : [
+      [1, [
+          {
+            "head" : [ { "name" : "maverickhunterhead" } ],
+            "chest" : [ { "name" : "maverickhunterchest" } ],
+            "legs" : [ { "name" : "maverickhunterpants" } ],
+            "primary" : [
+              "armcannon", "armcannonice", "armcannonexplosive", "armcannonshock", "armcannonfire", "armcannonproto"
+            ],
+            "secondary" : [
+              "armcannon", "armcannonice", "armcannonexplosive", "armcannonshock", "armcannonfire", "armcannonproto"
+            ]
+          }
+        ] ]
+    ]
+  }
+}

--- a/tilesets/frackinuniverse-custom/apex.json
+++ b/tilesets/frackinuniverse-custom/apex.json
@@ -3045,1105 +3045,1105 @@
   },
   "tiles" : {
     "0" : {
-      "image" : "../../../../../tiled/packed/objects/apexaquarium1.png"
+      "image" : "../../../../tiled/packed/objects/apexaquarium1.png"
     },
     "1" : {
-      "image" : "../../../../../tiled/packed/objects/apexrecordplayer.png"
+      "image" : "../../../../tiled/packed/objects/apexrecordplayer.png"
     },
     "10" : {
-      "image" : "../../../../../tiled/packed/objects/buglike7.png"
+      "image" : "../../../../tiled/packed/objects/buglike7.png"
     },
     "100" : {
-      "image" : "../../../../../tiled/packed/objects/apexpainting2.png"
+      "image" : "../../../../tiled/packed/objects/apexpainting2.png"
     },
     "101" : {
-      "image" : "../../../../../tiled/packed/objects/slimeblob5.png"
+      "image" : "../../../../tiled/packed/objects/slimeblob5.png"
     },
     "102" : {
-      "image" : "../../../../../tiled/packed/objects/rustbush1.png"
+      "image" : "../../../../tiled/packed/objects/rustbush1.png"
     },
     "103" : {
-      "image" : "../../../../../tiled/packed/objects/smashbones3.png"
+      "image" : "../../../../tiled/packed/objects/smashbones3.png"
     },
     "104" : {
-      "image" : "../../../../../tiled/packed/objects/platinumrock.png"
+      "image" : "../../../../tiled/packed/objects/platinumrock.png"
     },
     "105" : {
-      "image" : "../../../../../tiled/packed/objects/rustbush2.png"
+      "image" : "../../../../tiled/packed/objects/rustbush2.png"
     },
     "106" : {
-      "image" : "../../../../../tiled/packed/objects/classiccupboard.png"
+      "image" : "../../../../tiled/packed/objects/classiccupboard.png"
     },
     "107" : {
-      "image" : "../../../../../tiled/packed/objects/brokenapexfuelhatch.png"
+      "image" : "../../../../tiled/packed/objects/brokenapexfuelhatch.png"
     },
     "108" : {
-      "image" : "../../../../../tiled/packed/objects/apexcoolcupboard.png"
+      "image" : "../../../../tiled/packed/objects/apexcoolcupboard.png"
     },
     "109" : {
-      "image" : "../../../../../tiled/packed/objects/paintingapexpixellisa.png"
+      "image" : "../../../../tiled/packed/objects/paintingapexpixellisa.png"
     },
     "11" : {
-      "image" : "../../../../../tiled/packed/objects/buglike6.png"
+      "image" : "../../../../tiled/packed/objects/buglike6.png"
     },
     "110" : {
-      "image" : "../../../../../tiled/packed/objects/classicglass.png"
+      "image" : "../../../../tiled/packed/objects/classicglass.png"
     },
     "111" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush10.png"
+      "image" : "../../../../tiled/packed/objects/junglebush10.png"
     },
     "112" : {
-      "image" : "../../../../../tiled/packed/objects/fossilpod.png"
+      "image" : "../../../../tiled/packed/objects/fossilpod.png"
     },
     "113" : {
-      "image" : "../../../../../tiled/packed/objects/cellstructure5.png"
+      "image" : "../../../../tiled/packed/objects/cellstructure5.png"
     },
     "114" : {
-      "image" : "../../../../../tiled/packed/objects/apexwallpainting1.png"
+      "image" : "../../../../tiled/packed/objects/apexwallpainting1.png"
     },
     "115" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "116" : {
-      "image" : "../../../../../tiled/packed/objects/techstation.png"
+      "image" : "../../../../tiled/packed/objects/techstation.png"
     },
     "117" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush12.png"
+      "image" : "../../../../tiled/packed/objects/junglebush12.png"
     },
     "118" : {
-      "image" : "../../../../../tiled/packed/objects/vaseclassicsmall1.png"
+      "image" : "../../../../tiled/packed/objects/vaseclassicsmall1.png"
     },
     "119" : {
-      "image" : "../../../../../tiled/packed/objects/classicdesk.png"
+      "image" : "../../../../tiled/packed/objects/classicdesk.png"
     },
     "12" : {
-      "image" : "../../../../../tiled/packed/objects/buglike3.png"
+      "image" : "../../../../tiled/packed/objects/buglike3.png"
     },
     "120" : {
-      "image" : "../../../../../tiled/packed/objects/apexstoragelocker.png"
+      "image" : "../../../../tiled/packed/objects/apexstoragelocker.png"
     },
     "121" : {
-      "image" : "../../../../../tiled/packed/objects/platinumrocksmall.png"
+      "image" : "../../../../tiled/packed/objects/platinumrocksmall.png"
     },
     "122" : {
-      "image" : "../../../../../tiled/packed/objects/classicdiningtable.png"
+      "image" : "../../../../tiled/packed/objects/classicdiningtable.png"
     },
     "123" : {
-      "image" : "../../../../../tiled/packed/objects/apexpainting4.png"
+      "image" : "../../../../tiled/packed/objects/apexpainting4.png"
     },
     "124" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "125" : {
-      "image" : "../../../../../tiled/packed/objects/hivebush3.png"
+      "image" : "../../../../tiled/packed/objects/hivebush3.png"
     },
     "126" : {
-      "image" : "../../../../../tiled/packed/objects/silverrock.png"
+      "image" : "../../../../tiled/packed/objects/silverrock.png"
     },
     "127" : {
-      "image" : "../../../../../tiled/packed/objects/apexsecuritycamera.png"
+      "image" : "../../../../tiled/packed/objects/apexsecuritycamera.png"
     },
     "128" : {
-      "image" : "../../../../../tiled/packed/objects/apexbustmale.png"
+      "image" : "../../../../tiled/packed/objects/apexbustmale.png"
     },
     "129" : {
-      "image" : "../../../../../tiled/packed/objects/hivebush5.png"
+      "image" : "../../../../tiled/packed/objects/hivebush5.png"
     },
     "13" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "130" : {
-      "image" : "../../../../../tiled/packed/objects/tarcrystal3.png"
+      "image" : "../../../../tiled/packed/objects/tarcrystal3.png"
     },
     "131" : {
-      "image" : "../../../../../tiled/packed/objects/flowerbasket2.png"
+      "image" : "../../../../tiled/packed/objects/flowerbasket2.png"
     },
     "132" : {
-      "image" : "../../../../../tiled/packed/objects/flowerbasket2_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/flowerbasket2_orientation2.png"
     },
     "133" : {
-      "image" : "../../../../../tiled/packed/objects/flowerbasket2_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/flowerbasket2_orientation3.png"
     },
     "134" : {
-      "image" : "../../../../../tiled/packed/objects/blueflask.png"
+      "image" : "../../../../tiled/packed/objects/blueflask.png"
     },
     "135" : {
-      "image" : "../../../../../tiled/packed/objects/diamondrock.png"
+      "image" : "../../../../tiled/packed/objects/diamondrock.png"
     },
     "136" : {
-      "image" : "../../../../../tiled/packed/objects/teslaspike.png"
+      "image" : "../../../../tiled/packed/objects/teslaspike.png"
     },
     "137" : {
-      "image" : "../../../../../tiled/packed/objects/teslaspike_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/teslaspike_orientation2.png"
     },
     "138" : {
-      "image" : "../../../../../tiled/packed/objects/teslaspike_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/teslaspike_orientation3.png"
     },
     "139" : {
-      "image" : "../../../../../tiled/packed/objects/teslaspike_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/teslaspike_orientation4.png"
     },
     "14" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "140" : {
-      "image" : "../../../../../tiled/packed/objects/teslaspike_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/teslaspike_orientation5.png"
     },
     "141" : {
-      "image" : "../../../../../tiled/packed/objects/teslaspike_orientation6.png"
+      "image" : "../../../../tiled/packed/objects/teslaspike_orientation6.png"
     },
     "142" : {
-      "image" : "../../../../../tiled/packed/objects/teslaspike_orientation7.png"
+      "image" : "../../../../tiled/packed/objects/teslaspike_orientation7.png"
     },
     "143" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain2.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain2.png"
     },
     "144" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain2_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain2_orientation2.png"
     },
     "145" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain2_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain2_orientation3.png"
     },
     "146" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain2_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain2_orientation4.png"
     },
     "147" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain2_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain2_orientation5.png"
     },
     "148" : {
-      "image" : "../../../../../tiled/packed/objects/goldrock.png"
+      "image" : "../../../../tiled/packed/objects/goldrock.png"
     },
     "149" : {
-      "image" : "../../../../../tiled/packed/objects/apexbloodbank.png"
+      "image" : "../../../../tiled/packed/objects/apexbloodbank.png"
     },
     "15" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "150" : {
-      "image" : "../../../../../tiled/packed/objects/smashbones4.png"
+      "image" : "../../../../tiled/packed/objects/smashbones4.png"
     },
     "151" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse8.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse8.png"
     },
     "152" : {
-      "image" : "../../../../../tiled/packed/objects/cellstructure1.png"
+      "image" : "../../../../tiled/packed/objects/cellstructure1.png"
     },
     "153" : {
-      "image" : "../../../../../tiled/packed/objects/classicchina.png"
+      "image" : "../../../../tiled/packed/objects/classicchina.png"
     },
     "154" : {
-      "image" : "../../../../../tiled/packed/objects/apexapesign.png"
+      "image" : "../../../../tiled/packed/objects/apexapesign.png"
     },
     "155" : {
-      "image" : "../../../../../tiled/packed/objects/cellstructure2.png"
+      "image" : "../../../../tiled/packed/objects/cellstructure2.png"
     },
     "156" : {
-      "image" : "../../../../../tiled/packed/objects/grandfatherclock.png"
+      "image" : "../../../../tiled/packed/objects/grandfatherclock.png"
     },
     "157" : {
-      "image" : "../../../../../tiled/packed/objects/hivelight2.png"
+      "image" : "../../../../tiled/packed/objects/hivelight2.png"
     },
     "158" : {
-      "image" : "../../../../../tiled/packed/objects/hivelight2_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/hivelight2_orientation2.png"
     },
     "159" : {
-      "image" : "../../../../../tiled/packed/objects/hivelight2_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/hivelight2_orientation3.png"
     },
     "16" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "160" : {
-      "image" : "../../../../../tiled/packed/objects/hivelight2_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/hivelight2_orientation4.png"
     },
     "161" : {
-      "image" : "../../../../../tiled/packed/objects/classicpillarsmall.png"
+      "image" : "../../../../tiled/packed/objects/classicpillarsmall.png"
     },
     "162" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "163" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "164" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "165" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "166" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "167" : {
-      "image" : "../../../../../tiled/packed/objects/colourfulbush1.png"
+      "image" : "../../../../tiled/packed/objects/colourfulbush1.png"
     },
     "168" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush17.png"
+      "image" : "../../../../tiled/packed/objects/junglebush17.png"
     },
     "169" : {
-      "image" : "../../../../../tiled/packed/objects/classicplate.png"
+      "image" : "../../../../tiled/packed/objects/classicplate.png"
     },
     "17" : {
-      "image" : "../../../../../tiled/packed/objects/crystalcavebush2.png"
+      "image" : "../../../../tiled/packed/objects/crystalcavebush2.png"
     },
     "170" : {
-      "image" : "../../../../../tiled/packed/objects/apexofficechair.png"
+      "image" : "../../../../tiled/packed/objects/apexofficechair.png"
     },
     "171" : {
-      "image" : "../../../../../tiled/packed/objects/classictable.png"
+      "image" : "../../../../tiled/packed/objects/classictable.png"
     },
     "172" : {
-      "image" : "../../../../../tiled/packed/objects/crystalcavebush4.png"
+      "image" : "../../../../tiled/packed/objects/crystalcavebush4.png"
     },
     "173" : {
-      "image" : "../../../../../tiled/packed/objects/apexshiplocker.png"
+      "image" : "../../../../tiled/packed/objects/apexshiplocker.png"
     },
     "174" : {
-      "image" : "../../../../../tiled/packed/objects/paintinggothic.png"
+      "image" : "../../../../tiled/packed/objects/paintinggothic.png"
     },
     "175" : {
-      "image" : "../../../../../tiled/packed/objects/hivebush1.png"
+      "image" : "../../../../tiled/packed/objects/hivebush1.png"
     },
     "176" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "177" : {
-      "image" : "../../../../../tiled/packed/objects/colourfulbush5.png"
+      "image" : "../../../../tiled/packed/objects/colourfulbush5.png"
     },
     "178" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "179" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush2.png"
+      "image" : "../../../../tiled/packed/objects/junglebush2.png"
     },
     "18" : {
-      "image" : "../../../../../tiled/packed/objects/crystalcavebush1.png"
+      "image" : "../../../../tiled/packed/objects/crystalcavebush1.png"
     },
     "180" : {
-      "image" : "../../../../../tiled/packed/objects/apexcomfychair.png"
+      "image" : "../../../../tiled/packed/objects/apexcomfychair.png"
     },
     "181" : {
-      "image" : "../../../../../tiled/packed/objects/apexwardrobe.png"
+      "image" : "../../../../tiled/packed/objects/apexwardrobe.png"
     },
     "182" : {
-      "image" : "../../../../../tiled/packed/objects/embercoral2.png"
+      "image" : "../../../../tiled/packed/objects/embercoral2.png"
     },
     "183" : {
-      "image" : "../../../../../tiled/packed/objects/redflask.png"
+      "image" : "../../../../tiled/packed/objects/redflask.png"
     },
     "184" : {
-      "image" : "../../../../../tiled/packed/objects/apexwoodenshelves.png"
+      "image" : "../../../../tiled/packed/objects/apexwoodenshelves.png"
     },
     "185" : {
-      "image" : "../../../../../tiled/packed/objects/dnaplant2.png"
+      "image" : "../../../../tiled/packed/objects/dnaplant2.png"
     },
     "186" : {
-      "image" : "../../../../../tiled/packed/objects/paintingmonalisa.png"
+      "image" : "../../../../tiled/packed/objects/paintingmonalisa.png"
     },
     "187" : {
-      "image" : "../../../../../tiled/packed/objects/slimeblob3.png"
+      "image" : "../../../../tiled/packed/objects/slimeblob3.png"
     },
     "188" : {
-      "image" : "../../../../../tiled/packed/objects/greenflask.png"
+      "image" : "../../../../tiled/packed/objects/greenflask.png"
     },
     "189" : {
-      "image" : "../../../../../tiled/packed/objects/apexlamp3.png"
+      "image" : "../../../../tiled/packed/objects/apexlamp3.png"
     },
     "19" : {
-      "image" : "../../../../../tiled/packed/objects/embercoral4.png"
+      "image" : "../../../../tiled/packed/objects/embercoral4.png"
     },
     "190" : {
-      "image" : "../../../../../tiled/packed/objects/electricsign.png"
+      "image" : "../../../../tiled/packed/objects/electricsign.png"
     },
     "191" : {
-      "image" : "../../../../../tiled/packed/objects/smallwindmill.png"
+      "image" : "../../../../tiled/packed/objects/smallwindmill.png"
     },
     "192" : {
-      "image" : "../../../../../tiled/packed/objects/plasmadisc.png"
+      "image" : "../../../../tiled/packed/objects/plasmadisc.png"
     },
     "193" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush18.png"
+      "image" : "../../../../tiled/packed/objects/junglebush18.png"
     },
     "194" : {
-      "image" : "../../../../../tiled/packed/objects/apexnameplate.png"
+      "image" : "../../../../tiled/packed/objects/apexnameplate.png"
     },
     "195" : {
-      "image" : "../../../../../tiled/packed/objects/tarcrystal5.png"
+      "image" : "../../../../tiled/packed/objects/tarcrystal5.png"
     },
     "196" : {
-      "image" : "../../../../../tiled/packed/objects/signdispenser.png"
+      "image" : "../../../../tiled/packed/objects/signdispenser.png"
     },
     "197" : {
-      "image" : "../../../../../tiled/packed/objects/apexstatue3.png"
+      "image" : "../../../../tiled/packed/objects/apexstatue3.png"
     },
     "198" : {
-      "image" : "../../../../../tiled/packed/objects/classicfountain.png"
+      "image" : "../../../../tiled/packed/objects/classicfountain.png"
     },
     "199" : {
-      "image" : "../../../../../tiled/packed/objects/smallinn.png"
+      "image" : "../../../../tiled/packed/objects/smallinn.png"
     },
     "2" : {
-      "image" : "../../../../../tiled/packed/objects/apexsink.png"
+      "image" : "../../../../tiled/packed/objects/apexsink.png"
     },
     "20" : {
-      "image" : "../../../../../tiled/packed/objects/embercoral1.png"
+      "image" : "../../../../tiled/packed/objects/embercoral1.png"
     },
     "200" : {
-      "image" : "../../../../../tiled/packed/objects/apexcooldesk.png"
+      "image" : "../../../../tiled/packed/objects/apexcooldesk.png"
     },
     "201" : {
-      "image" : "../../../../../tiled/packed/objects/apexwoodenchair.png"
+      "image" : "../../../../tiled/packed/objects/apexwoodenchair.png"
     },
     "202" : {
-      "image" : "../../../../../tiled/packed/objects/apexpod2.png"
+      "image" : "../../../../tiled/packed/objects/apexpod2.png"
     },
     "203" : {
-      "image" : "../../../../../tiled/packed/objects/apexpainting3.png"
+      "image" : "../../../../tiled/packed/objects/apexpainting3.png"
     },
     "204" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush9.png"
+      "image" : "../../../../tiled/packed/objects/junglebush9.png"
     },
     "205" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse10.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse10.png"
     },
     "206" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush7.png"
+      "image" : "../../../../tiled/packed/objects/junglebush7.png"
     },
     "207" : {
-      "image" : "../../../../../tiled/packed/objects/copperrocksmall.png"
+      "image" : "../../../../tiled/packed/objects/copperrocksmall.png"
     },
     "208" : {
-      "image" : "../../../../../tiled/packed/objects/vaseclassicmedium2.png"
+      "image" : "../../../../tiled/packed/objects/vaseclassicmedium2.png"
     },
     "209" : {
-      "image" : "../../../../../tiled/packed/objects/cellstructure4.png"
+      "image" : "../../../../tiled/packed/objects/cellstructure4.png"
     },
     "21" : {
-      "image" : "../../../../../tiled/packed/objects/dnaplant1.png"
+      "image" : "../../../../tiled/packed/objects/dnaplant1.png"
     },
     "210" : {
-      "image" : "../../../../../tiled/packed/objects/vaseclassicmedium1.png"
+      "image" : "../../../../tiled/packed/objects/vaseclassicmedium1.png"
     },
     "211" : {
-      "image" : "../../../../../tiled/packed/objects/copperrock.png"
+      "image" : "../../../../tiled/packed/objects/copperrock.png"
     },
     "212" : {
-      "image" : "../../../../../tiled/packed/objects/markerwallplaque3.png"
+      "image" : "../../../../tiled/packed/objects/markerwallplaque3.png"
     },
     "213" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush3.png"
+      "image" : "../../../../tiled/packed/objects/junglebush3.png"
     },
     "214" : {
-      "image" : "../../../../../tiled/packed/objects/apexpiano.png"
+      "image" : "../../../../tiled/packed/objects/apexpiano.png"
     },
     "215" : {
-      "image" : "../../../../../tiled/packed/objects/apextable.png"
+      "image" : "../../../../tiled/packed/objects/apextable.png"
     },
     "216" : {
-      "image" : "../../../../../tiled/packed/objects/smallclocktower.png"
+      "image" : "../../../../tiled/packed/objects/smallclocktower.png"
     },
     "217" : {
-      "image" : "../../../../../tiled/packed/objects/buglike2.png"
+      "image" : "../../../../tiled/packed/objects/buglike2.png"
     },
     "218" : {
-      "image" : "../../../../../tiled/packed/objects/apexstatue.png"
+      "image" : "../../../../tiled/packed/objects/apexstatue.png"
     },
     "219" : {
-      "image" : "../../../../../tiled/packed/objects/buglike4.png"
+      "image" : "../../../../tiled/packed/objects/buglike4.png"
     },
     "22" : {
-      "image" : "../../../../../tiled/packed/objects/hivelight1.png"
+      "image" : "../../../../tiled/packed/objects/hivelight1.png"
     },
     "220" : {
-      "image" : "../../../../../tiled/packed/objects/flowerbed2.png"
+      "image" : "../../../../tiled/packed/objects/flowerbed2.png"
     },
     "221" : {
-      "image" : "../../../../../tiled/packed/objects/apexwallpainting2.png"
+      "image" : "../../../../tiled/packed/objects/apexwallpainting2.png"
     },
     "222" : {
-      "image" : "../../../../../tiled/packed/objects/slimeblob4.png"
+      "image" : "../../../../tiled/packed/objects/slimeblob4.png"
     },
     "223" : {
-      "image" : "../../../../../tiled/packed/objects/crystalcavebush3.png"
+      "image" : "../../../../tiled/packed/objects/crystalcavebush3.png"
     },
     "224" : {
-      "image" : "../../../../../tiled/packed/objects/apexbed.png"
+      "image" : "../../../../tiled/packed/objects/apexbed.png"
     },
     "225" : {
-      "image" : "../../../../../tiled/packed/objects/tarcrystal4.png"
+      "image" : "../../../../tiled/packed/objects/tarcrystal4.png"
     },
     "226" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse9.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse9.png"
     },
     "227" : {
-      "image" : "../../../../../tiled/packed/objects/apexshiplightBroken.png"
+      "image" : "../../../../tiled/packed/objects/apexshiplightBroken.png"
     },
     "228" : {
-      "image" : "../../../../../tiled/packed/objects/vaseclassiclarge2.png"
+      "image" : "../../../../tiled/packed/objects/vaseclassiclarge2.png"
     },
     "229" : {
-      "image" : "../../../../../tiled/packed/objects/apexslidingdoor2.png"
+      "image" : "../../../../tiled/packed/objects/apexslidingdoor2.png"
     },
     "23" : {
-      "image" : "../../../../../tiled/packed/objects/hivelight1_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/hivelight1_orientation2.png"
     },
     "230" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "231" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "232" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "233" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "234" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "235" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush8.png"
+      "image" : "../../../../tiled/packed/objects/junglebush8.png"
     },
     "236" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse11.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse11.png"
     },
     "237" : {
-      "image" : "../../../../../tiled/packed/objects/apexconsolekeyboard.png"
+      "image" : "../../../../tiled/packed/objects/apexconsolekeyboard.png"
     },
     "238" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse4.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse4.png"
     },
     "239" : {
-      "image" : "../../../../../tiled/packed/objects/apexshipdoorBroken.png"
+      "image" : "../../../../tiled/packed/objects/apexshipdoorBroken.png"
     },
     "24" : {
-      "image" : "../../../../../tiled/packed/objects/hivelight1_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/hivelight1_orientation3.png"
     },
     "240" : {
-      "image" : "../../../../../tiled/packed/objects/alarm.png"
+      "image" : "../../../../tiled/packed/objects/alarm.png"
     },
     "241" : {
-      "image" : "../../../../../tiled/packed/objects/crystallinebush3.png"
+      "image" : "../../../../tiled/packed/objects/crystallinebush3.png"
     },
     "242" : {
-      "image" : "../../../../../tiled/packed/objects/apexoven.png"
+      "image" : "../../../../tiled/packed/objects/apexoven.png"
     },
     "243" : {
-      "image" : "../../../../../tiled/packed/objects/crystallinebush2.png"
+      "image" : "../../../../tiled/packed/objects/crystallinebush2.png"
     },
     "244" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "245" : {
-      "image" : "../../../../../tiled/packed/objects/buglike5.png"
+      "image" : "../../../../tiled/packed/objects/buglike5.png"
     },
     "246" : {
-      "image" : "../../../../../tiled/packed/objects/flowerbasket1.png"
+      "image" : "../../../../tiled/packed/objects/flowerbasket1.png"
     },
     "247" : {
-      "image" : "../../../../../tiled/packed/objects/flowerbasket1_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/flowerbasket1_orientation2.png"
     },
     "248" : {
-      "image" : "../../../../../tiled/packed/objects/flowerbasket1_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/flowerbasket1_orientation3.png"
     },
     "249" : {
-      "image" : "../../../../../tiled/packed/objects/silverrocksmall.png"
+      "image" : "../../../../tiled/packed/objects/silverrocksmall.png"
     },
     "25" : {
-      "image" : "../../../../../tiled/packed/objects/hivelight1_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/hivelight1_orientation4.png"
     },
     "250" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse5.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse5.png"
     },
     "251" : {
-      "image" : "../../../../../tiled/packed/objects/apexradio.png"
+      "image" : "../../../../tiled/packed/objects/apexradio.png"
     },
     "252" : {
-      "image" : "../../../../../tiled/packed/objects/apexlevel1sign.png"
+      "image" : "../../../../tiled/packed/objects/apexlevel1sign.png"
     },
     "253" : {
-      "image" : "../../../../../tiled/packed/objects/apexfridge.png"
+      "image" : "../../../../tiled/packed/objects/apexfridge.png"
     },
     "254" : {
-      "image" : "../../../../../tiled/packed/objects/fantasyboardgame.png"
+      "image" : "../../../../tiled/packed/objects/fantasyboardgame.png"
     },
     "255" : {
-      "image" : "../../../../../tiled/packed/objects/apexspeaker.png"
+      "image" : "../../../../tiled/packed/objects/apexspeaker.png"
     },
     "256" : {
-      "image" : "../../../../../tiled/packed/objects/rustbush4.png"
+      "image" : "../../../../tiled/packed/objects/rustbush4.png"
     },
     "257" : {
-      "image" : "../../../../../tiled/packed/objects/capsulesmall.png"
+      "image" : "../../../../tiled/packed/objects/capsulesmall.png"
     },
     "258" : {
-      "image" : "../../../../../tiled/packed/objects/arrowsign.png"
+      "image" : "../../../../tiled/packed/objects/arrowsign.png"
     },
     "259" : {
-      "image" : "../../../../../tiled/packed/objects/flowerbed1.png"
+      "image" : "../../../../tiled/packed/objects/flowerbed1.png"
     },
     "26" : {
-      "image" : "../../../../../tiled/packed/objects/hivelight1_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/hivelight1_orientation5.png"
     },
     "260" : {
-      "image" : "../../../../../tiled/packed/objects/apextv.png"
+      "image" : "../../../../tiled/packed/objects/apextv.png"
     },
     "261" : {
-      "image" : "../../../../../tiled/packed/objects/markerwallplaque1.png"
+      "image" : "../../../../tiled/packed/objects/markerwallplaque1.png"
     },
     "262" : {
-      "image" : "../../../../../tiled/packed/objects/hivebush2.png"
+      "image" : "../../../../tiled/packed/objects/hivebush2.png"
     },
     "263" : {
-      "image" : "../../../../../tiled/packed/objects/colourfulbush4.png"
+      "image" : "../../../../tiled/packed/objects/colourfulbush4.png"
     },
     "264" : {
-      "image" : "../../../../../tiled/packed/objects/windchime.png"
+      "image" : "../../../../tiled/packed/objects/windchime.png"
     },
     "265" : {
-      "image" : "../../../../../tiled/packed/objects/apexslidingdoor1.png"
+      "image" : "../../../../tiled/packed/objects/apexslidingdoor1.png"
     },
     "266" : {
-      "image" : "../../../../../tiled/packed/objects/apexcoolserver.png"
+      "image" : "../../../../tiled/packed/objects/apexcoolserver.png"
     },
     "267" : {
-      "image" : "../../../../../tiled/packed/objects/dnaplant4.png"
+      "image" : "../../../../tiled/packed/objects/dnaplant4.png"
     },
     "268" : {
-      "image" : "../../../../../tiled/packed/objects/colourfulbush3.png"
+      "image" : "../../../../tiled/packed/objects/colourfulbush3.png"
     },
     "269" : {
-      "image" : "../../../../../tiled/packed/objects/apexcoolchair.png"
+      "image" : "../../../../tiled/packed/objects/apexcoolchair.png"
     },
     "27" : {
-      "image" : "../../../../../tiled/packed/objects/paintingshakespeare.png"
+      "image" : "../../../../tiled/packed/objects/paintingshakespeare.png"
     },
     "270" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "271" : {
-      "image" : "../../../../../tiled/packed/objects/apexfuelhatch.png"
+      "image" : "../../../../tiled/packed/objects/apexfuelhatch.png"
     },
     "272" : {
-      "image" : "../../../../../tiled/packed/objects/smashbones2.png"
+      "image" : "../../../../tiled/packed/objects/smashbones2.png"
     },
     "273" : {
-      "image" : "../../../../../tiled/packed/objects/apexbananasign.png"
+      "image" : "../../../../tiled/packed/objects/apexbananasign.png"
     },
     "274" : {
-      "image" : "../../../../../tiled/packed/objects/smashbones1.png"
+      "image" : "../../../../tiled/packed/objects/smashbones1.png"
     },
     "275" : {
-      "image" : "../../../../../tiled/packed/objects/apexshiplight.png"
+      "image" : "../../../../tiled/packed/objects/apexshiplight.png"
     },
     "276" : {
-      "image" : "../../../../../tiled/packed/objects/apexaquarium2.png"
+      "image" : "../../../../tiled/packed/objects/apexaquarium2.png"
     },
     "277" : {
-      "image" : "../../../../../tiled/packed/objects/crystallinebush1.png"
+      "image" : "../../../../tiled/packed/objects/crystallinebush1.png"
     },
     "278" : {
-      "image" : "../../../../../tiled/packed/objects/cider.png"
+      "image" : "../../../../tiled/packed/objects/cider.png"
     },
     "279" : {
-      "image" : "../../../../../tiled/packed/objects/vaseclassicsmall2.png"
+      "image" : "../../../../tiled/packed/objects/vaseclassicsmall2.png"
     },
     "28" : {
-      "image" : "../../../../../tiled/packed/objects/microscope.png"
+      "image" : "../../../../tiled/packed/objects/microscope.png"
     },
     "280" : {
-      "image" : "../../../../../tiled/packed/objects/apexobeysign.png"
+      "image" : "../../../../tiled/packed/objects/apexobeysign.png"
     },
     "281" : {
-      "image" : "../../../../../tiled/packed/objects/reddangersign.png"
+      "image" : "../../../../tiled/packed/objects/reddangersign.png"
     },
     "282" : {
-      "image" : "../../../../../tiled/packed/objects/classicchair.png"
+      "image" : "../../../../tiled/packed/objects/classicchair.png"
     },
     "283" : {
-      "image" : "../../../../../tiled/packed/objects/apexcounter2.png"
+      "image" : "../../../../tiled/packed/objects/apexcounter2.png"
     },
     "284" : {
-      "image" : "../../../../../tiled/packed/objects/smallchurch.png"
+      "image" : "../../../../tiled/packed/objects/smallchurch.png"
     },
     "285" : {
-      "image" : "../../../../../tiled/packed/objects/apexdesk.png"
+      "image" : "../../../../tiled/packed/objects/apexdesk.png"
     },
     "286" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse6.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse6.png"
     },
     "287" : {
-      "image" : "../../../../../tiled/packed/objects/apexbrainjar.png"
+      "image" : "../../../../tiled/packed/objects/apexbrainjar.png"
     },
     "288" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush1.png"
+      "image" : "../../../../tiled/packed/objects/junglebush1.png"
     },
     "289" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush13.png"
+      "image" : "../../../../tiled/packed/objects/junglebush13.png"
     },
     "29" : {
-      "image" : "../../../../../tiled/packed/objects/markerwallplaque2.png"
+      "image" : "../../../../tiled/packed/objects/markerwallplaque2.png"
     },
     "290" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush16.png"
+      "image" : "../../../../tiled/packed/objects/junglebush16.png"
     },
     "291" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush6.png"
+      "image" : "../../../../tiled/packed/objects/junglebush6.png"
     },
     "292" : {
-      "image" : "../../../../../tiled/packed/objects/rustbush3.png"
+      "image" : "../../../../tiled/packed/objects/rustbush3.png"
     },
     "293" : {
-      "image" : "../../../../../tiled/packed/objects/apexshipdoor.png"
+      "image" : "../../../../tiled/packed/objects/apexshipdoor.png"
     },
     "294" : {
-      "image" : "../../../../../tiled/packed/objects/apexshiplockerTier0.png"
+      "image" : "../../../../tiled/packed/objects/apexshiplockerTier0.png"
     },
     "295" : {
-      "image" : "../../../../../tiled/packed/objects/lunarbasedoor.png"
+      "image" : "../../../../tiled/packed/objects/lunarbasedoor.png"
     },
     "296" : {
-      "image" : "../../../../../tiled/packed/objects/lunarbasedoor_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/lunarbasedoor_orientation1.png"
     },
     "297" : {
-      "image" : "../../../../../tiled/packed/objects/apexpainting1.png"
+      "image" : "../../../../tiled/packed/objects/apexpainting1.png"
     },
     "298" : {
-      "image" : "../../../../../tiled/packed/objects/apexwoodpanel.png"
+      "image" : "../../../../tiled/packed/objects/apexwoodpanel.png"
     },
     "299" : {
-      "image" : "../../../../../tiled/packed/objects/tarcrystal1.png"
+      "image" : "../../../../tiled/packed/objects/tarcrystal1.png"
     },
     "3" : {
-      "image" : "../../../../../tiled/packed/objects/cellstructure3.png"
+      "image" : "../../../../tiled/packed/objects/cellstructure3.png"
     },
     "30" : {
-      "image" : "../../../../../tiled/packed/objects/classiclight.png"
+      "image" : "../../../../tiled/packed/objects/classiclight.png"
     },
     "300" : {
-      "image" : "../../../../../tiled/packed/objects/apexmedsign.png"
+      "image" : "../../../../tiled/packed/objects/apexmedsign.png"
     },
     "301" : {
-      "image" : "../../../../../tiled/packed/objects/redlightBroken.png"
+      "image" : "../../../../tiled/packed/objects/redlightBroken.png"
     },
     "302" : {
-      "image" : "../../../../../tiled/packed/objects/apexflusign.png"
+      "image" : "../../../../tiled/packed/objects/apexflusign.png"
     },
     "303" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "304" : {
-      "image" : "../../../../../tiled/packed/objects/apexhdtv.png"
+      "image" : "../../../../tiled/packed/objects/apexhdtv.png"
     },
     "305" : {
-      "image" : "../../../../../tiled/packed/objects/techstationTier0.png"
+      "image" : "../../../../tiled/packed/objects/techstationTier0.png"
     },
     "306" : {
-      "image" : "../../../../../tiled/packed/objects/embercoral5.png"
+      "image" : "../../../../tiled/packed/objects/embercoral5.png"
     },
     "307" : {
-      "image" : "../../../../../tiled/packed/objects/paintingcreationofapepixel.png"
+      "image" : "../../../../tiled/packed/objects/paintingcreationofapepixel.png"
     },
     "308" : {
-      "image" : "../../../../../tiled/packed/objects/paintingbirthofapevenus.png"
+      "image" : "../../../../tiled/packed/objects/paintingbirthofapevenus.png"
     },
     "309" : {
-      "image" : "../../../../../tiled/packed/objects/paintingapegothic.png"
+      "image" : "../../../../tiled/packed/objects/paintingapegothic.png"
     },
     "31" : {
-      "image" : "../../../../../tiled/packed/objects/classiclight_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/classiclight_orientation2.png"
     },
     "310" : {
-      "image" : "../../../../../tiled/packed/objects/paintingapexpearlearring.png"
+      "image" : "../../../../tiled/packed/objects/paintingapexpearlearring.png"
     },
     "311" : {
-      "image" : "../../../../../tiled/packed/objects/paintingapescream.png"
+      "image" : "../../../../tiled/packed/objects/paintingapescream.png"
     },
     "312" : {
-      "image" : "../../../../../tiled/packed/objects/classicbanner1.png"
+      "image" : "../../../../tiled/packed/objects/classicbanner1.png"
     },
     "313" : {
-      "image" : "../../../../../tiled/packed/objects/classicbanner3.png"
+      "image" : "../../../../tiled/packed/objects/classicbanner3.png"
     },
     "314" : {
-      "image" : "../../../../../tiled/packed/objects/classicbanner2.png"
+      "image" : "../../../../tiled/packed/objects/classicbanner2.png"
     },
     "315" : {
-      "image" : "../../../../../tiled/packed/objects/combinationprop.png"
+      "image" : "../../../../tiled/packed/objects/combinationprop.png"
     },
     "316" : {
-      "image" : "../../../../../tiled/packed/objects/paintingapexwithermine.png"
+      "image" : "../../../../tiled/packed/objects/paintingapexwithermine.png"
     },
     "317" : {
-      "image" : "../../../../../tiled/packed/objects/classicbanner2b.png"
+      "image" : "../../../../tiled/packed/objects/classicbanner2b.png"
     },
     "318" : {
-      "image" : "../../../../../tiled/packed/objects/classicbannertattered.png"
+      "image" : "../../../../tiled/packed/objects/classicbannertattered.png"
     },
     "319" : {
-      "image" : "../../../../../tiled/packed/objects/flagapex.png"
+      "image" : "../../../../tiled/packed/objects/flagapex.png"
     },
     "32" : {
-      "image" : "../../../../../tiled/packed/objects/classiclight_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/classiclight_orientation3.png"
     },
     "320" : {
-      "image" : "../../../../../tiled/packed/objects/flagapex_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/flagapex_orientation1.png"
     },
     "321" : {
-      "image" : "../../../../../tiled/packed/objects/teleporterTier0.png"
+      "image" : "../../../../tiled/packed/objects/teleporterTier0.png"
     },
     "322" : {
-      "image" : "../../../../../tiled/packed/objects/teleporter.png"
+      "image" : "../../../../tiled/packed/objects/teleporter.png"
     },
     "323" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "324" : {
-      "image" : "../../../../../tiled/packed/objects/tenstudiesplaque.png"
+      "image" : "../../../../tiled/packed/objects/tenstudiesplaque.png"
     },
     "325" : {
-      "image" : "../../../../../tiled/packed/objects/saloonlight.png"
+      "image" : "../../../../tiled/packed/objects/saloonlight.png"
     },
     "326" : {
-      "image" : "../../../../../tiled/packed/objects/saloonlight_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/saloonlight_orientation2.png"
     },
     "327" : {
-      "image" : "../../../../../tiled/packed/objects/saloonlight_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/saloonlight_orientation3.png"
     },
     "328" : {
-      "image" : "../../../../../tiled/packed/objects/symbiotesample.png"
+      "image" : "../../../../tiled/packed/objects/symbiotesample.png"
     },
     "329" : {
-      "image" : "../../../../../tiled/packed/objects/teslaspike_orientation8.png"
+      "image" : "../../../../tiled/packed/objects/teslaspike_orientation8.png"
     },
     "33" : {
-      "image" : "../../../../../tiled/packed/objects/classicbed.png"
+      "image" : "../../../../tiled/packed/objects/classicbed.png"
     },
     "330" : {
-      "image" : "../../../../../tiled/packed/objects/laboratoryverticaldoor.png"
+      "image" : "../../../../tiled/packed/objects/laboratoryverticaldoor.png"
     },
     "331" : {
-      "image" : "../../../../../tiled/packed/objects/laboratorylight.png"
+      "image" : "../../../../tiled/packed/objects/laboratorylight.png"
     },
     "332" : {
-      "image" : "../../../../../tiled/packed/objects/prismrock4.png"
+      "image" : "../../../../tiled/packed/objects/prismrock4.png"
     },
     "333" : {
-      "image" : "../../../../../tiled/packed/objects/prismrock7.png"
+      "image" : "../../../../tiled/packed/objects/prismrock7.png"
     },
     "334" : {
-      "image" : "../../../../../tiled/packed/objects/prismrock6.png"
+      "image" : "../../../../tiled/packed/objects/prismrock6.png"
     },
     "335" : {
-      "image" : "../../../../../tiled/packed/objects/prismrock8.png"
+      "image" : "../../../../tiled/packed/objects/prismrock8.png"
     },
     "336" : {
-      "image" : "../../../../../tiled/packed/objects/prismrock5.png"
+      "image" : "../../../../tiled/packed/objects/prismrock5.png"
     },
     "337" : {
-      "image" : "../../../../../tiled/packed/objects/protectoratewallbanner.png"
+      "image" : "../../../../tiled/packed/objects/protectoratewallbanner.png"
     },
     "338" : {
-      "image" : "../../../../../tiled/packed/objects/foundryconsole.png"
+      "image" : "../../../../tiled/packed/objects/foundryconsole.png"
     },
     "339" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "34" : {
-      "image" : "../../../../../tiled/packed/objects/classicdoor.png"
+      "image" : "../../../../tiled/packed/objects/classicdoor.png"
     },
     "340" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "341" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "342" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "343" : {
-      "image" : "../../../../../tiled/packed/objects/bombsheltershelf1.png"
+      "image" : "../../../../tiled/packed/objects/bombsheltershelf1.png"
     },
     "344" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "345" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "346" : {
-      "image" : "../../../../../tiled/packed/objects/scorchedcitycounter.png"
+      "image" : "../../../../tiled/packed/objects/scorchedcitycounter.png"
     },
     "347" : {
-      "image" : "../../../../../tiled/packed/objects/scorchedcitybrokenstoreshelf.png"
+      "image" : "../../../../tiled/packed/objects/scorchedcitybrokenstoreshelf.png"
     },
     "348" : {
-      "image" : "../../../../../tiled/packed/objects/miniknogoldsign.png"
+      "image" : "../../../../tiled/packed/objects/miniknogoldsign.png"
     },
     "349" : {
-      "image" : "../../../../../tiled/packed/objects/apexartifactaltar.png"
+      "image" : "../../../../tiled/packed/objects/apexartifactaltar.png"
     },
     "35" : {
-      "image" : "../../../../../tiled/packed/objects/classiccandlestick.png"
+      "image" : "../../../../tiled/packed/objects/classiccandlestick.png"
     },
     "350" : {
-      "image" : "../../../../../tiled/packed/objects/fistlauncher.png"
+      "image" : "../../../../tiled/packed/objects/fistlauncher.png"
     },
     "351" : {
-      "image" : "../../../../../tiled/packed/objects/fistlauncher_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/fistlauncher_orientation1.png"
     },
     "352" : {
-      "image" : "../../../../../tiled/packed/objects/fistlauncher_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/fistlauncher_orientation2.png"
     },
     "353" : {
-      "image" : "../../../../../tiled/packed/objects/fistlauncher_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/fistlauncher_orientation3.png"
     },
     "354" : {
-      "image" : "../../../../../tiled/packed/objects/bigapescreen.png"
+      "image" : "../../../../tiled/packed/objects/bigapescreen.png"
     },
     "355" : {
-      "image" : "../../../../../tiled/packed/objects/tentaclepopbig.png"
+      "image" : "../../../../tiled/packed/objects/tentaclepopbig.png"
     },
     "356" : {
-      "image" : "../../../../../tiled/packed/objects/tentaclepopmed.png"
+      "image" : "../../../../tiled/packed/objects/tentaclepopmed.png"
     },
     "357" : {
-      "image" : "../../../../../tiled/packed/objects/tentaclepopsmall.png"
+      "image" : "../../../../tiled/packed/objects/tentaclepopsmall.png"
     },
     "358" : {
-      "image" : "../../../../../tiled/packed/objects/apexstoresign.png"
+      "image" : "../../../../tiled/packed/objects/apexstoresign.png"
     },
     "359" : {
-      "image" : "../../../../../tiled/packed/objects/sandbags.png"
+      "image" : "../../../../tiled/packed/objects/sandbags.png"
     },
     "36" : {
-      "image" : "../../../../../tiled/packed/objects/classiccandlestick_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/classiccandlestick_orientation1.png"
     },
     "360" : {
-      "image" : "../../../../../tiled/packed/objects/bigapetargetmap.png"
+      "image" : "../../../../tiled/packed/objects/bigapetargetmap.png"
     },
     "361" : {
-      "image" : "../../../../../tiled/packed/objects/miniknogintel1.png"
+      "image" : "../../../../tiled/packed/objects/miniknogintel1.png"
     },
     "362" : {
-      "image" : "../../../../../tiled/packed/objects/minidronerack.png"
+      "image" : "../../../../tiled/packed/objects/minidronerack.png"
     },
     "363" : {
-      "image" : "../../../../../tiled/packed/objects/miniknognewspaper.png"
+      "image" : "../../../../tiled/packed/objects/miniknognewspaper.png"
     },
     "364" : {
-      "image" : "../../../../../tiled/packed/objects/bigapedoll.png"
+      "image" : "../../../../tiled/packed/objects/bigapedoll.png"
     },
     "365" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain3.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain3.png"
     },
     "366" : {
-      "image" : "../../../../../tiled/packed/objects/classicapestatuenohead.png"
+      "image" : "../../../../tiled/packed/objects/classicapestatuenohead.png"
     },
     "37" : {
-      "image" : "../../../../../tiled/packed/objects/classicbardoor.png"
+      "image" : "../../../../tiled/packed/objects/classicbardoor.png"
     },
     "38" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "39" : {
-      "image" : "../../../../../tiled/packed/objects/apextablelamp.png"
+      "image" : "../../../../tiled/packed/objects/apextablelamp.png"
     },
     "4" : {
-      "image" : "../../../../../tiled/packed/objects/diamondrocksmall.png"
+      "image" : "../../../../tiled/packed/objects/diamondrocksmall.png"
     },
     "40" : {
-      "image" : "../../../../../tiled/packed/objects/apexstatue2.png"
+      "image" : "../../../../tiled/packed/objects/apexstatue2.png"
     },
     "41" : {
-      "image" : "../../../../../tiled/packed/objects/apexcaptainschair.png"
+      "image" : "../../../../tiled/packed/objects/apexcaptainschair.png"
     },
     "42" : {
-      "image" : "../../../../../tiled/packed/objects/apexturret.png"
+      "image" : "../../../../tiled/packed/objects/apexturret.png"
     },
     "43" : {
-      "image" : "../../../../../tiled/packed/objects/apexpod.png"
+      "image" : "../../../../tiled/packed/objects/apexpod.png"
     },
     "44" : {
-      "image" : "../../../../../tiled/packed/objects/classicchest.png"
+      "image" : "../../../../tiled/packed/objects/classicchest.png"
     },
     "45" : {
-      "image" : "../../../../../tiled/packed/objects/apexmocksign.png"
+      "image" : "../../../../tiled/packed/objects/apexmocksign.png"
     },
     "46" : {
-      "image" : "../../../../../tiled/packed/objects/apexlocker.png"
+      "image" : "../../../../tiled/packed/objects/apexlocker.png"
     },
     "47" : {
-      "image" : "../../../../../tiled/packed/objects/colourfulbush2.png"
+      "image" : "../../../../tiled/packed/objects/colourfulbush2.png"
     },
     "48" : {
-      "image" : "../../../../../tiled/packed/objects/apexpainting5.png"
+      "image" : "../../../../tiled/packed/objects/apexpainting5.png"
     },
     "49" : {
-      "image" : "../../../../../tiled/packed/objects/buglike1.png"
+      "image" : "../../../../tiled/packed/objects/buglike1.png"
     },
     "5" : {
-      "image" : "../../../../../tiled/packed/objects/slimeblob1.png"
+      "image" : "../../../../tiled/packed/objects/slimeblob1.png"
     },
     "50" : {
-      "image" : "../../../../../tiled/packed/objects/capsulemed.png"
+      "image" : "../../../../tiled/packed/objects/capsulemed.png"
     },
     "51" : {
-      "image" : "../../../../../tiled/packed/objects/apexcooldoor.png"
+      "image" : "../../../../tiled/packed/objects/apexcooldoor.png"
     },
     "52" : {
-      "image" : "../../../../../tiled/packed/objects/apexcoolbookcase.png"
+      "image" : "../../../../tiled/packed/objects/apexcoolbookcase.png"
     },
     "53" : {
-      "image" : "../../../../../tiled/packed/objects/apexceilingtv.png"
+      "image" : "../../../../tiled/packed/objects/apexceilingtv.png"
     },
     "54" : {
-      "image" : "../../../../../tiled/packed/objects/apexcoolshelf1.png"
+      "image" : "../../../../tiled/packed/objects/apexcoolshelf1.png"
     },
     "55" : {
-      "image" : "../../../../../tiled/packed/objects/apexarmchair.png"
+      "image" : "../../../../tiled/packed/objects/apexarmchair.png"
     },
     "56" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush15.png"
+      "image" : "../../../../tiled/packed/objects/junglebush15.png"
     },
     "57" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse7.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse7.png"
     },
     "58" : {
-      "image" : "../../../../../tiled/packed/objects/apexdonotenter.png"
+      "image" : "../../../../tiled/packed/objects/apexdonotenter.png"
     },
     "59" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse3.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse3.png"
     },
     "6" : {
-      "image" : "../../../../../tiled/packed/objects/blueprintblob.png"
+      "image" : "../../../../tiled/packed/objects/blueprintblob.png"
     },
     "60" : {
-      "image" : "../../../../../tiled/packed/objects/classicchandelier.png"
+      "image" : "../../../../tiled/packed/objects/classicchandelier.png"
     },
     "61" : {
-      "image" : "../../../../../tiled/packed/objects/buglike10.png"
+      "image" : "../../../../tiled/packed/objects/buglike10.png"
     },
     "62" : {
-      "image" : "../../../../../tiled/packed/objects/apexcoolcomputer.png"
+      "image" : "../../../../tiled/packed/objects/apexcoolcomputer.png"
     },
     "63" : {
-      "image" : "../../../../../tiled/packed/objects/apexconsole1.png"
+      "image" : "../../../../tiled/packed/objects/apexconsole1.png"
     },
     "64" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush4.png"
+      "image" : "../../../../tiled/packed/objects/junglebush4.png"
     },
     "65" : {
-      "image" : "../../../../../tiled/packed/objects/apexcouch.png"
+      "image" : "../../../../tiled/packed/objects/apexcouch.png"
     },
     "66" : {
-      "image" : "../../../../../tiled/packed/objects/crystallinebush4.png"
+      "image" : "../../../../tiled/packed/objects/crystallinebush4.png"
     },
     "67" : {
-      "image" : "../../../../../tiled/packed/objects/movingsunflower.png"
+      "image" : "../../../../tiled/packed/objects/movingsunflower.png"
     },
     "68" : {
-      "image" : "../../../../../tiled/packed/objects/tarcrystal2.png"
+      "image" : "../../../../tiled/packed/objects/tarcrystal2.png"
     },
     "69" : {
-      "image" : "../../../../../tiled/packed/objects/apexlamp2.png"
+      "image" : "../../../../tiled/packed/objects/apexlamp2.png"
     },
     "7" : {
-      "image" : "../../../../../tiled/packed/objects/hivebush4.png"
+      "image" : "../../../../tiled/packed/objects/hivebush4.png"
     },
     "70" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush11.png"
+      "image" : "../../../../tiled/packed/objects/junglebush11.png"
     },
     "71" : {
-      "image" : "../../../../../tiled/packed/objects/paintingapespeare.png"
+      "image" : "../../../../tiled/packed/objects/paintingapespeare.png"
     },
     "72" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "73" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse1.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse1.png"
     },
     "74" : {
-      "image" : "../../../../../tiled/packed/objects/classicbookcase.png"
+      "image" : "../../../../tiled/packed/objects/classicbookcase.png"
     },
     "75" : {
-      "image" : "../../../../../tiled/packed/objects/classicapestatue.png"
+      "image" : "../../../../tiled/packed/objects/classicapestatue.png"
     },
     "76" : {
-      "image" : "../../../../../tiled/packed/objects/apexcooltable.png"
+      "image" : "../../../../tiled/packed/objects/apexcooltable.png"
     },
     "77" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush5.png"
+      "image" : "../../../../tiled/packed/objects/junglebush5.png"
     },
     "78" : {
-      "image" : "../../../../../tiled/packed/objects/smallhouse2.png"
+      "image" : "../../../../tiled/packed/objects/smallhouse2.png"
     },
     "79" : {
-      "image" : "../../../../../tiled/packed/objects/apexstatue1.png"
+      "image" : "../../../../tiled/packed/objects/apexstatue1.png"
     },
     "8" : {
-      "image" : "../../../../../tiled/packed/objects/buglike9.png"
+      "image" : "../../../../tiled/packed/objects/buglike9.png"
     },
     "80" : {
-      "image" : "../../../../../tiled/packed/objects/vaseclassiclarge1.png"
+      "image" : "../../../../tiled/packed/objects/vaseclassiclarge1.png"
     },
     "81" : {
-      "image" : "../../../../../tiled/packed/objects/junglebush14.png"
+      "image" : "../../../../tiled/packed/objects/junglebush14.png"
     },
     "82" : {
-      "image" : "../../../../../tiled/packed/objects/goldrocksmall.png"
+      "image" : "../../../../tiled/packed/objects/goldrocksmall.png"
     },
     "83" : {
-      "image" : "../../../../../tiled/packed/objects/paintingstarrynight.png"
+      "image" : "../../../../tiled/packed/objects/paintingstarrynight.png"
     },
     "84" : {
-      "image" : "../../../../../tiled/packed/objects/embercoral3.png"
+      "image" : "../../../../tiled/packed/objects/embercoral3.png"
     },
     "85" : {
-      "image" : "../../../../../tiled/packed/objects/apexthoughtreassign.png"
+      "image" : "../../../../tiled/packed/objects/apexthoughtreassign.png"
     },
     "86" : {
-      "image" : "../../../../../tiled/packed/objects/dnaplant3.png"
+      "image" : "../../../../tiled/packed/objects/dnaplant3.png"
     },
     "87" : {
-      "image" : "../../../../../tiled/packed/objects/apextorturebed.png"
+      "image" : "../../../../tiled/packed/objects/apextorturebed.png"
     },
     "88" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain1.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain1.png"
     },
     "89" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain1_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain1_orientation2.png"
     },
     "9" : {
-      "image" : "../../../../../tiled/packed/objects/buglike8.png"
+      "image" : "../../../../tiled/packed/objects/buglike8.png"
     },
     "90" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain1_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain1_orientation3.png"
     },
     "91" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain1_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain1_orientation4.png"
     },
     "92" : {
-      "image" : "../../../../../tiled/packed/objects/classiccurtain1_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/classiccurtain1_orientation5.png"
     },
     "93" : {
-      "image" : "../../../../../tiled/packed/objects/capsulebig.png"
+      "image" : "../../../../tiled/packed/objects/capsulebig.png"
     },
     "94" : {
-      "image" : "../../../../../tiled/packed/objects/apexcoolshelf2.png"
+      "image" : "../../../../tiled/packed/objects/apexcoolshelf2.png"
     },
     "95" : {
-      "image" : "../../../../../tiled/packed/objects/slimeblob2.png"
+      "image" : "../../../../tiled/packed/objects/slimeblob2.png"
     },
     "96" : {
-      "image" : "../../../../../tiled/packed/objects/classiclightart.png"
+      "image" : "../../../../tiled/packed/objects/classiclightart.png"
     },
     "97" : {
-      "image" : "../../../../../tiled/packed/objects/apexcounter1.png"
+      "image" : "../../../../tiled/packed/objects/apexcounter1.png"
     },
     "98" : {
-      "image" : "../../../../../tiled/packed/objects/apexlamp1.png"
+      "image" : "../../../../tiled/packed/objects/apexlamp1.png"
     },
     "99" : {
-      "image" : "../../../../../tiled/packed/objects/apexcurtain.png"
+      "image" : "../../../../tiled/packed/objects/apexcurtain.png"
     }
   },
   "tilewidth" : 80

--- a/tilesets/frackinuniverse-custom/copper.json
+++ b/tilesets/frackinuniverse-custom/copper.json
@@ -91,31 +91,31 @@
   },
   "tiles" : {
     "0" : {
-      "image" : "../../../../../tiled/packed/objects/coppersupport.png"
+      "image" : "../../../../tiled/packed/objects/coppersupport.png"
     },
     "1" : {
-      "image" : "../../../../../tiled/packed/objects/coppersupport_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/coppersupport_orientation1.png"
     },
     "2" : {
-      "image" : "../../../../../tiled/packed/objects/coppersupport_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/coppersupport_orientation2.png"
     },
     "3" : {
-      "image" : "../../../../../tiled/packed/objects/coppersupport_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/coppersupport_orientation3.png"
     },
     "4" : {
-      "image" : "../../../../../tiled/packed/objects/copperlantern.png"
+      "image" : "../../../../tiled/packed/objects/copperlantern.png"
     },
     "5" : {
-      "image" : "../../../../../tiled/packed/objects/copperlantern_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/copperlantern_orientation2.png"
     },
     "6" : {
-      "image" : "../../../../../tiled/packed/objects/coppershelf.png"
+      "image" : "../../../../tiled/packed/objects/coppershelf.png"
     },
     "7" : {
-      "image" : "../../../../../tiled/packed/objects/copperceilinglight.png"
+      "image" : "../../../../tiled/packed/objects/copperceilinglight.png"
     },
     "8" : {
-      "image" : "../../../../../tiled/packed/objects/copperbox1.png"
+      "image" : "../../../../tiled/packed/objects/copperbox1.png"
     }
   },
   "tilewidth" : 8

--- a/tilesets/frackinuniverse-custom/human.json
+++ b/tilesets/frackinuniverse-custom/human.json
@@ -2313,814 +2313,814 @@
   },
   "tiles" : {
     "0" : {
-      "image" : "../../../../../tiled/packed/objects/prisonbed.png"
+      "image" : "../../../../tiled/packed/objects/prisonbed.png"
     },
     "1" : {
-      "image" : "../../../../../tiled/packed/objects/glasspanel.png"
+      "image" : "../../../../tiled/packed/objects/glasspanel.png"
     },
     "10" : {
-      "image" : "../../../../../tiled/packed/objects/timer1s.png"
+      "image" : "../../../../tiled/packed/objects/timer1s.png"
     },
     "100" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerposter1.png"
+      "image" : "../../../../tiled/packed/objects/bunkerposter1.png"
     },
     "101" : {
-      "image" : "../../../../../tiled/packed/objects/jukebox.png"
+      "image" : "../../../../tiled/packed/objects/jukebox.png"
     },
     "102" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerdisplay3.png"
+      "image" : "../../../../tiled/packed/objects/bunkerdisplay3.png"
     },
     "103" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfence2.png"
+      "image" : "../../../../tiled/packed/objects/prisonfence2.png"
     },
     "104" : {
-      "image" : "../../../../../tiled/packed/objects/xor.png"
+      "image" : "../../../../tiled/packed/objects/xor.png"
     },
     "105" : {
-      "image" : "../../../../../tiled/packed/objects/drip1.png"
+      "image" : "../../../../tiled/packed/objects/drip1.png"
     },
     "106" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "107" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "108" : {
-      "image" : "../../../../../tiled/packed/objects/prisonlocker1.png"
+      "image" : "../../../../tiled/packed/objects/prisonlocker1.png"
     },
     "109" : {
-      "image" : "../../../../../tiled/packed/objects/miningbelt.png"
+      "image" : "../../../../tiled/packed/objects/miningbelt.png"
     },
     "11" : {
-      "image" : "../../../../../tiled/packed/objects/timer.png"
+      "image" : "../../../../tiled/packed/objects/timer.png"
     },
     "110" : {
-      "image" : "../../../../../tiled/packed/objects/humanstoragelocker.png"
+      "image" : "../../../../tiled/packed/objects/humanstoragelocker.png"
     },
     "111" : {
-      "image" : "../../../../../tiled/packed/objects/hazardtapeh.png"
+      "image" : "../../../../tiled/packed/objects/hazardtapeh.png"
     },
     "112" : {
-      "image" : "../../../../../tiled/packed/objects/brokenhumanfuelhatch.png"
+      "image" : "../../../../tiled/packed/objects/brokenhumanfuelhatch.png"
     },
     "113" : {
-      "image" : "../../../../../tiled/packed/objects/bunkertable2.png"
+      "image" : "../../../../tiled/packed/objects/bunkertable2.png"
     },
     "114" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerpanel2.png"
+      "image" : "../../../../tiled/packed/objects/bunkerpanel2.png"
     },
     "115" : {
-      "image" : "../../../../../tiled/packed/objects/fridge.png"
+      "image" : "../../../../tiled/packed/objects/fridge.png"
     },
     "116" : {
-      "image" : "../../../../../tiled/packed/objects/oven1.png"
+      "image" : "../../../../tiled/packed/objects/oven1.png"
     },
     "117" : {
-      "image" : "../../../../../tiled/packed/objects/miningcrusher.png"
+      "image" : "../../../../tiled/packed/objects/miningcrusher.png"
     },
     "118" : {
-      "image" : "../../../../../tiled/packed/objects/prisonshower.png"
+      "image" : "../../../../tiled/packed/objects/prisonshower.png"
     },
     "119" : {
-      "image" : "../../../../../tiled/packed/objects/basicbath.png"
+      "image" : "../../../../tiled/packed/objects/basicbath.png"
     },
     "12" : {
-      "image" : "../../../../../tiled/packed/objects/dlatch.png"
+      "image" : "../../../../tiled/packed/objects/dlatch.png"
     },
     "120" : {
-      "image" : "../../../../../tiled/packed/objects/prisonradiator.png"
+      "image" : "../../../../tiled/packed/objects/prisonradiator.png"
     },
     "121" : {
-      "image" : "../../../../../tiled/packed/objects/watermachine.png"
+      "image" : "../../../../tiled/packed/objects/watermachine.png"
     },
     "122" : {
-      "image" : "../../../../../tiled/packed/objects/prisonsign1.png"
+      "image" : "../../../../tiled/packed/objects/prisonsign1.png"
     },
     "123" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerpanel3.png"
+      "image" : "../../../../tiled/packed/objects/bunkerpanel3.png"
     },
     "124" : {
-      "image" : "../../../../../tiled/packed/objects/humantechstation.png"
+      "image" : "../../../../tiled/packed/objects/humantechstation.png"
     },
     "125" : {
-      "image" : "../../../../../tiled/packed/objects/spawnerwizard.png"
+      "image" : "../../../../tiled/packed/objects/spawnerwizard.png"
     },
     "126" : {
-      "image" : "../../../../../tiled/packed/objects/pixelcompressor.png"
+      "image" : "../../../../tiled/packed/objects/pixelcompressor.png"
     },
     "127" : {
-      "image" : "../../../../../tiled/packed/objects/spawnerhuman.png"
+      "image" : "../../../../tiled/packed/objects/spawnerhuman.png"
     },
     "128" : {
-      "image" : "../../../../../tiled/packed/objects/humanshiplocker.png"
+      "image" : "../../../../tiled/packed/objects/humanshiplocker.png"
     },
     "129" : {
-      "image" : "../../../../../tiled/packed/objects/bunkervent.png"
+      "image" : "../../../../tiled/packed/objects/bunkervent.png"
     },
     "13" : {
-      "image" : "../../../../../tiled/packed/objects/not.png"
+      "image" : "../../../../tiled/packed/objects/not.png"
     },
     "130" : {
-      "image" : "../../../../../tiled/packed/objects/spawnerglitch.png"
+      "image" : "../../../../tiled/packed/objects/spawnerglitch.png"
     },
     "131" : {
-      "image" : "../../../../../tiled/packed/objects/prisonturbine.png"
+      "image" : "../../../../tiled/packed/objects/prisonturbine.png"
     },
     "132" : {
-      "image" : "../../../../../tiled/packed/objects/prisongraffiti2.png"
+      "image" : "../../../../tiled/packed/objects/prisongraffiti2.png"
     },
     "133" : {
-      "image" : "../../../../../tiled/packed/objects/prisonpanel.png"
+      "image" : "../../../../tiled/packed/objects/prisonpanel.png"
     },
     "134" : {
-      "image" : "../../../../../tiled/packed/objects/prisonpaper1.png"
+      "image" : "../../../../tiled/packed/objects/prisonpaper1.png"
     },
     "135" : {
-      "image" : "../../../../../tiled/packed/objects/prisonpaper2.png"
+      "image" : "../../../../tiled/packed/objects/prisonpaper2.png"
     },
     "136" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerpanel1.png"
+      "image" : "../../../../tiled/packed/objects/bunkerpanel1.png"
     },
     "137" : {
-      "image" : "../../../../../tiled/packed/objects/humanfuelhatch.png"
+      "image" : "../../../../tiled/packed/objects/humanfuelhatch.png"
     },
     "138" : {
-      "image" : "../../../../../tiled/packed/objects/prisoncabinet1.png"
+      "image" : "../../../../tiled/packed/objects/prisoncabinet1.png"
     },
     "139" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerwires.png"
+      "image" : "../../../../tiled/packed/objects/bunkerwires.png"
     },
     "14" : {
-      "image" : "../../../../../tiled/packed/objects/or.png"
+      "image" : "../../../../tiled/packed/objects/or.png"
     },
     "140" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "141" : {
-      "image" : "../../../../../tiled/packed/objects/prisonstonesign.png"
+      "image" : "../../../../tiled/packed/objects/prisonstonesign.png"
     },
     "142" : {
-      "image" : "../../../../../tiled/packed/objects/novakidshipdoor.png"
+      "image" : "../../../../tiled/packed/objects/novakidshipdoor.png"
     },
     "143" : {
-      "image" : "../../../../../tiled/packed/objects/prisontorturebed1.png"
+      "image" : "../../../../tiled/packed/objects/prisontorturebed1.png"
     },
     "144" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlightBroken.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlightBroken.png"
     },
     "145" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlightBroken_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlightBroken_orientation1.png"
     },
     "146" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlightBroken_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlightBroken_orientation2.png"
     },
     "147" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlightBroken_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlightBroken_orientation3.png"
     },
     "148" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlightBroken_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlightBroken_orientation4.png"
     },
     "149" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlightBroken_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlightBroken_orientation5.png"
     },
     "15" : {
-      "image" : "../../../../../tiled/packed/objects/humanshipdoorBroken.png"
+      "image" : "../../../../tiled/packed/objects/humanshipdoorBroken.png"
     },
     "150" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlightBroken_orientation6.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlightBroken_orientation6.png"
     },
     "151" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlightBroken_orientation7.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlightBroken_orientation7.png"
     },
     "152" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerceilinglight2.png"
+      "image" : "../../../../tiled/packed/objects/bunkerceilinglight2.png"
     },
     "153" : {
-      "image" : "../../../../../tiled/packed/objects/flagapex.png"
+      "image" : "../../../../tiled/packed/objects/flagapex.png"
     },
     "154" : {
-      "image" : "../../../../../tiled/packed/objects/flagapex_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/flagapex_orientation1.png"
     },
     "155" : {
-      "image" : "../../../../../tiled/packed/objects/prisonmirror2.png"
+      "image" : "../../../../tiled/packed/objects/prisonmirror2.png"
     },
     "156" : {
-      "image" : "../../../../../tiled/packed/objects/prisongratev.png"
+      "image" : "../../../../tiled/packed/objects/prisongratev.png"
     },
     "157" : {
-      "image" : "../../../../../tiled/packed/objects/barbedwire.png"
+      "image" : "../../../../tiled/packed/objects/barbedwire.png"
     },
     "158" : {
-      "image" : "../../../../../tiled/packed/objects/prisoncorner.png"
+      "image" : "../../../../tiled/packed/objects/prisoncorner.png"
     },
     "159" : {
-      "image" : "../../../../../tiled/packed/objects/prisoncorner_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/prisoncorner_orientation2.png"
     },
     "16" : {
-      "image" : "../../../../../tiled/packed/objects/microwave.png"
+      "image" : "../../../../tiled/packed/objects/microwave.png"
     },
     "160" : {
-      "image" : "../../../../../tiled/packed/objects/prisoncorner_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/prisoncorner_orientation3.png"
     },
     "161" : {
-      "image" : "../../../../../tiled/packed/objects/spawnerchef.png"
+      "image" : "../../../../tiled/packed/objects/spawnerchef.png"
     },
     "162" : {
-      "image" : "../../../../../tiled/packed/objects/bunkertv2.png"
+      "image" : "../../../../tiled/packed/objects/bunkertv2.png"
     },
     "163" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlight.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlight.png"
     },
     "164" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlight_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlight_orientation1.png"
     },
     "165" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlight_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlight_orientation2.png"
     },
     "166" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlight_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlight_orientation3.png"
     },
     "167" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlight_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlight_orientation4.png"
     },
     "168" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlight_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlight_orientation5.png"
     },
     "169" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlight_orientation6.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlight_orientation6.png"
     },
     "17" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "170" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfloodlight_orientation7.png"
+      "image" : "../../../../tiled/packed/objects/prisonfloodlight_orientation7.png"
     },
     "171" : {
-      "image" : "../../../../../tiled/packed/objects/lunarbasecrate.png"
+      "image" : "../../../../tiled/packed/objects/lunarbasecrate.png"
     },
     "172" : {
-      "image" : "../../../../../tiled/packed/objects/novakidshipdoorBroken.png"
+      "image" : "../../../../tiled/packed/objects/novakidshipdoorBroken.png"
     },
     "173" : {
-      "image" : "../../../../../tiled/packed/objects/prisondoor.png"
+      "image" : "../../../../tiled/packed/objects/prisondoor.png"
     },
     "174" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "175" : {
-      "image" : "../../../../../tiled/packed/objects/mysteriouslight.png"
+      "image" : "../../../../tiled/packed/objects/mysteriouslight.png"
     },
     "176" : {
-      "image" : "../../../../../tiled/packed/objects/mysteriouslight_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/mysteriouslight_orientation2.png"
     },
     "177" : {
-      "image" : "../../../../../tiled/packed/objects/mysteriouslight_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/mysteriouslight_orientation3.png"
     },
     "178" : {
-      "image" : "../../../../../tiled/packed/objects/mysteriouslight_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/mysteriouslight_orientation4.png"
     },
     "179" : {
-      "image" : "../../../../../tiled/packed/objects/mysteriouslight_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/mysteriouslight_orientation5.png"
     },
     "18" : {
-      "image" : "../../../../../tiled/packed/objects/and.png"
+      "image" : "../../../../tiled/packed/objects/and.png"
     },
     "180" : {
-      "image" : "../../../../../tiled/packed/objects/mysteriouslight_orientation6.png"
+      "image" : "../../../../tiled/packed/objects/mysteriouslight_orientation6.png"
     },
     "181" : {
-      "image" : "../../../../../tiled/packed/objects/mysteriouslight_orientation7.png"
+      "image" : "../../../../tiled/packed/objects/mysteriouslight_orientation7.png"
     },
     "182" : {
-      "image" : "../../../../../tiled/packed/objects/mysteriouslight_orientation8.png"
+      "image" : "../../../../tiled/packed/objects/mysteriouslight_orientation8.png"
     },
     "183" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerconsole4.png"
+      "image" : "../../../../tiled/packed/objects/bunkerconsole4.png"
     },
     "184" : {
-      "image" : "../../../../../tiled/packed/objects/basictv.png"
+      "image" : "../../../../tiled/packed/objects/basictv.png"
     },
     "185" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerconsole2.png"
+      "image" : "../../../../tiled/packed/objects/bunkerconsole2.png"
     },
     "186" : {
-      "image" : "../../../../../tiled/packed/objects/bunkercabinet1.png"
+      "image" : "../../../../tiled/packed/objects/bunkercabinet1.png"
     },
     "187" : {
-      "image" : "../../../../../tiled/packed/objects/bunkercrate.png"
+      "image" : "../../../../tiled/packed/objects/bunkercrate.png"
     },
     "188" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerdisplay2.png"
+      "image" : "../../../../tiled/packed/objects/bunkerdisplay2.png"
     },
     "189" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerdisplay4.png"
+      "image" : "../../../../tiled/packed/objects/bunkerdisplay4.png"
     },
     "19" : {
-      "image" : "../../../../../tiled/packed/objects/flagglitch.png"
+      "image" : "../../../../tiled/packed/objects/flagglitch.png"
     },
     "190" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerlighth.png"
+      "image" : "../../../../tiled/packed/objects/bunkerlighth.png"
     },
     "191" : {
-      "image" : "../../../../../tiled/packed/objects/miningdoor.png"
+      "image" : "../../../../tiled/packed/objects/miningdoor.png"
     },
     "192" : {
-      "image" : "../../../../../tiled/packed/objects/prisontable.png"
+      "image" : "../../../../tiled/packed/objects/prisontable.png"
     },
     "193" : {
-      "image" : "../../../../../tiled/packed/objects/sewervalve.png"
+      "image" : "../../../../tiled/packed/objects/sewervalve.png"
     },
     "194" : {
-      "image" : "../../../../../tiled/packed/objects/chalktally.png"
+      "image" : "../../../../tiled/packed/objects/chalktally.png"
     },
     "195" : {
-      "image" : "../../../../../tiled/packed/objects/dangersignv.png"
+      "image" : "../../../../tiled/packed/objects/dangersignv.png"
     },
     "196" : {
-      "image" : "../../../../../tiled/packed/objects/hazardtapev.png"
+      "image" : "../../../../tiled/packed/objects/hazardtapev.png"
     },
     "197" : {
-      "image" : "../../../../../tiled/packed/objects/lavalamp1.png"
+      "image" : "../../../../tiled/packed/objects/lavalamp1.png"
     },
     "198" : {
-      "image" : "../../../../../tiled/packed/objects/prisonarch.png"
+      "image" : "../../../../tiled/packed/objects/prisonarch.png"
     },
     "199" : {
-      "image" : "../../../../../tiled/packed/objects/prisonarch_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/prisonarch_orientation2.png"
     },
     "2" : {
-      "image" : "../../../../../tiled/packed/objects/prisonmattress.png"
+      "image" : "../../../../tiled/packed/objects/prisonmattress.png"
     },
     "20" : {
-      "image" : "../../../../../tiled/packed/objects/flagglitch_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/flagglitch_orientation1.png"
     },
     "200" : {
-      "image" : "../../../../../tiled/packed/objects/prisonarch_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/prisonarch_orientation3.png"
     },
     "201" : {
-      "image" : "../../../../../tiled/packed/objects/prisonarch_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/prisonarch_orientation4.png"
     },
     "202" : {
-      "image" : "../../../../../tiled/packed/objects/prisonarch_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/prisonarch_orientation5.png"
     },
     "203" : {
-      "image" : "../../../../../tiled/packed/objects/prisonarch_orientation6.png"
+      "image" : "../../../../tiled/packed/objects/prisonarch_orientation6.png"
     },
     "204" : {
-      "image" : "../../../../../tiled/packed/objects/prisonarch_orientation7.png"
+      "image" : "../../../../tiled/packed/objects/prisonarch_orientation7.png"
     },
     "205" : {
-      "image" : "../../../../../tiled/packed/objects/prisoncontrolpanel.png"
+      "image" : "../../../../tiled/packed/objects/prisoncontrolpanel.png"
     },
     "206" : {
-      "image" : "../../../../../tiled/packed/objects/prisonexitsign.png"
+      "image" : "../../../../tiled/packed/objects/prisonexitsign.png"
     },
     "207" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfile2.png"
+      "image" : "../../../../tiled/packed/objects/prisonfile2.png"
     },
     "208" : {
-      "image" : "../../../../../tiled/packed/objects/prisongraffiti6.png"
+      "image" : "../../../../tiled/packed/objects/prisongraffiti6.png"
     },
     "209" : {
-      "image" : "../../../../../tiled/packed/objects/prisonmirror1.png"
+      "image" : "../../../../tiled/packed/objects/prisonmirror1.png"
     },
     "21" : {
-      "image" : "../../../../../tiled/packed/objects/bunkercorner.png"
+      "image" : "../../../../tiled/packed/objects/bunkercorner.png"
     },
     "210" : {
-      "image" : "../../../../../tiled/packed/objects/prisonpaper3.png"
+      "image" : "../../../../tiled/packed/objects/prisonpaper3.png"
     },
     "211" : {
-      "image" : "../../../../../tiled/packed/objects/prisonpipefence.png"
+      "image" : "../../../../tiled/packed/objects/prisonpipefence.png"
     },
     "212" : {
-      "image" : "../../../../../tiled/packed/objects/prisonsecuritycamera.png"
+      "image" : "../../../../tiled/packed/objects/prisonsecuritycamera.png"
     },
     "213" : {
-      "image" : "../../../../../tiled/packed/objects/prisonsecuritycamera_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/prisonsecuritycamera_orientation1.png"
     },
     "214" : {
-      "image" : "../../../../../tiled/packed/objects/prisonsecuritycamera_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/prisonsecuritycamera_orientation2.png"
     },
     "215" : {
-      "image" : "../../../../../tiled/packed/objects/prisonsecuritycamera_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/prisonsecuritycamera_orientation3.png"
     },
     "216" : {
-      "image" : "../../../../../tiled/packed/objects/prisonsecuritycamera_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/prisonsecuritycamera_orientation4.png"
     },
     "217" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "218" : {
-      "image" : "../../../../../tiled/packed/objects/vendingmachine.png"
+      "image" : "../../../../tiled/packed/objects/vendingmachine.png"
     },
     "219" : {
-      "image" : "../../../../../tiled/packed/objects/humantechstationTier0.png"
+      "image" : "../../../../tiled/packed/objects/humantechstationTier0.png"
     },
     "22" : {
-      "image" : "../../../../../tiled/packed/objects/bunkercorner_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/bunkercorner_orientation1.png"
     },
     "220" : {
-      "image" : "../../../../../tiled/packed/objects/prisonlocker2.png"
+      "image" : "../../../../tiled/packed/objects/prisonlocker2.png"
     },
     "221" : {
-      "image" : "../../../../../tiled/packed/objects/flaghuman.png"
+      "image" : "../../../../tiled/packed/objects/flaghuman.png"
     },
     "222" : {
-      "image" : "../../../../../tiled/packed/objects/flaghuman_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/flaghuman_orientation1.png"
     },
     "223" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerslidingdoor.png"
+      "image" : "../../../../tiled/packed/objects/bunkerslidingdoor.png"
     },
     "224" : {
-      "image" : "../../../../../tiled/packed/objects/flagfloran.png"
+      "image" : "../../../../tiled/packed/objects/flagfloran.png"
     },
     "225" : {
-      "image" : "../../../../../tiled/packed/objects/flagfloran_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/flagfloran_orientation1.png"
     },
     "226" : {
-      "image" : "../../../../../tiled/packed/objects/prisonsign2.png"
+      "image" : "../../../../tiled/packed/objects/prisonsign2.png"
     },
     "227" : {
-      "image" : "../../../../../tiled/packed/objects/basicbathdripping.png"
+      "image" : "../../../../tiled/packed/objects/basicbathdripping.png"
     },
     "228" : {
-      "image" : "../../../../../tiled/packed/objects/marinesign.png"
+      "image" : "../../../../tiled/packed/objects/marinesign.png"
     },
     "229" : {
-      "image" : "../../../../../tiled/packed/objects/humanteleporter.png"
+      "image" : "../../../../tiled/packed/objects/humanteleporter.png"
     },
     "23" : {
-      "image" : "../../../../../tiled/packed/objects/bunkercorner_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/bunkercorner_orientation2.png"
     },
     "230" : {
-      "image" : "../../../../../tiled/packed/objects/drip2.png"
+      "image" : "../../../../tiled/packed/objects/drip2.png"
     },
     "231" : {
-      "image" : "../../../../../tiled/packed/objects/drip2_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/drip2_orientation2.png"
     },
     "232" : {
-      "image" : "../../../../../tiled/packed/objects/drip2_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/drip2_orientation3.png"
     },
     "233" : {
-      "image" : "../../../../../tiled/packed/objects/mininghazardsign.png"
+      "image" : "../../../../tiled/packed/objects/mininghazardsign.png"
     },
     "234" : {
-      "image" : "../../../../../tiled/packed/objects/miningskip.png"
+      "image" : "../../../../tiled/packed/objects/miningskip.png"
     },
     "235" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerdesk.png"
+      "image" : "../../../../tiled/packed/objects/bunkerdesk.png"
     },
     "236" : {
-      "image" : "../../../../../tiled/packed/objects/prisonbarrelfire.png"
+      "image" : "../../../../tiled/packed/objects/prisonbarrelfire.png"
     },
     "237" : {
-      "image" : "../../../../../tiled/packed/objects/prisongraffiti7.png"
+      "image" : "../../../../tiled/packed/objects/prisongraffiti7.png"
     },
     "238" : {
-      "image" : "../../../../../tiled/packed/objects/novakidteleporter.png"
+      "image" : "../../../../tiled/packed/objects/novakidteleporter.png"
     },
     "239" : {
-      "image" : "../../../../../tiled/packed/objects/humanshiplockerTier0.png"
+      "image" : "../../../../tiled/packed/objects/humanshiplockerTier0.png"
     },
     "24" : {
-      "image" : "../../../../../tiled/packed/objects/bunkercorner_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/bunkercorner_orientation3.png"
     },
     "240" : {
-      "image" : "../../../../../tiled/packed/objects/spawnerapex.png"
+      "image" : "../../../../tiled/packed/objects/spawnerapex.png"
     },
     "241" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "242" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "243" : {
-      "image" : "../../../../../tiled/packed/objects/displaylight.png"
+      "image" : "../../../../tiled/packed/objects/displaylight.png"
     },
     "244" : {
-      "image" : "../../../../../tiled/packed/objects/displaylight_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/displaylight_orientation1.png"
     },
     "245" : {
-      "image" : "../../../../../tiled/packed/objects/displaylight_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/displaylight_orientation2.png"
     },
     "246" : {
-      "image" : "../../../../../tiled/packed/objects/displaylight_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/displaylight_orientation3.png"
     },
     "247" : {
-      "image" : "../../../../../tiled/packed/objects/displaylight_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/displaylight_orientation4.png"
     },
     "248" : {
-      "image" : "../../../../../tiled/packed/objects/displaylight_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/displaylight_orientation5.png"
     },
     "249" : {
-      "image" : "../../../../../tiled/packed/objects/displaylightbroken.png"
+      "image" : "../../../../tiled/packed/objects/displaylightbroken.png"
     },
     "25" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "250" : {
-      "image" : "../../../../../tiled/packed/objects/displaylightbroken_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/displaylightbroken_orientation1.png"
     },
     "251" : {
-      "image" : "../../../../../tiled/packed/objects/displaylightbroken_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/displaylightbroken_orientation2.png"
     },
     "252" : {
-      "image" : "../../../../../tiled/packed/objects/displaylightbroken_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/displaylightbroken_orientation3.png"
     },
     "253" : {
-      "image" : "../../../../../tiled/packed/objects/displaylightbroken_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/displaylightbroken_orientation4.png"
     },
     "254" : {
-      "image" : "../../../../../tiled/packed/objects/displaylightbroken_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/displaylightbroken_orientation5.png"
     },
     "255" : {
-      "image" : "../../../../../tiled/packed/objects/countdowntimer.png"
+      "image" : "../../../../tiled/packed/objects/countdowntimer.png"
     },
     "256" : {
-      "image" : "../../../../../tiled/packed/objects/dripblood1.png"
+      "image" : "../../../../tiled/packed/objects/dripblood1.png"
     },
     "257" : {
-      "image" : "../../../../../tiled/packed/objects/dripblood1_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/dripblood1_orientation2.png"
     },
     "258" : {
-      "image" : "../../../../../tiled/packed/objects/dripblood1_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/dripblood1_orientation3.png"
     },
     "259" : {
-      "image" : "../../../../../tiled/packed/objects/hivedoor.png"
+      "image" : "../../../../tiled/packed/objects/hivedoor.png"
     },
     "26" : {
-      "image" : "../../../../../tiled/packed/objects/prisongirderv.png"
+      "image" : "../../../../tiled/packed/objects/prisongirderv.png"
     },
     "260" : {
-      "image" : "../../../../../tiled/packed/objects/smokemachine.png"
+      "image" : "../../../../tiled/packed/objects/smokemachine.png"
     },
     "261" : {
-      "image" : "../../../../../tiled/packed/objects/foundryxor.png"
+      "image" : "../../../../tiled/packed/objects/foundryxor.png"
     },
     "262" : {
-      "image" : "../../../../../tiled/packed/objects/magmalamp.png"
+      "image" : "../../../../tiled/packed/objects/magmalamp.png"
     },
     "263" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "264" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "265" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "266" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "267" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "268" : {
-      "image" : "../../../../../tiled/packed/objects/glitchalarm.png"
+      "image" : "../../../../tiled/packed/objects/glitchalarm.png"
     },
     "269" : {
-      "image" : "../../../../../tiled/packed/objects/glitchalarm_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/glitchalarm_orientation1.png"
     },
     "27" : {
-      "image" : "../../../../../tiled/packed/objects/prisongirderv_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/prisongirderv_orientation2.png"
     },
     "28" : {
-      "image" : "../../../../../tiled/packed/objects/prisongirderv_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/prisongirderv_orientation3.png"
     },
     "29" : {
-      "image" : "../../../../../tiled/packed/objects/prisongirderv_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/prisongirderv_orientation4.png"
     },
     "3" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerheater1.png"
+      "image" : "../../../../tiled/packed/objects/bunkerheater1.png"
     },
     "30" : {
-      "image" : "../../../../../tiled/packed/objects/prisongirderv_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/prisongirderv_orientation5.png"
     },
     "31" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerdisplay1.png"
+      "image" : "../../../../tiled/packed/objects/bunkerdisplay1.png"
     },
     "32" : {
-      "image" : "../../../../../tiled/packed/objects/monsterspawner.png"
+      "image" : "../../../../tiled/packed/objects/monsterspawner.png"
     },
     "33" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerposter2.png"
+      "image" : "../../../../tiled/packed/objects/bunkerposter2.png"
     },
     "34" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerceilinglight1.png"
+      "image" : "../../../../tiled/packed/objects/bunkerceilinglight1.png"
     },
     "35" : {
-      "image" : "../../../../../tiled/packed/objects/spawneravian.png"
+      "image" : "../../../../tiled/packed/objects/spawneravian.png"
     },
     "36" : {
-      "image" : "../../../../../tiled/packed/objects/bunkertable1.png"
+      "image" : "../../../../tiled/packed/objects/bunkertable1.png"
     },
     "37" : {
-      "image" : "../../../../../tiled/packed/objects/prisongraffiti1.png"
+      "image" : "../../../../tiled/packed/objects/prisongraffiti1.png"
     },
     "38" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerbigpanel.png"
+      "image" : "../../../../tiled/packed/objects/bunkerbigpanel.png"
     },
     "39" : {
-      "image" : "../../../../../tiled/packed/objects/prisongraffiti5.png"
+      "image" : "../../../../tiled/packed/objects/prisongraffiti5.png"
     },
     "4" : {
-      "image" : "../../../../../tiled/packed/objects/timer5s.png"
+      "image" : "../../../../tiled/packed/objects/timer5s.png"
     },
     "40" : {
-      "image" : "../../../../../tiled/packed/objects/flickeringfluorescentlight.png"
+      "image" : "../../../../tiled/packed/objects/flickeringfluorescentlight.png"
     },
     "41" : {
-      "image" : "../../../../../tiled/packed/objects/flickeringfluorescentlight_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/flickeringfluorescentlight_orientation1.png"
     },
     "42" : {
-      "image" : "../../../../../tiled/packed/objects/flickeringfluorescentlight_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/flickeringfluorescentlight_orientation2.png"
     },
     "43" : {
-      "image" : "../../../../../tiled/packed/objects/bunkereyescanner.png"
+      "image" : "../../../../tiled/packed/objects/bunkereyescanner.png"
     },
     "44" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "45" : {
-      "image" : "../../../../../tiled/packed/objects/flagavian.png"
+      "image" : "../../../../tiled/packed/objects/flagavian.png"
     },
     "46" : {
-      "image" : "../../../../../tiled/packed/objects/flagavian_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/flagavian_orientation1.png"
     },
     "47" : {
-      "image" : "../../../../../tiled/packed/objects/miningfence.png"
+      "image" : "../../../../tiled/packed/objects/miningfence.png"
     },
     "48" : {
-      "image" : "../../../../../tiled/packed/objects/prisonfile1.png"
+      "image" : "../../../../tiled/packed/objects/prisonfile1.png"
     },
     "49" : {
-      "image" : "../../../../../tiled/packed/objects/penguinbasedoor.png"
+      "image" : "../../../../tiled/packed/objects/penguinbasedoor.png"
     },
     "5" : {
-      "image" : "../../../../../tiled/packed/objects/dripslime1.png"
+      "image" : "../../../../tiled/packed/objects/dripslime1.png"
     },
     "50" : {
-      "image" : "../../../../../tiled/packed/objects/prisonbench.png"
+      "image" : "../../../../tiled/packed/objects/prisonbench.png"
     },
     "51" : {
-      "image" : "../../../../../tiled/packed/objects/bunkermotiondetector.png"
+      "image" : "../../../../tiled/packed/objects/bunkermotiondetector.png"
     },
     "52" : {
-      "image" : "../../../../../tiled/packed/objects/prisontorturebed2.png"
+      "image" : "../../../../tiled/packed/objects/prisontorturebed2.png"
     },
     "53" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerconsole3.png"
+      "image" : "../../../../tiled/packed/objects/bunkerconsole3.png"
     },
     "54" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerconsole3_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/bunkerconsole3_orientation1.png"
     },
     "55" : {
-      "image" : "../../../../../tiled/packed/objects/humancaptainschair.png"
+      "image" : "../../../../tiled/packed/objects/humancaptainschair.png"
     },
     "56" : {
-      "image" : "../../../../../tiled/packed/objects/bunkertable3.png"
+      "image" : "../../../../tiled/packed/objects/bunkertable3.png"
     },
     "57" : {
-      "image" : "../../../../../tiled/packed/objects/prisontoilet.png"
+      "image" : "../../../../tiled/packed/objects/prisontoilet.png"
     },
     "58" : {
-      "image" : "../../../../../tiled/packed/objects/humanteleporterTier0.png"
+      "image" : "../../../../tiled/packed/objects/humanteleporterTier0.png"
     },
     "59" : {
-      "image" : "../../../../../tiled/packed/objects/bunkercomputer.png"
+      "image" : "../../../../tiled/packed/objects/bunkercomputer.png"
     },
     "6" : {
-      "image" : "../../../../../tiled/packed/objects/dripslime1_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/dripslime1_orientation2.png"
     },
     "60" : {
-      "image" : "../../../../../tiled/packed/objects/prisongrateh.png"
+      "image" : "../../../../tiled/packed/objects/prisongrateh.png"
     },
     "61" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerhandscanner.png"
+      "image" : "../../../../tiled/packed/objects/bunkerhandscanner.png"
     },
     "62" : {
-      "image" : "../../../../../tiled/packed/objects/prisonshowerdripping.png"
+      "image" : "../../../../tiled/packed/objects/prisonshowerdripping.png"
     },
     "63" : {
-      "image" : "../../../../../tiled/packed/objects/prisongraffiti4.png"
+      "image" : "../../../../tiled/packed/objects/prisongraffiti4.png"
     },
     "64" : {
-      "image" : "../../../../../tiled/packed/objects/bulb.png"
+      "image" : "../../../../tiled/packed/objects/bulb.png"
     },
     "65" : {
-      "image" : "../../../../../tiled/packed/objects/spawnerfloran.png"
+      "image" : "../../../../tiled/packed/objects/spawnerfloran.png"
     },
     "66" : {
-      "image" : "../../../../../tiled/packed/objects/prisonforcecell.png"
+      "image" : "../../../../tiled/packed/objects/prisonforcecell.png"
     },
     "67" : {
-      "image" : "../../../../../tiled/packed/objects/bunkertv.png"
+      "image" : "../../../../tiled/packed/objects/bunkertv.png"
     },
     "68" : {
-      "image" : "../../../../../tiled/packed/objects/bunkertv_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/bunkertv_orientation1.png"
     },
     "69" : {
-      "image" : "../../../../../tiled/packed/objects/bunkertv_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/bunkertv_orientation2.png"
     },
     "7" : {
-      "image" : "../../../../../tiled/packed/objects/dripslime1_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/dripslime1_orientation3.png"
     },
     "70" : {
-      "image" : "../../../../../tiled/packed/objects/bunkertv_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/bunkertv_orientation3.png"
     },
     "71" : {
-      "image" : "../../../../../tiled/packed/objects/prisonbars.png"
+      "image" : "../../../../tiled/packed/objects/prisonbars.png"
     },
     "72" : {
-      "image" : "../../../../../tiled/packed/objects/prisongirderh.png"
+      "image" : "../../../../tiled/packed/objects/prisongirderh.png"
     },
     "73" : {
-      "image" : "../../../../../tiled/packed/objects/prisongirderh_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/prisongirderh_orientation2.png"
     },
     "74" : {
-      "image" : "../../../../../tiled/packed/objects/prisongirderh_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/prisongirderh_orientation3.png"
     },
     "75" : {
-      "image" : "../../../../../tiled/packed/objects/prisongirderh_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/prisongirderh_orientation4.png"
     },
     "76" : {
-      "image" : "../../../../../tiled/packed/objects/prisongraffiti3.png"
+      "image" : "../../../../tiled/packed/objects/prisongraffiti3.png"
     },
     "77" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerconsole1.png"
+      "image" : "../../../../tiled/packed/objects/bunkerconsole1.png"
     },
     "78" : {
-      "image" : "../../../../../tiled/packed/objects/basictoilet.png"
+      "image" : "../../../../tiled/packed/objects/basictoilet.png"
     },
     "79" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerserver.png"
+      "image" : "../../../../tiled/packed/objects/bunkerserver.png"
     },
     "8" : {
-      "image" : "../../../../../tiled/packed/objects/miningverticaldoor.png"
+      "image" : "../../../../tiled/packed/objects/miningverticaldoor.png"
     },
     "80" : {
-      "image" : "../../../../../tiled/packed/objects/spawnerguard.png"
+      "image" : "../../../../tiled/packed/objects/spawnerguard.png"
     },
     "81" : {
-      "image" : "../../../../../tiled/packed/objects/prisoncamerastation.png"
+      "image" : "../../../../tiled/packed/objects/prisoncamerastation.png"
     },
     "82" : {
-      "image" : "../../../../../tiled/packed/objects/timer4s.png"
+      "image" : "../../../../tiled/packed/objects/timer4s.png"
     },
     "83" : {
-      "image" : "../../../../../tiled/packed/objects/dangersignh.png"
+      "image" : "../../../../tiled/packed/objects/dangersignh.png"
     },
     "84" : {
-      "image" : "../../../../../tiled/packed/objects/outpostslidingdoor.png"
+      "image" : "../../../../tiled/packed/objects/outpostslidingdoor.png"
     },
     "85" : {
-      "image" : "../../../../../tiled/packed/objects/humangenerator.png"
+      "image" : "../../../../tiled/packed/objects/humangenerator.png"
     },
     "86" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerbookcase.png"
+      "image" : "../../../../tiled/packed/objects/bunkerbookcase.png"
     },
     "87" : {
-      "image" : "../../../../../tiled/packed/objects/curtain1.png"
+      "image" : "../../../../tiled/packed/objects/curtain1.png"
     },
     "88" : {
-      "image" : "../../../../../tiled/packed/objects/curtain1_orientation2.png"
+      "image" : "../../../../tiled/packed/objects/curtain1_orientation2.png"
     },
     "89" : {
-      "image" : "../../../../../tiled/packed/objects/curtain1_orientation3.png"
+      "image" : "../../../../tiled/packed/objects/curtain1_orientation3.png"
     },
     "9" : {
-      "image" : "../../../../../tiled/packed/objects/timer2s.png"
+      "image" : "../../../../tiled/packed/objects/timer2s.png"
     },
     "90" : {
-      "image" : "../../../../../tiled/packed/objects/curtain1_orientation4.png"
+      "image" : "../../../../tiled/packed/objects/curtain1_orientation4.png"
     },
     "91" : {
-      "image" : "../../../../../tiled/packed/objects/curtain1_orientation5.png"
+      "image" : "../../../../tiled/packed/objects/curtain1_orientation5.png"
     },
     "92" : {
-      "image" : "../../../../../tiled/packed/objects/curtain1_orientation6.png"
+      "image" : "../../../../tiled/packed/objects/curtain1_orientation6.png"
     },
     "93" : {
-      "image" : "../../../../../tiled/packed/objects/curtain1_orientation7.png"
+      "image" : "../../../../tiled/packed/objects/curtain1_orientation7.png"
     },
     "94" : {
-      "image" : "../../../../../tiled/packed/objects/curtain1_orientation8.png"
+      "image" : "../../../../tiled/packed/objects/curtain1_orientation8.png"
     },
     "95" : {
-      "image" : "../../../../../tiled/packed/objects/curtain1_orientation9.png"
+      "image" : "../../../../tiled/packed/objects/curtain1_orientation9.png"
     },
     "96" : {
-      "image" : "../../../../../tiled/packed/objects/bunkerlightv.png"
+      "image" : "../../../../tiled/packed/objects/bunkerlightv.png"
     },
     "97" : {
-      "image" : "../../../../../tiled/packed/objects/humanshipdoor.png"
+      "image" : "../../../../tiled/packed/objects/humanshipdoor.png"
     },
     "98" : {
-      "image" : "../../../../../tiled/packed/../packed/invalid.png"
+      "image" : "../../../../tiled/packed/../packed/invalid.png"
     },
     "99" : {
-      "image" : "../../../../../tiled/packed/objects/timer3s.png"
+      "image" : "../../../../tiled/packed/objects/timer3s.png"
     }
   },
   "tilewidth" : 160

--- a/tilesets/frackinuniverse-custom/steampunk.json
+++ b/tilesets/frackinuniverse-custom/steampunk.json
@@ -73,25 +73,25 @@
   },
   "tiles" : {
     "0" : {
-      "image" : "../../../../../tiled/packed/objects/steampunkarmchair.png"
+      "image" : "../../../../tiled/packed/objects/steampunkarmchair.png"
     },
     "1" : {
-      "image" : "../../../../../tiled/packed/objects/steampunkdesk.png"
+      "image" : "../../../../tiled/packed/objects/steampunkdesk.png"
     },
     "2" : {
-      "image" : "../../../../../tiled/packed/objects/steampunklamp.png"
+      "image" : "../../../../tiled/packed/objects/steampunklamp.png"
     },
     "3" : {
-      "image" : "../../../../../tiled/packed/objects/steampunkshelf.png"
+      "image" : "../../../../tiled/packed/objects/steampunkshelf.png"
     },
     "4" : {
-      "image" : "../../../../../tiled/packed/objects/steampunkshelf_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/steampunkshelf_orientation1.png"
     },
     "5" : {
-      "image" : "../../../../../tiled/packed/objects/steampunkbed.png"
+      "image" : "../../../../tiled/packed/objects/steampunkbed.png"
     },
     "6" : {
-      "image" : "../../../../../tiled/packed/objects/steampunkglobe.png"
+      "image" : "../../../../tiled/packed/objects/steampunkglobe.png"
     }
   },
   "tilewidth" : 8

--- a/tilesets/frackinuniverse-custom/steamspring.json
+++ b/tilesets/frackinuniverse-custom/steamspring.json
@@ -63,22 +63,22 @@
   },
   "tiles" : {
     "0" : {
-      "image" : "../../../../../tiled/packed/objects/steamspringchair.png"
+      "image" : "../../../../tiled/packed/objects/steamspringchair.png"
     },
     "1" : {
-      "image" : "../../../../../tiled/packed/objects/steamspringtable.png"
+      "image" : "../../../../tiled/packed/objects/steamspringtable.png"
     },
     "2" : {
-      "image" : "../../../../../tiled/packed/objects/steamspringlamp.png"
+      "image" : "../../../../tiled/packed/objects/steamspringlamp.png"
     },
     "3" : {
-      "image" : "../../../../../tiled/packed/objects/steamspringlamp_orientation1.png"
+      "image" : "../../../../tiled/packed/objects/steamspringlamp_orientation1.png"
     },
     "4" : {
-      "image" : "../../../../../tiled/packed/objects/steamspringdoor.png"
+      "image" : "../../../../tiled/packed/objects/steamspringdoor.png"
     },
     "5" : {
-      "image" : "../../../../../tiled/packed/objects/steamspringbed.png"
+      "image" : "../../../../tiled/packed/objects/steamspringbed.png"
     }
   },
   "tilewidth" : 8


### PR DESCRIPTION
- Tile protection can now be disabled on all asteroid microdungeons. This only applies to newly-generated asteroid fields and biomes.
- Added a new guard npc type for friendly asteroid microdungeons.
- Vel'uuish civilians will no longer threaten the player with Big Ape.

(Not changelog)
- Fixed some tileset image paths, which expected the Tiled images folder to be in the folder above Starbound.