### PR TITLE
Updated hydrogen extraction tutorial

### DIFF
--- a/quests/fu_questlines/tutorial/extractor/extractor6.questtemplate
+++ b/quests/fu_questlines/tutorial/extractor/extractor6.questtemplate
@@ -2,7 +2,7 @@
 	"id" : "extractor6",
 	"prerequisites" : [ "extractor1" ],
 	"title" : "Hydrogen",
-	"text" : "^orange;Water^reset; is never in short supply. If you have upgraded your ^orange;Matter Manipulator^reset; to pick up liquids...^green;extract some^reset; and bring me 5 ^orange;Hydrogen^reset; if you don't mind?",
+	"text" : "^orange;Water^reset; is never in short supply. If you have upgraded your ^orange;Matter Manipulator^reset; to pick up liquids...^green;extract some^reset;, ^yellow;come to the Science Outpost^reset; and bring me 5 ^orange;Hydrogen^reset; if you don't mind?",
 	"completionText" : "Great. Thanks so very much. Now I can complete this power cell! Take this as payment for your deeds.",
 	"moneyRange" : [200, 500],
 	"rewards" : [ [ [ "rewardbag", 1 ] ] ],


### PR DESCRIPTION
- The description for the extraction tutorial quest 'Hydrogen' now explicitly directs players to the Science Outpost.