### PR TITLE
Bugfix: Replace unnecessary category 'upgradeable epp'

### DIFF
--- a/items/armors/backitems/erithianalgaepack/batterypack_erithian.back
+++ b/items/armors/backitems/erithianalgaepack/batterypack_erithian.back
@@ -7,7 +7,7 @@
   "description" : "This lovely piece of gear grants: Energy x1.1, +10% E. Regen, -5% E. Block, protection from electrical storms and a slight ^#00aa00;glow^reset;.",
   "shortdescription" : "Erithian Energy Pack",
   "tooltipKind" : "baseaugment",
-  "category" : "^#e43774;Upgradeable EPP^reset;",
+  "category" : "enviroProtectionPack",
   "acceptsAugmentType" : "back",
   "radioMessagesOnPickup" : [ "pickupepp" ],
   "maxStack" : 1,

--- a/items/armors/backitems/protocytepack/batterypack_protocyte.back
+++ b/items/armors/backitems/protocytepack/batterypack_protocyte.back
@@ -7,7 +7,7 @@
   "description" : "An improved energy pack. Immunity: proto-poison, electrical storms. Energy x1.15, +20% E. Regen, -10% E. Block, and a slight ^#3c3c00;glow^reset;.",
   "shortdescription" : "Protocite Energy Pack",
   "tooltipKind" : "baseaugment",
-  "category" : "^#e43774;Upgradeable EPP^reset;",
+  "category" : "enviroProtectionPack",
   "acceptsAugmentType" : "back",
   "radioMessagesOnPickup" : [ "pickupepp" ],
 

--- a/scripts/kheAA/transferconfig.config
+++ b/scripts/kheAA/transferconfig.config
@@ -4,7 +4,7 @@
 	"categories" : {
 		// special
 		"unhandled":"unhandled",
-		
+
 		// materials
 		"block" : "material",
 		"liquid" : "material",
@@ -29,7 +29,7 @@
 		"matter manipulator" : "tool",
 		"throwableitem" : "tool",
 		"console" : "tool",
-	
+
 
 		// rail-related
 		"rail" : "rail",
@@ -124,7 +124,7 @@
 		"actionfigure" : "treasure",
 		"artifact" : "treasure",
 		"crewcontract" : "treasure",
-		
+
 		//currency has special handling now, and is its own separate category
 		"currency" : "currency",
 
@@ -191,7 +191,6 @@
 		"legarmour" : "armor",
 		"backarmour" : "armor",
 		"enviroprotectionpack" : "armor",
-		"^#e43774;upgradeable epp^reset;" : "armor",
 		"t1armor" : "armor",
 		"t1armoru" : "armor",
 		"t2armor" : "armor",


### PR DESCRIPTION
This dedicated category gives you the impression there's smth special about this EPP regarding upgrades, but there's none ... It can be upgraded like other EPPs too, that don't have any special category. Even the batterypack_morphite that's part of this kind of EPPs doesn't have category 'upgradeable epp'.

This PR removes 'upgradeable epp' and replaces it with vanilla EPP category. I had no crashes/problem after this change during my tests and the EPP worked as expected.