### PR TITLE
Tooltips: rename missed "Power Switch" labels (in other capitalization)

### DIFF
--- a/objects/kheAA/kheAA_grabber/kheAA_grabber.object
+++ b/objects/kheAA/kheAA_grabber/kheAA_grabber.object
@@ -4,7 +4,7 @@
 	"printable" : false,
 	"rarity" : "Common",
 	"description" : "Basic Grabber. Grabs items from the world. Range: 4.
-^blue;Input: ^white;power switch^reset;
+^blue;Input: ^white;On/Off Switch^reset;
 ^red;Output: ^white;item network^reset;",
 	"shortdescription" : "Grabber v1",
 	"objectType" : "container",

--- a/objects/kheAA/kheAA_grabber/kheAA_grabber2.object
+++ b/objects/kheAA/kheAA_grabber/kheAA_grabber2.object
@@ -4,7 +4,7 @@
 	"printable" : false,
 	"rarity" : "Rare",
 	"description" : "Better capacity Grabber. Grabs items from the world. Range: 8.
-^blue;Input: ^white;power switch
+^blue;Input: ^white;On/Off Switch
 ^red;Output: ^white;item network^reset;",
 	"shortdescription" : "Grabber v2",
 	"objectType" : "container",

--- a/objects/kheAA/kheAA_grabber/kheAA_grabber3.object
+++ b/objects/kheAA/kheAA_grabber/kheAA_grabber3.object
@@ -4,7 +4,7 @@
 	"printable" : false,
 	"rarity" : "legendary",
 	"description" : "Highest capacity Grabber. Grabs items from the world. Range: 12.
-^blue;Input: ^white;power switch 
+^blue;Input: ^white;On/Off Switch 
 ^red;Output: ^white;item network^reset;",
 	"shortdescription" : "Grabber v3",
 	"objectType" : "container",

--- a/objects/kheAA/kheAA_pump/kheAA_pump.object
+++ b/objects/kheAA/kheAA_pump/kheAA_pump.object
@@ -3,7 +3,7 @@
 	"colonyTags": ["wired"],
 	"printable": false,
 	"rarity": "Common",
-	"description": "Pumps liquids.\n^blue;Input^white;1^blue;: ^white;power switch\n^blue;Input^white;2^blue;: ^white;compression\n^red;Output^white;1^red;: ^white;item network\n^red;Output^white;2^red;: ^white;unused^reset;",
+	"description": "Pumps liquids.\n^blue;Input^white;1^blue;: ^white;On/Off Switch\n^blue;Input^white;2^blue;: ^white;compression\n^red;Output^white;1^red;: ^white;item network\n^red;Output^white;2^red;: ^white;unused^reset;",
 	"shortdescription": "Copper Pump",
 //	"learnBlueprintsOnPickup": ["network_pump_iron"],
 	"objectType": "container",

--- a/objects/kheAA/kheAA_pump/kheAA_pump_densinium.object
+++ b/objects/kheAA/kheAA_pump/kheAA_pump_densinium.object
@@ -3,7 +3,7 @@
 	"colonyTags": ["wired"],
 	"printable": false,
 	"rarity": "rare",
-	"description": "Pumps liquids.\n^blue;Input^white;1^blue;: ^white;power switch\n^blue;Input^white;2^blue;: ^white;compression\n^red;Output^white;1^red;: ^white;item network\n^red;Output^white;2^red;: ^white;unused^reset;",
+	"description": "Pumps liquids.\n^blue;Input^white;1^blue;: ^white;On/Off Switch\n^blue;Input^white;2^blue;: ^white;compression\n^red;Output^white;1^red;: ^white;item network\n^red;Output^white;2^red;: ^white;unused^reset;",
 	"shortdescription": "Densinium Pump",
 	"objectType": "container",
 	"tooltipKind": "container",

--- a/objects/kheAA/kheAA_pump/kheAA_pump_iron.object
+++ b/objects/kheAA/kheAA_pump/kheAA_pump_iron.object
@@ -3,7 +3,7 @@
 	"colonyTags": ["wired"],
 	"printable": false,
 	"rarity": "Common",
-	"description": "Pumps liquids.\n^blue;Input^white;1^blue;: ^white;power switch\n^blue;Input^white;2^blue;: ^white;compression\n^red;Output^white;1^red;: ^white;item network\n^red;Output^white;2^red;: ^white;unused^reset;",
+	"description": "Pumps liquids.\n^blue;Input^white;1^blue;: ^white;On/Off Switch\n^blue;Input^white;2^blue;: ^white;compression\n^red;Output^white;1^red;: ^white;item network\n^red;Output^white;2^red;: ^white;unused^reset;",
 	"shortdescription": "Iron Pump",
 //	"learnBlueprintsOnPickup": ["network_pump_titanium"],
 	"objectType": "container",

--- a/objects/kheAA/kheAA_pump/kheAA_pump_titanium.object
+++ b/objects/kheAA/kheAA_pump/kheAA_pump_titanium.object
@@ -3,7 +3,7 @@
 	"colonyTags": ["wired"],
 	"printable": false,
 	"rarity": "uncommon",
-	"description": "Pumps liquids.\n^blue;Input^white;1^blue;: ^white;power switch\n^blue;Input^white;2^blue;: ^white;compression\n^red;Output^white;1^red;: ^white;item network\n^red;Output^white;2^red;: ^white;unused^reset;",
+	"description": "Pumps liquids.\n^blue;Input^white;1^blue;: ^white;On/Off Switch\n^blue;Input^white;2^blue;: ^white;compression\n^red;Output^white;1^red;: ^white;item network\n^red;Output^white;2^red;: ^white;unused^reset;",
 	"shortdescription": "Titanium Pump",
 //	"learnBlueprintsOnPickup": ["network_pump_densinium"],
 	"objectType": "container",

--- a/objects/kheAA/kheAA_router/kheAA_router.object
+++ b/objects/kheAA/kheAA_router/kheAA_router.object
@@ -7,7 +7,7 @@
 	"category" : "wire",
 	"price" : 500,
 	"description" : "Moves items between containers.
-^blue;Input^white;1^blue;: ^white;power switch
+^blue;Input^white;1^blue;: ^white;On/Off Switch
 ^blue;Input^white;2^blue;: ^white;item network
 ^red;Output: ^white;item network^reset;",
 	"shortdescription" : "Item Transference Device",

--- a/objects/kheAA/kheAA_spout/kheAA_dropper.object
+++ b/objects/kheAA/kheAA_spout/kheAA_dropper.object
@@ -4,7 +4,7 @@
 	"printable" : false,
 	"rarity" : "Common",
 	"description" : "Drops Items into the world.
-^blue;Input^white;1^blue;: ^white;power switch",
+^blue;Input^white;1^blue;: ^white;On/Off Switch",
 	"shortdescription" : "Item Dropper",
 	"objectType" : "container",
 	"tooltipKind" : "container",

--- a/objects/kheAA/kheAA_spout/kheAA_spout.object
+++ b/objects/kheAA/kheAA_spout/kheAA_spout.object
@@ -4,7 +4,7 @@
 	"printable" : false,
 	"rarity" : "Common",
 	"description" : "Pours Liquids into the world.
-^blue;Input^white;1^blue;: ^white;power switch
+^blue;Input^white;1^blue;: ^white;On/Off Switch
 ^blue;Input^white;2^blue;: ^white;item network^reset;",
 	"shortdescription" : "Spout",
 	"objectType" : "container",

--- a/objects/outpost/outpostservicepanel/outpostservicepanel.object
+++ b/objects/outpost/outpostservicepanel/outpostservicepanel.object
@@ -2,7 +2,7 @@
   "objectName" : "outpostservicepanel",
   "colonyTags" : ["outpost","electronic","science"],
   "rarity" : "Common",
-  "description" : "A service panel. Transmits power. Use with care. ^blue;Upper Input^reset;: Power switch. You may need ^cyan;Watchers^reset; to keep distant stations running.",
+  "description" : "A service panel. Transmits power. Use with care. ^blue;Upper Input^reset;: On/Off Switch. You may need ^cyan;Watchers^reset; to keep distant stations running.",
   "shortdescription" : "Service Panel",
   "race" : "generic",
   "category" : "wire",

--- a/objects/power/fu_conduit/fu_conduit.object
+++ b/objects/power/fu_conduit/fu_conduit.object
@@ -3,7 +3,7 @@
   "colonyTags" : ["science"],
   "printable" : false,
   "rarity" : "common",
-  "description" : "Transmits power. Use with care. ^blue;Upper Input^reset;: Power switch. You may need ^cyan;Watchers^reset; to keep distant stations running.",
+  "description" : "Transmits power. Use with care. ^blue;Upper Input^reset;: On/Off Switch. You may need ^cyan;Watchers^reset; to keep distant stations running.",
   "shortdescription" : "Power Relay",
   "race" : "generic",
 


### PR DESCRIPTION
Follow-up to #3168.