### PR TITLE
Fix Wasteland chests using a wrong treasure pool

### DIFF
--- a/treasure/default.treasurechests.patch
+++ b/treasure/default.treasurechests.patch
@@ -166,7 +166,7 @@
 	[
 		{
 		"containers" : [ "rustchest" ],
-		"treasurePool" : "ffmetallicbigChest",
+		"treasurePool" : "ffwastelandChest",
 		"minimumLevel" : 1
 		}
 	]


### PR DESCRIPTION
Wasteland chest is likely intended to use "ffwastelandChest" pool,
value "ffmetallicbigChest" is a copy-paste error (chests above use it).