### PR TITLE
RNG rapiers no longer tagged as shortswords

### DIFF
--- a/items/active/weapons/melee/rapier/fucommonrapier.activeitem
+++ b/items/active/weapons/melee/rapier/fucommonrapier.activeitem
@@ -8,7 +8,7 @@
   "tooltipKind" : "sword2",
   "category" : "rapier",
   "twoHanded" : false,
-  "itemTags" : ["weapon","melee","shortsword", "rapier", "upgradeableWeapon"],
+  "itemTags" : ["weapon","melee", "rapier", "upgradeableWeapon"],
 
   "animation" : "piercecombo.animation",
   "animationParts" : { },

--- a/items/active/weapons/melee/rapier/furarerapier.activeitem
+++ b/items/active/weapons/melee/rapier/furarerapier.activeitem
@@ -8,7 +8,7 @@
   "tooltipKind" : "sword2",
   "category" : "rapier",
   "twoHanded" : false,
-  "itemTags" : ["weapon","melee","shortsword", "rapier", "upgradeableWeapon"],
+  "itemTags" : ["weapon","melee", "rapier", "upgradeableWeapon"],
 
   "animation" : "piercecombo.animation",
   "animationParts" : { },

--- a/items/active/weapons/melee/rapier/fuuncommonrapier.activeitem
+++ b/items/active/weapons/melee/rapier/fuuncommonrapier.activeitem
@@ -8,7 +8,7 @@
   "tooltipKind" : "sword2",
   "category" : "rapier",
   "twoHanded" : false,
-  "itemTags" : ["weapon","melee","shortsword", "rapier", "upgradeableWeapon"],
+  "itemTags" : ["weapon","melee", "rapier", "upgradeableWeapon"],
 
   "animation" : "piercecombo.animation",
   "animationParts" : { },


### PR DESCRIPTION
- RNG rapiers are no longer tagged as shortswords