### PR TITLE
Tenant criteria order

### DIFF
--- a/tenants/darkkizku/cultist_temple_builder.tenant
+++ b/tenants/darkkizku/cultist_temple_builder.tenant
@@ -3,6 +3,7 @@
   "priority": 10,
 
   "colonyTagCriteria": {
+    "door": 1,
     "elder": 1,
     "hideous": 1,
     "statue": 1

--- a/tenants/other/villager_precursor.tenant
+++ b/tenants/other/villager_precursor.tenant
@@ -3,7 +3,7 @@
   "priority" : 2,
 
   "colonyTagCriteria": {
-    "light" : 2,
+    "light" : 1,
     "door" : 1,
     "precursor" : 15
   },

--- a/tenants/vanillaraces/aviangravedigger.tenant
+++ b/tenants/vanillaraces/aviangravedigger.tenant
@@ -3,8 +3,8 @@
   "priority": 10,
 
   "colonyTagCriteria": {
-    "door": 1,
     "light": 1,
+    "door": 1,
     "macabre": 8,	
     "madness": 8
   },

--- a/tenants/vanillaraces/beekeeper.tenant
+++ b/tenants/vanillaraces/beekeeper.tenant
@@ -3,10 +3,10 @@
   "priority": 8,
 
   "colonyTagCriteria": {
-    "hive": 1,
-    "bees": 12,
+    "light": 1,
     "door": 1,
-    "light": 2
+    "hive": 1,
+    "bees": 12
   },
 
   "tenants": [

--- a/tenants/vanillaraces/brewmaster.tenant
+++ b/tenants/vanillaraces/brewmaster.tenant
@@ -3,9 +3,9 @@
   "priority": 8,
 
   "colonyTagCriteria": {
-    "booze": 12,
+    "light": 1,
     "door": 1,
-    "light": 2
+    "booze": 12
   },
 
   "tenants": [

--- a/tenants/vanillaraces/drunkard.tenant
+++ b/tenants/vanillaraces/drunkard.tenant
@@ -3,9 +3,9 @@
   "priority": 8,
 
   "colonyTagCriteria": {
-    "drunkard": 5,
+    "light": 1,
     "door": 1,
-    "light": 2
+    "drunkard": 5
   },
 
   "tenants": [

--- a/tenants/vanillaraces/humanlumberjack.tenant
+++ b/tenants/vanillaraces/humanlumberjack.tenant
@@ -3,8 +3,8 @@
   "priority": 10,
 
   "colonyTagCriteria": {
-    "door": 1,
     "light": 1,
+    "door": 1,
     "glitchvillage": 6,	
     "knowledge": 6,
 	  "storage": 6

--- a/tenants/vanillaraces/thickjungle.tenant
+++ b/tenants/vanillaraces/thickjungle.tenant
@@ -3,7 +3,7 @@
   "priority": 5,
 
   "colonyTagCriteria": {
-    "light": 2,
+    "light": 1,
     "door": 1,
     "nature" : 4,
     "thickjungle" : 6


### PR DESCRIPTION
- Cultist Temple Builder tenants now require doors.