### PR TITLE
Update fuenergyArrow.projectile

### DIFF
--- a/projectiles/guns/arrows/fuenergyArrow/fuenergyArrow.projectile
+++ b/projectiles/guns/arrows/fuenergyArrow/fuenergyArrow.projectile
@@ -9,7 +9,7 @@
       ]
     }
   ],
-  "image" : "energyArrow.png",
+  "image" : "fuenergyArrow.png",
   "animationCycle" : 0.25,
   "frameNumber" : 1,
   "damageKindImage" : "icon.png",


### PR DESCRIPTION
Corrected typo that caused Energy Arrow sprite not showing when fired. Fixing bug #3198