### PR TITLE
x'i hunger buff and tooltip revision

### DIFF
--- a/species/radien.raceeffect
+++ b/species/radien.raceeffect
@@ -1,15 +1,15 @@
 {
 	"stats": [
-		{ "stat": "maxHealth", "effectiveMultiplier": 1.10 },
-		{ "stat": "maxEnergy", "effectiveMultiplier": 1.20 },
+		{ "stat": "maxHealth", "effectiveMultiplier": 1.1 },
+		{ "stat": "maxEnergy", "effectiveMultiplier": 1.2 },
 		{ "stat": "protection", "effectiveMultiplier": 1.03 },
 		{ "stat": "foodDelta", "baseMultiplier": 1.25 },
         
 		{ "stat": "mentalProtection", "amount": 0.05 },
-		{ "stat": "fireResistance", "amount": -0.10 },
-		{ "stat": "iceResistance", "amount": -0.10 },
-		{ "stat": "poisonResistance", "amount": 0.10 },
-		{ "stat": "electricResistance", "amount": -0.10 },
+		{ "stat": "fireResistance", "amount": -0.2 },
+		{ "stat": "iceResistance", "amount": -0.2 },
+		{ "stat": "poisonResistance", "amount": 0.1 },
+		{ "stat": "electricResistance", "amount": -0.2 },
 		{ "stat": "cosmicResistance", "amount": 0.05 },
 		{ "stat": "radioactiveResistance", "amount": 0.35 },
         

--- a/species/radien.species
+++ b/species/radien.species
@@ -4,13 +4,13 @@
   "charCreationTooltip" : {
       "title" : "X'i",
       "subTitle" : "CH9",
-      "description" : "A race of shy radioactive beings with a disputed origin. This species ^red;must^reset; be played in Survival or Hardcore modes. ^red;Challenge is high^reset;.
+      "description" : "A race of shy radioactive beings with a disputed origin. This species ^red;is designed around Hunger^reset;. ^red;Challenge is high^reset;.
 
 ^orange;Diet^reset;: Any, including prepared Isotopes.
 
 ^orange;Perks^reset;:
-  Health x^green;1.1^reset;, Energy x^green;1.2^reset;, Defense x^green;1.03^reset;
-  ^green;Resist^reset;: +^cyan;35^reset;% Radiation, +^cyan;10^reset;% Poison, +^cyan;5^reset;% Mental, +^cyan;5^reset;% Cosmic
+  Health x^green;1.1^reset;, Energy x^green;1.2^reset;, ^red;Reduced by Hunger^reset;. Defense x^green;1.03^reset;
+  ^green;Resist^reset;: +^green;35^reset;% Radiation, +^green;10^reset;% Poison, +^green;5^reset;% Cosmic, ^green;Up to 2x when Full Belly^reset;. +^green;5^reset;% Mental.
   Tech: Seed Bulb
   ^cyan;Immune^reset;: Radiation Burn
 
@@ -21,11 +21,11 @@
   ^cyan;Racial Tech is integral to success^reset;.
 
 ^orange;Weapons^reset;:
-  X'i Weapons: +^green;1.5^reset;% Crit Chance and Defense x^green;1.15^reset;
+  X'i Weapons: +^green;1.5^reset;% Crit Chance, Defense x^green;1.15^reset;
 
 ^red;Weaknesses^reset;:
-  +^red;25^reset;% Hunger drain. +^red;Hunger affects all listed resistance values^reset;
-  ^red;Resist^reset;: -^red;10^reset;% Fire, Ice & Electric. ^red;Worsens with hunger^reset;.
+  +^red;25^reset;% Hunger drain.
+  ^red;Resist^reset;: -^red;20^reset;% Fire, Ice & Electric, ^red;Up to 1.5x when Hungry^reset;.
   ^red;CANNOT^reset; use Healing items. Must use racial heals."
   },
 

--- a/stats/bonuses/radienFoodBoost.lua
+++ b/stats/bonuses/radienFoodBoost.lua
@@ -1,89 +1,62 @@
 function init()
-  self.armorTimer = 0
-  self.armorTotal = 1
+	modifiers=config.getParameter("modifiers",{})
 end
 
-function checkHealth()
-  self.baseHealth = config.getParameter("baseHealth")
-  self.baseEnergy =  config.getParameter("baseEnergy")
-  self.healthMultPenalty = self.baseHealth * ( self.baseHealth *  -(1 - (self.foodValue)))
-  self.energyMultBonus = self.baseEnergy * ( self.baseEnergy *  -(1 - (self.foodValue)))
-  self.finalHealth = math.ceil(self.healthMultPenalty * self.baseMod) -2
-  self.finalEnergy = math.ceil(self.healthMultPenalty * self.baseMod) -3
-end
+--[[doc:
+note that this file handles direct scaling modifiers. no static base values. so no 10+(food*x) or such.
+modifiers table:
+"statName":{"type":"statModifierType(baseMultiplier/effectiveMultiplier/amount)","value":baseValue,["inverse":false],["step":0.1]}
+applies modifier to statName, using statModifierType, scaling the baseValue by foodPercent (or the default defined in checkFoodPercent).
+inverse causes the value to grow as hunger does, rather than shrink. step clamps hunger to the value for the calculation.
+]]
 
 function setValues()
-  self.radiationBoost = self.foodValue * 0.40
-  self.poisonBoost = self.foodValue * 0.10
-  self.powerMultBonus = self.foodValue * 0.15
-  self.firePenaltyBonusMod = -0.25 + (self.powerMultBonus)
-  self.icePenaltyBonusMod = -0.25 + (self.powerMultBonus)
-  self.electricPenaltyBonusMod = -0.25 + (self.powerMultBonus)
-
-  --failsafes so that at 10% food you are hard-locked to a particular amount to not get too weak
-  if self.foodValue < 0.1 then
-      self.firePenaltyBonusMod = -0.25
-      self.poisonBoost = 0
-      self.powerMultBonus = 0
-      self.radiationBoost = 0.10
-      self.firePenaltyBonusMod = -0.2
-      self.icePenaltyBonusMod = -0.2
-      self.electricPenaltyBonusMod = -0.2
-  end  
-
-  status.setPersistentEffects("radienPower", {
-      {stat = "maxHealth", amount = self.finalHealth },
-      {stat = "maxEnergy", amount = self.finalEnergy },
-      --penalties
-      {stat = "poisonResistance", amount = self.poisonBoost},
-      {stat = "fireResistance", amount = self.firePenaltyBonusMod },
-      --bonuses
-      {stat = "radioactiveResistance", amount = self.radiationBoost },
-      {stat = "iceResistance", amount = self.icePenaltyBonusMod },
-      {stat = "electricResistance", amount = self.electricPenaltyBonusMod }
-  })
+	local buffer={}
+	local foodPercent=checkFoodPercent()
+	for statName,data in pairs(modifiers) do
+		local val=data.value
+		local fVal=foodPercent
+		if data.step then
+			fVal=round(fVal/data.step)*data.step
+		end
+		fVal=((data.invert and (1-fVal)) or fVal)
+		local isMult=(data.type=="effectiveMultiplier") or (data.type=="baseMultiplier")
+		if isMult then val=val-1.0 end
+		val=val*fVal
+		if isMult then val=val+1.0 end
+		local subBuffer={stat=statName}
+		subBuffer[data.type]=val
+		buffer[#buffer+1]=subBuffer
+	end
+	status.setPersistentEffects("radienPower",buffer)
 end
 
-
+function checkFoodPercent()
+	return (((status.statusProperty("fuFoodTrackerHandler",0)>-1) and status.isResource("food")) and status.resourcePercentage("food")) or 0.5
+end
 
 function update(dt)
-	if status.isResource("food") then
-		self.foodValue = status.resourcePercentage("food")
-	else
-		self.foodValue=0.5
+	self.armorTimer = (self.armorTimer or 0) + dt
+
+	if self.armorTimer >= 50 then
+		self.armorTotal = math.min(25,self.armorTotal + 1)
+		status.setPersistentEffects("radienArmor", {{stat = "protection", amount = 1+ self.armorTotal }})
+		self.armorTimer = 0
 	end
-
-  self.armorTimer = self.armorTimer + 1
-
-  if self.armorTimer == 3000 then
-    self.armorTimer = 0
-    self.armorTotal = self.armorTotal + 1
-    if self.armorTotal >= 25 then
-      self.armorTotal = 25
-    end
-
-    status.setPersistentEffects("radienArmor", {
-      {stat = "protection", amount = 1+ self.armorTotal }
-    })
-  end
-
-  if self.foodValue >= 0.98 then
-    self.dt = 1
-    self.baseMod = 1
-  else
-    self.dt = 0
-    self.baseMod = 1 * (10 + self.dt)
-    self.dt = dt + (self.baseMod)
-  end
-
-  checkHealth()  -- set health adjustment stats
-  setValues() -- set adjustments to stats
-
+	
+	self.valueTimer=(self.valueTimer or 0)-dt
+	if self.valueTimer<=0 then
+		setValues()
+		self.valueTimer=0.5
+	end
 end
 
 function uninit()
-  status.clearPersistentEffects("radienPower")
-  status.clearPersistentEffects("radienArmor")
-  self.armorTotal = 1
-  self.armorTimer = 0
+	status.clearPersistentEffects("radienPower")
+	status.clearPersistentEffects("radienArmor")
+end
+
+function round(num, idp)
+  local mult = 10^(idp or 0)
+  return math.floor(num * mult + 0.5) / mult
 end

--- a/stats/bonuses/radienFoodBoost.statuseffect
+++ b/stats/bonuses/radienFoodBoost.statuseffect
@@ -1,17 +1,21 @@
 {
-  "name" : "radienFoodBoost",
-  "effectConfig" : {
-    //Core attributes
-    "radioactiveResistance" : 0.5,
-    "damageBonus" : 0.2,
-    "baseHealth" : 0.95,
-    "baseEnergy" : 1.1
-  },
+	"name" : "radienFoodBoost",
+	"effectConfig" : {
+		"modifiers":{
+			"maxHealth":{"type":"effectiveMultiplier","value":0.91,"invert":true,"step":0.1},
+			"maxEnergy":{"type":"effectiveMultiplier","value":0.83,"invert":true,"step":0.1},
+			"radioactiveResistance":{"type":"amount","value":0.35},
+			"poisonResistance":{"type":"amount","value":0.1,"step":0.1},
+			"cosmicResistance":{"type":"amount","value":0.05,"step":0.2},
+			"iceResistance":{"type":"amount","value":-0.1,"invert":true,"step":0.1},
+			"fireResistance":{"type":"amount","value":-0.1,"invert":true,"step":0.1},
+			"electricResistance":{"type":"amount","value":-0.1,"invert":true,"step":0.1}
+		}
+	},
 
-  "defaultDuration" : 3,
+	"defaultDuration" : 3,
 
-  "scripts" : [
-    "radienFoodBoost.lua"
-  ]
-
+	"scripts" : [
+		"radienFoodBoost.lua"
+	]
 }


### PR DESCRIPTION
shorthand:
x'i hunger buff optimized and revised to be a bit less rad resistance buff, a bit less elec/fire/cold weakness, and added cosmic.
default hunger threshold (IE: casual mode) is now 50%. This is a nerf to casual players. I repeat: THIS IS A NERF.

long version:
x'i hunger based scaling:
optimized. Reduced calculation frequency to half a second instead of 1/60 a second, some resistances apply in steps of hunger.
Revised max values at full belly to 35% rad, 10% poison, and 5% cosmic.
Revised max values at empty belly to -10% ice, electric, and fire.
different energy/hp scaling.

x'i raceeffect file:
revised racial resistances to keep to overall design.

Net changes: -5% rad at max belly. +5% cosmic at max belly. +3% ice/electric/fire at empty belly. racial energy/health boost negated at empty belly.

hunger system detection integrated, effective hunger when hunger is disabled is now 50%.