### PR TITLE
Bugfix: Wrong frame number set for shroomburstshot projectile

### DIFF
--- a/projectiles/mushroom/shroomcloud/shroomburstshot.projectile
+++ b/projectiles/mushroom/shroomcloud/shroomburstshot.projectile
@@ -4,7 +4,7 @@
   "physics" : "fu_flybug",
   "animationCycle" : 1.5,
   "damageKindImage" : "icon.png",
-  "frameNumber" : 24,
+  "frameNumber" : 2,
   "power" : 1,
   "level" : 5,
   "speed" : 40,
@@ -25,11 +25,11 @@
     {
       "action" : "config",
       "file" : "/projectiles/explosions/vsmallregularexplosion/vsmallregularexplosion.config"
-    },    
+    },
     {
       "action" : "sound",
       "options" : [ "/sfx/npc/smallbiped/bulbouseyehead_small_idle1.ogg", "/sfx/npc/smallbiped/bulbouseyehead_small_idle2.ogg", "/sfx/npc/smallbiped/bulbouseyehead_small_attack1.ogg", "/sfx/npc/smallbiped/bulbouseyehead_small_attack2.ogg" ]
-    },    
+    },
     {
       "action" : "loop",
       "count" : 4,


### PR DESCRIPTION
Fixes #3210 