### PR TITLE
Added "Leave One" and "Only Stack" functions to ITD

### DIFF
--- a/interface/kheAA/kheAA_router/kheAA_routerGui.config
+++ b/interface/kheAA/kheAA_router/kheAA_routerGui.config
@@ -528,6 +528,28 @@
 			"base": "/interface/kheAA/kheAA_router/slotItemGrey.png",
 			"baseImage": "/interface/kheAA/kheAA_router/slotItemGrey.png",
 			"baseImageChecked": "/interface/kheAA/kheAA_router/slotItemGreyChecked.png"
+		},
+		"leaveOneItemMode": {
+			"callback": "leaveOneItemToggle",
+			"type": "button",
+			"checkable": true,
+			"caption": "Leave One",
+			"hAnchor": "left",
+			"position": [129, 17],
+			"base": "/interface/kheAA/kheAA_router/slotItemGrey.png",
+			"baseImage": "/interface/kheAA/kheAA_router/slotItemGrey.png",
+			"baseImageChecked": "/interface/kheAA/kheAA_router/slotItemGreyChecked.png"
+		},
+		"onlyStackMode": {
+			"callback": "onlyStackToggle",
+			"type": "button",
+			"checkable": true,
+			"caption": "Stack Only",
+			"hAnchor": "left",
+			"position": [186, 17],
+			"base": "/interface/kheAA/kheAA_router/slotItemGrey.png",
+			"baseImage": "/interface/kheAA/kheAA_router/slotItemGrey.png",
+			"baseImageChecked": "/interface/kheAA/kheAA_router/slotItemGreyChecked.png"
 		}
 	},
 	"scriptWidgetCallbacks": [
@@ -541,7 +563,9 @@
 		"subOutputSlot",
 		"addOutputSlot",
 		"roundRobinToggle",
-		"roundRobinSlotToggle"
+		"roundRobinSlotToggle",
+		"leaveOneItemToggle",
+		"onlyStackToggle"
 	],
 
 	"scripts": ["/interface/kheAA/kheAA_router/kheAA_routerGui.lua"],

--- a/interface/kheAA/kheAA_router/kheAA_routerGui.lua
+++ b/interface/kheAA/kheAA_router/kheAA_routerGui.lua
@@ -45,6 +45,8 @@ function initialize(conf)
 	invertSlots=conf[5]
 	widget.setChecked("roundRobinMode", conf[6])
 	widget.setChecked("roundRobinSlotMode", conf[7])
+	widget.setChecked("leaveOneItemMode", conf[8])
+	widget.setChecked("onlyStackMode", conf[9])
 	redrawListSlots(inputList, inputSlots);
 	redrawListSlots(outputList, outputSlots);
 	redrawItemFilters()
@@ -188,6 +190,16 @@ end
 function roundRobinSlotToggle(name)
 	roundRobin = widget.getChecked(name)
 	world.sendEntityMessage(myBox, "setRRS", roundRobin)
+end
+
+function leaveOneItemToggle(name)
+	leaveOne = widget.getChecked(name)
+	world.sendEntityMessage(myBox, "setLO", leaveOne)
+end
+
+function onlyStackToggle(name)
+	onlyStack = widget.getChecked(name)
+	world.sendEntityMessage(myBox, "setOS", onlyStack)
 end
 
 

--- a/objects/kheAA/kheAA_router/kheAA_router.lua
+++ b/objects/kheAA/kheAA_router/kheAA_router.lua
@@ -11,6 +11,8 @@ function init()
 	message.setHandler("setOutputSlots", function (msg, _, slots) storage.outputSlots = slots end)
 	message.setHandler("setRR", function (msg, _, rr) storage.roundRobin = rr end)
 	message.setHandler("setRRS", function (msg, _, rr) storage.roundRobinSlots = rr end)
+	message.setHandler("setLO", function (msg, _, leaveOne) storage.leaveOne = leaveOne end)
+	message.setHandler("setOS", function (msg, _, onlyStack) storage.onlyStack = onlyStack end)
 	object.setInteractive(true)
 end
 
@@ -97,7 +99,7 @@ function sendConfig()
 	if not storage.invertSlots then
 		storage.invertSlots={false,false}
 	end
-	return {storage.inputSlots,storage.outputSlots,storage.filterInverted,storage.filterType,storage.invertSlots,storage.roundRobin or false,storage.roundRobinSlots or false}
+	return {storage.inputSlots,storage.outputSlots,storage.filterInverted,storage.filterType,storage.invertSlots,storage.roundRobin or false,storage.roundRobinSlots or false,storage.leaveOne or false,storage.onlyStack or false}
 end
 
 function routeItems(dt)
@@ -119,111 +121,122 @@ function routeItems(dt)
 
 		if sourceItems then
 			for indexIn,item in pairs(sourceItems or {}) do
-				local pass,mod = checkFilter(item)
-				if pass and (not storage.roundRobin or item.count>=(mod*outputSizeG)) then
-					local outputSlotCountG = util.tableSize(storage.outputSlots)
-					local originalCount=item.count
-					local canRobinRoundSlots
-					if storage.roundRobin then
-						local buffer
-						buffer=math.floor(item.count/outputSizeG)
-						buffer=math.floor(buffer-(buffer%mod))
-						item.count = math.floor(buffer)
+				if not storage.leaveOne or item.count > 1 then
+					if storage.leaveOne then 
+						item.count = item.count - 1
 					end
-					if storage.roundRobinSlots and not storage.invertSlots[2] and outputSlotCountG>0 then
-						local buffer
-						buffer=math.floor(item.count/outputSlotCountG)
-						buffer=math.floor(buffer-(buffer%mod))
-						item.count = math.floor(buffer)
-					end
-					item.count = item.count - (item.count % mod)
-					for targetContainer,targetPos in pairs(transferUtil.vars.outContainers or {}) do
-						local targetAwake,ping2=transferUtil.containerAwake(targetContainer,targetPos)
-						if ping2 ~= nil then
-							targetContainer=ping2
+					local pass,mod = checkFilter(item)
+					if pass and (not storage.roundRobin or item.count>=(mod*outputSizeG)) then
+						local outputSlotCountG = util.tableSize(storage.outputSlots)
+						local originalCount=item.count
+						local canRobinRoundSlots
+						if storage.roundRobin then
+							local buffer
+							buffer=math.floor(item.count/outputSizeG)
+							buffer=math.floor(buffer-(buffer%mod))
+							item.count = math.floor(buffer)
 						end
-						if targetAwake == true and sourceAwake == true then
-							local containerSize=world.containerSize(targetContainer)
-							local outputSlotCount=outputSlotCountG
-							local outputSlotsBuffer={}
+						if storage.roundRobinSlots and not storage.invertSlots[2] and outputSlotCountG>0 then
+							local buffer
+							buffer=math.floor(item.count/outputSlotCountG)
+							buffer=math.floor(buffer-(buffer%mod))
+							item.count = math.floor(buffer)
+						end
+						item.count = item.count - (item.count % mod)
+						for targetContainer,targetPos in pairs(transferUtil.vars.outContainers or {}) do
+							local targetAwake,ping2=transferUtil.containerAwake(targetContainer,targetPos)
+							if ping2 ~= nil then
+								targetContainer=ping2
+							end
+							if targetAwake == true and sourceAwake == true then
+								local containerSize=world.containerSize(targetContainer)
+								local outputSlotCount=outputSlotCountG
+								local outputSlotsBuffer={}
 
 
-							for _,v in pairs(storage.outputSlots) do
-								if v <= containerSize then
-									table.insert(outputSlotsBuffer,v)
+								for _,v in pairs(storage.outputSlots) do
+									if v <= containerSize then
+										table.insert(outputSlotsBuffer,v)
+									end
 								end
-							end
 
-							outputSlotCount=util.tableSize(outputSlotsBuffer)
+								outputSlotCount=util.tableSize(outputSlotsBuffer)
 
 
-							local subCount=item.count
-							if storage.roundRobinSlots and storage.invertSlots[2] then
-								outputSlotCount=containerSize-outputSlotCount
-								local buffer
-								buffer=math.floor(item.count/outputSlotCount)
-								buffer=math.floor(buffer-(buffer%mod))
-								item.count = math.floor(buffer)
-							end
+								local subCount=item.count
+								if storage.roundRobinSlots and storage.invertSlots[2] then
+									outputSlotCount=containerSize-outputSlotCount
+									local buffer
+									buffer=math.floor(item.count/outputSlotCount)
+									buffer=math.floor(buffer-(buffer%mod))
+									item.count = math.floor(buffer)
+								end
 
-							if validInputSlot(indexIn) then
-								if outputSlotCount > 0 then
-									local buffer=item.count * (storage.roundRobin and outputSize or 1) * (storage.roundRobinSlots and outputSlotCount or 1)
-									if item.count>0 and buffer<=originalCount then
-										for indexOut=1,containerSize do
-											if validOutputSlot(indexOut) then
-												local leftOverItems=world.containerPutItemsAt(targetContainer,item,indexOut-1)
-												if leftOverItems then
-													world.containerTakeNumItemsAt(sourceContainer,indexIn-1,item.count-leftOverItems.count)
-													originalCount=originalCount-(item.count-leftOverItems.count)
-													if not storage.roundRobinSlots then
-														if not storage.roundRobin then
-															item = leftOverItems
-														else
+								if validInputSlot(indexIn) then
+									if outputSlotCount > 0 or storage.onlyStack then
+										local buffer=item.count * (storage.roundRobin and outputSize or 1) * (storage.roundRobinSlots and outputSlotCount or 1)
+										if item.count>0 and buffer<=originalCount then
+											for indexOut=1,containerSize do
+												if validOutputSlot(indexOut) then
+													if storage.onlyStack and not world.containerItemAt(targetContainer,indexOut-1) then
+														if not storage.roundRobinSlots and storage.roundRobin then
 															break
 														end
+													else
+														local leftOverItems=world.containerPutItemsAt(targetContainer,item,indexOut-1)
+														if leftOverItems then
+															world.containerTakeNumItemsAt(sourceContainer,indexIn-1,item.count-leftOverItems.count)
+															originalCount=originalCount-(item.count-leftOverItems.count)
+															if not storage.roundRobinSlots then
+																if not storage.roundRobin then
+																	item = leftOverItems
+																else
+																	break
+																end
+															end
+														else
+															world.containerTakeNumItemsAt(sourceContainer,indexIn-1,item.count)
+															originalCount=originalCount-item.count
+															if not (storage.roundRobinSlots) then
+																break
+															end
+														end
+													end
+												end
+											end
+										end
+									else
+										if item.count>0 then
+											--world.containerStackItems() attempts to add items to an existing stack. fails otherwise. returns leftovers
+											local test=world.containerItemsCanFit(targetContainer,item)
+											if test>0 then
+												local leftOverItems=world.containerAddItems(targetContainer,item)
+												if leftOverItems then
+													local tempQuantity=item.count-leftOverItems.count
+													if tempQuantity > 0 then
+														world.containerTakeNumItemsAt(sourceContainer,indexIn-1,tempQuantity)
+														item=leftOverItems
+													else
+														backflowInstances=backflowInstances+1
 													end
 												else
 													world.containerTakeNumItemsAt(sourceContainer,indexIn-1,item.count)
-													originalCount=originalCount-item.count
-													if not (storage.roundRobinSlots) then
-														break
+													if not storage.roundRobin then
+														item.count=0
 													end
 												end
-											end
-										end
-									end
-								else
-									if item.count>0 then
-										--world.containerStackItems() attempts to add items to an existing stack. fails otherwise. returns leftovers
-										local test=world.containerItemsCanFit(targetContainer,item)
-										if test>0 then
-											local leftOverItems=world.containerAddItems(targetContainer,item)
-											if leftOverItems then
-												local tempQuantity=item.count-leftOverItems.count
-												if tempQuantity > 0 then
-													world.containerTakeNumItemsAt(sourceContainer,indexIn-1,tempQuantity)
-													item=leftOverItems
-												else
-													backflowInstances=backflowInstances+1
-												end
 											else
-												world.containerTakeNumItemsAt(sourceContainer,indexIn-1,item.count)
-												if not storage.roundRobin then
-													item.count=0
-												end
+												backflowInstances=backflowInstances+1
 											end
-										else
-											backflowInstances=backflowInstances+1
 										end
 									end
 								end
+								if storage.roundRobinSlots and storage.invertSlots[2] then
+									item.count=subCount
+								end
 							end
-							if storage.roundRobinSlots and storage.invertSlots[2] then
-								item.count=subCount
-							end
+							outputSize=outputSize-1
 						end
-						outputSize=outputSize-1
 					end
 				end
 			end


### PR DESCRIPTION
Alongside the stack and slot split toggles in the item transference device, I added new "leave one" and "only stack" options as well. The former will always leave at least one item behind in every source slot/stack before transferring (it does this check early allowing it to be efficient and to take the 'minus one' item count into account before for item count calculations down the line). The latter only adds items to existing stacks in output slots, functionally treating empty, but valid slots as "full" for the purposes of round robin logic. 

Not too big a change, all in all its about a 50 line change between the gui config and lua scripting (the diff makes it look worse, wish LUA had a 'continue' function. If you can diff with whitespace ignored it makes it much clearer). Performance impact should be minimal, I tested both options together, as well as with the stack splitting toggles/filters mixed in. Everything seems to work correctly.

![PlHqPVO](https://user-images.githubusercontent.com/91115992/134224574-406d4916-3351-4b6d-a9fc-81bca921c36d.png)

Using two ITDs and a storage item between them, this would effectively allow for "infinite" filtering options. Good example for this is a drop box that will automatically move siftable blocks and crushable blocks into their own separate containers that feed into the sifters/crushers. An ITD configured with "only stack" would move items from the drop box to the "siftables" box, provided you put any new block you encounter that is siftable into the sift box one time. Another ITD configured with "leave one" would then take these siftable blocks (but always leave one behind, so that the first ITD can still move blocks into it from the drop box), and send them to the sifters.