### PR TITLE
Rebalanced ancient temple loot

### DIFF
--- a/dungeons/missions/ancienttemple/ancienttemple.json
+++ b/dungeons/missions/ancienttemple/ancienttemple.json
@@ -1,12 +1,5 @@
 { "backgroundcolor":"#000000",
  "compressionlevel":-1,
- "editorsettings":
-    {
-     "export":
-        {
-         "target":"."
-        }
-    },
  "height":605,
  "infinite":false,
  "layers":[
@@ -72,12 +65,14 @@
                  "height":16,
                  "id":562,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -90,12 +85,14 @@
                  "height":16,
                  "id":563,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -108,12 +105,14 @@
                  "height":16,
                  "id":564,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -126,12 +125,14 @@
                  "height":16,
                  "id":565,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -384,12 +385,14 @@
                  "height":24,
                  "id":587,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"maybeWeaponTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"maybeWeaponTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -402,12 +405,14 @@
                  "height":16,
                  "id":588,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -420,12 +425,14 @@
                  "height":16,
                  "id":589,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -438,12 +445,14 @@
                  "height":16,
                  "id":590,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -528,12 +537,14 @@
                  "height":40,
                  "id":597,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -546,12 +557,14 @@
                  "height":40,
                  "id":598,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -564,12 +577,14 @@
                  "height":31,
                  "id":599,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1194,12 +1209,14 @@
                  "height":32,
                  "id":651,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1212,12 +1229,14 @@
                  "height":31,
                  "id":652,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1230,12 +1249,14 @@
                  "height":24,
                  "id":653,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"maybeWeaponTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"maybeWeaponTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1248,12 +1269,14 @@
                  "height":24,
                  "id":654,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"maybeWeaponTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"maybeWeaponTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1266,12 +1289,14 @@
                  "height":16,
                  "id":655,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1524,12 +1549,14 @@
                  "height":20,
                  "id":676,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"weaponChestTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"weaponChestTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1542,12 +1569,14 @@
                  "height":20,
                  "id":677,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"weaponChestTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"weaponChestTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1812,12 +1841,14 @@
                  "height":16,
                  "id":699,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1830,12 +1861,14 @@
                  "height":16,
                  "id":700,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1860,12 +1893,14 @@
                  "height":16,
                  "id":702,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1878,12 +1913,14 @@
                  "height":16,
                  "id":703,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1896,12 +1933,14 @@
                  "height":16,
                  "id":704,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1914,12 +1953,14 @@
                  "height":16,
                  "id":705,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1968,12 +2009,14 @@
                  "height":40,
                  "id":709,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -1986,12 +2029,14 @@
                  "height":40,
                  "id":710,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2004,12 +2049,14 @@
                  "height":40,
                  "id":711,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2022,12 +2069,14 @@
                  "height":32,
                  "id":712,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2040,12 +2089,14 @@
                  "height":40,
                  "id":713,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2058,12 +2109,14 @@
                  "height":16,
                  "id":714,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2076,12 +2129,14 @@
                  "height":16,
                  "id":715,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2094,12 +2149,14 @@
                  "height":24,
                  "id":716,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2124,12 +2181,14 @@
                  "height":16,
                  "id":718,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2142,12 +2201,14 @@
                  "height":16,
                  "id":719,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2160,12 +2221,14 @@
                  "height":16,
                  "id":720,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2178,12 +2241,14 @@
                  "height":16,
                  "id":721,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2196,12 +2261,14 @@
                  "height":16,
                  "id":722,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2214,12 +2281,14 @@
                  "height":16,
                  "id":723,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2232,12 +2301,14 @@
                  "height":16,
                  "id":724,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2250,12 +2321,14 @@
                  "height":16,
                  "id":725,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2268,12 +2341,14 @@
                  "height":16,
                  "id":726,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2286,12 +2361,14 @@
                  "height":16,
                  "id":727,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2304,12 +2381,14 @@
                  "height":40,
                  "id":728,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2322,12 +2401,14 @@
                  "height":40,
                  "id":729,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2340,12 +2421,14 @@
                  "height":40,
                  "id":730,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2370,12 +2453,14 @@
                  "height":16,
                  "id":732,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2388,12 +2473,14 @@
                  "height":16,
                  "id":733,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2406,12 +2493,14 @@
                  "height":16,
                  "id":734,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2424,12 +2513,14 @@
                  "height":16,
                  "id":735,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2442,12 +2533,14 @@
                  "height":16,
                  "id":736,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2460,12 +2553,14 @@
                  "height":16,
                  "id":737,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -2982,12 +3077,14 @@
                  "height":31,
                  "id":781,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -3000,12 +3097,14 @@
                  "height":32,
                  "id":782,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -3018,12 +3117,14 @@
                  "height":32,
                  "id":783,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -3108,12 +3209,14 @@
                  "height":40,
                  "id":790,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -3126,12 +3229,14 @@
                  "height":31,
                  "id":791,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -3948,12 +4053,14 @@
                  "height":8,
                  "id":860,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -4086,12 +4193,14 @@
                  "height":24,
                  "id":871,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -4104,12 +4213,14 @@
                  "height":24,
                  "id":872,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -4122,12 +4233,14 @@
                  "height":16,
                  "id":873,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -4140,12 +4253,14 @@
                  "height":16,
                  "id":874,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -4158,12 +4273,14 @@
                  "height":16,
                  "id":875,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -4428,12 +4545,14 @@
                  "height":16,
                  "id":897,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5118,12 +5237,14 @@
                  "height":24,
                  "id":1037,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5136,12 +5257,14 @@
                  "height":24,
                  "id":1038,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5154,12 +5277,14 @@
                  "height":16,
                  "id":1039,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5172,12 +5297,14 @@
                  "height":16,
                  "id":1040,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5202,12 +5329,14 @@
                  "height":16,
                  "id":1044,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"produce\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"produce\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5460,12 +5589,14 @@
                  "height":32,
                  "id":1094,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5478,12 +5609,14 @@
                  "height":32,
                  "id":1095,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5928,6 +6061,14 @@
                  "height":24,
                  "id":1288,
                  "name":"",
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"chestMoney\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -5952,6 +6093,14 @@
                  "height":32,
                  "id":1290,
                  "name":"",
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"chestMoney\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6432,12 +6581,14 @@
                  "height":16,
                  "id":1366,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6450,12 +6601,14 @@
                  "height":16,
                  "id":1367,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6468,12 +6621,14 @@
                  "height":16,
                  "id":1368,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6486,12 +6641,14 @@
                  "height":12,
                  "id":1370,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6504,12 +6661,14 @@
                  "height":12,
                  "id":1371,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6522,12 +6681,14 @@
                  "height":12,
                  "id":1372,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6540,12 +6701,14 @@
                  "height":12,
                  "id":1373,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6558,12 +6721,14 @@
                  "height":20,
                  "id":1376,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6576,12 +6741,14 @@
                  "height":35,
                  "id":1377,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6594,12 +6761,14 @@
                  "height":16,
                  "id":1378,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6612,12 +6781,14 @@
                  "height":35,
                  "id":1379,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6630,12 +6801,14 @@
                  "height":35,
                  "id":1380,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6648,12 +6821,14 @@
                  "height":32,
                  "id":1383,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6666,12 +6841,14 @@
                  "height":32,
                  "id":1384,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6708,12 +6885,14 @@
                  "height":40,
                  "id":1389,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6726,12 +6905,14 @@
                  "height":35,
                  "id":1390,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6744,12 +6925,14 @@
                  "height":24,
                  "id":1391,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6762,12 +6945,14 @@
                  "height":24,
                  "id":1392,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6780,12 +6965,14 @@
                  "height":16,
                  "id":1394,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6798,12 +6985,14 @@
                  "height":16,
                  "id":1395,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6816,12 +7005,14 @@
                  "height":16,
                  "id":1396,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6834,12 +7025,14 @@
                  "height":12,
                  "id":1397,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6852,12 +7045,14 @@
                  "height":12,
                  "id":1399,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6870,12 +7065,14 @@
                  "height":32,
                  "id":1400,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6888,12 +7085,14 @@
                  "height":32,
                  "id":1401,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6906,12 +7105,14 @@
                  "height":12,
                  "id":1402,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6924,12 +7125,14 @@
                  "height":12,
                  "id":1403,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6942,12 +7145,14 @@
                  "height":12,
                  "id":1404,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6960,12 +7165,14 @@
                  "height":16,
                  "id":1405,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6978,12 +7185,14 @@
                  "height":16,
                  "id":1406,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -6996,12 +7205,14 @@
                  "height":16,
                  "id":1407,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7014,12 +7225,14 @@
                  "height":16,
                  "id":1408,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7032,12 +7245,14 @@
                  "height":16,
                  "id":1409,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7050,12 +7265,14 @@
                  "height":16,
                  "id":1410,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7068,12 +7285,14 @@
                  "height":48,
                  "id":1412,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7086,12 +7305,14 @@
                  "height":16,
                  "id":1414,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7104,12 +7325,14 @@
                  "height":16,
                  "id":1416,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7122,12 +7345,14 @@
                  "height":16,
                  "id":1417,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7140,12 +7365,14 @@
                  "height":16,
                  "id":1418,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7158,12 +7385,14 @@
                  "height":16,
                  "id":1420,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7560,12 +7789,14 @@
                  "height":32,
                  "id":1469,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7590,12 +7821,14 @@
                  "height":32,
                  "id":1471,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -7620,12 +7853,14 @@
                  "height":31,
                  "id":1473,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9102,12 +9337,14 @@
                  "height":16,
                  "id":1647,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9392,12 +9629,14 @@
                  "height":24,
                  "id":1698,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9410,12 +9649,14 @@
                  "height":32,
                  "id":1699,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9428,12 +9669,14 @@
                  "height":16,
                  "id":1700,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9446,12 +9689,14 @@
                  "height":8,
                  "id":1701,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9464,12 +9709,14 @@
                  "height":32,
                  "id":1702,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9482,12 +9729,14 @@
                  "height":16,
                  "id":1703,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9500,12 +9749,14 @@
                  "height":16,
                  "id":1704,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9518,12 +9769,14 @@
                  "height":16,
                  "id":1705,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9536,12 +9789,14 @@
                  "height":24,
                  "id":1706,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9758,12 +10013,14 @@
                  "height":16,
                  "id":1790,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9776,12 +10033,14 @@
                  "height":32,
                  "id":1791,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9794,12 +10053,14 @@
                  "height":24,
                  "id":1792,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9812,12 +10073,14 @@
                  "height":24,
                  "id":1793,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9830,12 +10093,14 @@
                  "height":16,
                  "id":1794,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9848,12 +10113,14 @@
                  "height":16,
                  "id":1795,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9866,12 +10133,14 @@
                  "height":32,
                  "id":1796,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9884,12 +10153,14 @@
                  "height":8,
                  "id":1797,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9902,12 +10173,14 @@
                  "height":8,
                  "id":1798,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9920,12 +10193,14 @@
                  "height":8,
                  "id":1799,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9938,12 +10213,14 @@
                  "height":24,
                  "id":1800,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -9956,12 +10233,14 @@
                  "height":24,
                  "id":1801,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -10070,12 +10349,14 @@
                  "height":8,
                  "id":1822,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-1, -10], [1, 10] ]}"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-1, -10], [1, 10] ]}"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -10436,12 +10717,14 @@
                  "height":8,
                  "id":1904,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-1, -10], [1, 10] ]}"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-1, -10], [1, 10] ]}"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11186,12 +11469,14 @@
                  "height":16,
                  "id":1980,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11204,12 +11489,14 @@
                  "height":16,
                  "id":1984,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11222,12 +11509,14 @@
                  "height":16,
                  "id":1987,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11240,12 +11529,14 @@
                  "height":16,
                  "id":1988,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11258,12 +11549,14 @@
                  "height":16,
                  "id":1989,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11276,12 +11569,14 @@
                  "height":16,
                  "id":1992,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11294,12 +11589,14 @@
                  "height":16,
                  "id":1993,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11792,12 +12089,14 @@
                  "height":8,
                  "id":2044,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11810,12 +12109,14 @@
                  "height":8,
                  "id":2045,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11828,12 +12129,14 @@
                  "height":8,
                  "id":2046,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11846,12 +12149,14 @@
                  "height":8,
                  "id":2047,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11864,12 +12169,14 @@
                  "height":8,
                  "id":2048,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -11882,12 +12189,14 @@
                  "height":8,
                  "id":2049,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-1, -20], [1, 20] ]}"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12244,12 +12553,14 @@
                  "height":8,
                  "id":2116,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-29, -21], [29, 21] ], \"detectDamageTeam\" : { \"type\" : \"enemy\" } }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-29, -21], [29, 21] ], \"detectDamageTeam\" : { \"type\" : \"enemy\" } }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12406,12 +12717,14 @@
                  "height":16,
                  "id":2139,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12424,12 +12737,14 @@
                  "height":16,
                  "id":2141,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12442,12 +12757,14 @@
                  "height":16,
                  "id":2142,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12460,12 +12777,14 @@
                  "height":16,
                  "id":2145,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12478,12 +12797,14 @@
                  "height":16,
                  "id":2146,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12496,12 +12817,14 @@
                  "height":16,
                  "id":2147,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"unbreakable\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"unbreakable\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12706,12 +13029,14 @@
                  "height":32,
                  "id":2168,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicChestTreasure\" ,\"salvageComponent\"] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"instrument\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12724,12 +13049,14 @@
                  "height":24,
                  "id":2169,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicChestTreasure\",\"salvageComponent\",\"salvageComponent\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicChestTreasure\"] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12742,12 +13069,14 @@
                  "height":16,
                  "id":2170,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"challengeChestTreasure\" ,\"salvageComponent\",\"salvageComponent\",\"salvageComponent\"] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"challengeChestTreasure\",\"salvageComponent\"] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12760,12 +13089,14 @@
                  "height":24,
                  "id":2171,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicChestTreasure\",\"salvageComponent\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"basicChestTreasure\"] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12778,12 +13109,14 @@
                  "height":24,
                  "id":2173,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"basicChestTreasure\" ,\"salvageComponent\"] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"costume\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12796,12 +13129,14 @@
                  "height":16,
                  "id":2174,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"challengeChestTreasure\",\"salvageComponent\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"challengeChestTreasure\",\"salvageComponent\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12862,12 +13197,14 @@
                  "height":16,
                  "id":2182,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"challengeChestTreasure\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"challengeChestTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12880,12 +13217,14 @@
                  "height":32,
                  "id":2183,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"chestMoney\" ,\"salvageComponent\"] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"chestMoney\",\"salvageComponent\"] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12910,12 +13249,14 @@
                  "height":24,
                  "id":2185,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"chestMoney\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"chestMoney\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12928,12 +13269,14 @@
                  "height":32,
                  "id":2186,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"chestMoney\",\"salvageComponent\",\"salvageComponent\",\"salvageComponent\",\"salvageComponent\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"chestMoney\",\"salvageComponent\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12946,12 +13289,14 @@
                  "height":24,
                  "id":2187,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameter",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"chestMoney\",\"salvageComponent\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameter":"{ \"treasurePools\" : [ \"challengeSmallChestTreasure\",\"salvageComponent\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameter":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12964,12 +13309,14 @@
                  "height":16,
                  "id":2188,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"challengeChestTreasure\",\"salvageComponent\" ] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"challengeChestTreasure\",\"salvageComponent\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -12982,12 +13329,14 @@
                  "height":16,
                  "id":2189,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"treasurePools\" : [ \"challengeChestTreasure\" ,\"salvageComponent\",\"salvageComponent\",\"salvageComponent\"] }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"challengeChestTreasure\"] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13023,17 +13372,16 @@
                  "height":48,
                  "id":2198,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple01\" }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple01\" }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13057,17 +13405,16 @@
                  "height":48,
                  "id":2209,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple02\" }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple02\" }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13079,17 +13426,16 @@
                  "height":56,
                  "id":2210,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple03\" }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple03\" }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13101,17 +13447,16 @@
                  "height":48,
                  "id":2211,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple04\" }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple04\" }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13123,17 +13468,16 @@
                  "height":32,
                  "id":2212,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple05\" }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple05\" }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13145,17 +13489,16 @@
                  "height":80,
                  "id":2213,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple06\" }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple06\" }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13348,12 +13691,14 @@
                  "height":16,
                  "id":2309,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"templeguard\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"templeguard\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13366,12 +13711,14 @@
                  "height":16,
                  "id":2310,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"templeguard\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"templeguard\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13384,12 +13731,14 @@
                  "height":16,
                  "id":2311,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"battlepriest\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 5], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"battlepriest\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 5], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13402,12 +13751,14 @@
                  "height":16,
                  "id":2312,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"battlepriest\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 5], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"battlepriest\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 5], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13420,12 +13771,14 @@
                  "height":16,
                  "id":2313,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"firebird\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"firebird\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13438,12 +13791,14 @@
                  "height":16,
                  "id":2314,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"firebird\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"spawner\" : { \"npcSpecies\" : [\"avian\"], \"npcTypes\" : [\"firebird\"], \"npcParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [3, 3], \"stock\" : 2, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13455,17 +13810,16 @@
                  "height":48,
                  "id":2328,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple02fu\"  }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple02fu\"  }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13477,17 +13831,16 @@
                  "height":48,
                  "id":2329,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple03fu\"  }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple03fu\"  }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13499,17 +13852,16 @@
                  "height":128,
                  "id":2330,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple04fu\"  }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple04fu\"  }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13521,17 +13873,16 @@
                  "height":40,
                  "id":2331,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple05fu\"  }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple05fu\"  }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13543,17 +13894,16 @@
                  "height":120,
                  "id":2332,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple06fu\" }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple06fu\" }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13565,17 +13915,16 @@
                  "height":40,
                  "id":2333,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple08fu\" }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple08fu\" }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13587,17 +13936,16 @@
                  "height":120,
                  "id":2334,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple07fu\" }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple07fu\" }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13609,17 +13957,16 @@
                  "height":136,
                  "id":2335,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"radioMessage\" : \"ancienttemple01fu\"  }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"radiomessage"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"radioMessage\" : \"ancienttemple01fu\"  }",
+                     "stagehand":"radiomessage"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13644,12 +13991,14 @@
                  "height":8,
                  "id":2339,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"detectArea\" : [ [-50, 30], [-2, 0] ], \"detectEntityTypes\" : [ \"player\" ]}"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"detectArea\" : [ [-50, 30], [-2, 0] ], \"detectEntityTypes\" : [ \"player\" ]}"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13662,12 +14011,14 @@
                  "height":16,
                  "id":2340,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"spawner\" : { \"monsterTypes\" : [\"kluexsentry2\"], \"monsterParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [1, 2], \"stock\" : 1, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"spawner\" : { \"monsterTypes\" : [\"kluexsentry2\"], \"monsterParams\" : { \"aggressive\" : true }, \"position\" : [0, 0], \"positionVariance\" : [0, 0], \"frequency\" : [1, 2], \"stock\" : 1, \"trigger\" : \"wire\", \"outOfSight\" : false } }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13679,17 +14030,16 @@
                  "height":336,
                  "id":2343,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"messageType\" : \"playAltMusic\", \"messageArgs\" : [[\"\/music\/fighter.ogg\"], 2.0] }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"messenger"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"messageType\" : \"playAltMusic\", \"messageArgs\" : [[\"\/music\/fighter.ogg\"], 2.0] }",
+                     "stagehand":"messenger"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13701,17 +14051,16 @@
                  "height":104,
                  "id":2344,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"messageType\" : \"playAltMusic\", \"messageArgs\" : [[\"\/music\/depth.ogg\"], 2.0] }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"messenger"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"messageType\" : \"playAltMusic\", \"messageArgs\" : [[\"\/music\/depth.ogg\"], 2.0] }",
+                     "stagehand":"messenger"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13723,17 +14072,16 @@
                  "height":136,
                  "id":2345,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"messageType\" : \"playAltMusic\", \"messageArgs\" : [[\"\/music\/robotech.ogg\"], 2.0] }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"messenger"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"messageType\" : \"playAltMusic\", \"messageArgs\" : [[\"\/music\/robotech.ogg\"], 2.0] }",
+                     "stagehand":"messenger"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13745,17 +14093,16 @@
                  "height":96,
                  "id":2346,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"messageType\" : \"playAltMusic\", \"messageArgs\" : [[\"\/music\/floodedcomplex.ogg\"], 2.0] }"
-                        }, 
-                        {
-                         "name":"stagehand",
-                         "type":"string",
-                         "value":"messenger"
-                        }],
+                 "properties":
+                    {
+                     "parameters":"{ \"messageType\" : \"playAltMusic\", \"messageArgs\" : [[\"\/music\/floodedcomplex.ogg\"], 2.0] }",
+                     "stagehand":"messenger"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string",
+                     "stagehand":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13862,17 +14209,16 @@
                  "height":8,
                  "id":913,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13884,17 +14230,16 @@
                  "height":8,
                  "id":914,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13906,17 +14251,16 @@
                  "height":8,
                  "id":915,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"batong"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"batong",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13928,17 +14272,16 @@
                  "height":8,
                  "id":916,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"batong"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"batong",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13950,17 +14293,16 @@
                  "height":8,
                  "id":917,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"batong"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"batong",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13972,17 +14314,16 @@
                  "height":8,
                  "id":918,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"batong"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"batong",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -13994,17 +14335,16 @@
                  "height":8,
                  "id":919,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"batong"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"batong",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14016,17 +14356,16 @@
                  "height":8,
                  "id":920,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"sporgus"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"sporgus",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14038,17 +14377,16 @@
                  "height":8,
                  "id":921,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"sporgus"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"sporgus",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14060,17 +14398,16 @@
                  "height":8,
                  "id":922,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14082,17 +14419,16 @@
                  "height":8,
                  "id":923,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14104,17 +14440,16 @@
                  "height":8,
                  "id":924,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14126,17 +14461,16 @@
                  "height":8,
                  "id":925,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14148,17 +14482,16 @@
                  "height":8,
                  "id":926,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"firebird"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"firebird"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14170,17 +14503,16 @@
                  "height":8,
                  "id":927,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14192,17 +14524,16 @@
                  "height":8,
                  "id":928,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14214,17 +14545,16 @@
                  "height":8,
                  "id":929,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14236,17 +14566,16 @@
                  "height":8,
                  "id":930,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14258,17 +14587,16 @@
                  "height":8,
                  "id":931,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14280,17 +14608,16 @@
                  "height":8,
                  "id":932,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14302,17 +14629,16 @@
                  "height":8,
                  "id":933,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14324,17 +14650,16 @@
                  "height":8,
                  "id":934,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"firebird"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"firebird"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14346,17 +14671,16 @@
                  "height":8,
                  "id":935,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"firebird"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"firebird"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14368,17 +14692,16 @@
                  "height":8,
                  "id":936,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"battlepriest"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"battlepriest"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14390,17 +14713,16 @@
                  "height":8,
                  "id":937,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14412,17 +14734,16 @@
                  "height":8,
                  "id":938,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14434,17 +14755,16 @@
                  "height":8,
                  "id":939,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"merchant"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"merchant"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14456,17 +14776,16 @@
                  "height":8,
                  "id":940,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"adultpoptop"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"adultpoptop",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14478,17 +14797,16 @@
                  "height":8,
                  "id":941,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"poptop"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"poptop",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14500,17 +14818,16 @@
                  "height":8,
                  "id":942,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"poptop"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"poptop",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14522,17 +14839,16 @@
                  "height":8,
                  "id":943,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"poptop"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"poptop",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14544,17 +14860,16 @@
                  "height":8,
                  "id":944,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"poptop"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"poptop",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14566,17 +14881,16 @@
                  "height":8,
                  "id":945,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14588,17 +14902,16 @@
                  "height":8,
                  "id":946,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14610,17 +14923,16 @@
                  "height":8,
                  "id":947,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14632,17 +14944,16 @@
                  "height":8,
                  "id":948,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14654,17 +14965,16 @@
                  "height":8,
                  "id":949,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templefollower"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templefollower"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14676,17 +14986,16 @@
                  "height":8,
                  "id":950,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templefollower"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templefollower"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14698,17 +15007,16 @@
                  "height":8,
                  "id":951,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templefollower"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templefollower"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14720,17 +15028,16 @@
                  "height":8,
                  "id":1058,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"battlepriest"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"battlepriest"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14742,17 +15049,16 @@
                  "height":8,
                  "id":1059,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"firebird"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"firebird"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14764,17 +15070,16 @@
                  "height":8,
                  "id":1060,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14786,17 +15091,16 @@
                  "height":8,
                  "id":1062,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templeguard"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templeguard"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14808,17 +15112,16 @@
                  "height":8,
                  "id":1087,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"snaunt"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"snaunt",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14830,17 +15133,16 @@
                  "height":8,
                  "id":1088,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"snaunt"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"snaunt",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14852,17 +15154,16 @@
                  "height":8,
                  "id":1089,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"snaunt"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"snaunt",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14874,17 +15175,16 @@
                  "height":8,
                  "id":1090,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"snaunt"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"snaunt",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14896,17 +15196,16 @@
                  "height":8,
                  "id":1337,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"miasmop"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"miasmop",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14918,17 +15217,16 @@
                  "height":8,
                  "id":1338,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"miasmop"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"miasmop",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14940,17 +15238,16 @@
                  "height":8,
                  "id":1339,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"miasmop"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"miasmop",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14962,17 +15259,16 @@
                  "height":8,
                  "id":1340,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"miasmop"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"miasmop",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14984,17 +15280,16 @@
                  "height":8,
                  "id":1530,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -15006,17 +15301,16 @@
                  "height":8,
                  "id":1531,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -15028,17 +15322,16 @@
                  "height":8,
                  "id":1532,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -15050,17 +15343,16 @@
                  "height":8,
                  "id":1533,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"largefish"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"largefish",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -15072,17 +15364,16 @@
                  "height":8,
                  "id":2155,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"npc",
-                         "type":"string",
-                         "value":"avian"
-                        }, 
-                        {
-                         "name":"typeName",
-                         "type":"string",
-                         "value":"templehighpriest"
-                        }],
+                 "properties":
+                    {
+                     "npc":"avian",
+                     "typeName":"templehighpriest"
+                    },
+                 "propertytypes":
+                    {
+                     "npc":"string",
+                     "typeName":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -19557,17 +19848,16 @@
                  "height":8,
                  "id":2337,
                  "name":"",
-                 "properties":[
-                        {
-                         "name":"monster",
-                         "type":"string",
-                         "value":"kluexsentry2"
-                        }, 
-                        {
-                         "name":"parameters",
-                         "type":"string",
-                         "value":"{ \"aggressive\" : true }"
-                        }],
+                 "properties":
+                    {
+                     "monster":"kluexsentry2",
+                     "parameters":"{ \"aggressive\" : true }"
+                    },
+                 "propertytypes":
+                    {
+                     "monster":"string",
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -19717,7 +20007,7 @@
                 }],
          "opacity":1,
          "type":"objectgroup",
-         "visible":true,
+         "visible":false,
          "x":0,
          "y":0
         }],
@@ -19725,7 +20015,7 @@
  "nextobjectid":2365,
  "orientation":"orthogonal",
  "renderorder":"right-down",
- "tiledversion":"1.4.2",
+ "tiledversion":"1.5.0",
  "tileheight":8,
  "tilesets":[
         {
@@ -19822,6 +20112,6 @@
         }],
  "tilewidth":8,
  "type":"map",
- "version":1.4,
+ "version":1.1,
  "width":774
 }

--- a/dungeons/missions/volcanobase/volcanobase.json
+++ b/dungeons/missions/volcanobase/volcanobase.json
@@ -2957,6 +2957,14 @@
                  "height":16,
                  "id":369,
                  "name":"",
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"challengeSmallChestTreasure\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,
@@ -14667,6 +14675,14 @@
                  "height":24,
                  "id":1587,
                  "name":"",
+                 "properties":
+                    {
+                     "parameters":"{ \"treasurePools\" : [ \"instrument\" ] }"
+                    },
+                 "propertytypes":
+                    {
+                     "parameters":"string"
+                    },
                  "rotation":0,
                  "type":"",
                  "visible":true,

--- a/zb/researchTree/fu_craftsmanship.config
+++ b/zb/researchTree/fu_craftsmanship.config
@@ -663,7 +663,7 @@
             "workbenchbone": [ "Bone Construction", "^orange;Tier 1^reset;\n\nYou can create dragon-themed furniture out of leather and sculpted bone."],
             "workbenchprecious": [ "Precious Metal Construction", "^orange;Tier 2^reset;\n\nYou can make some blocks out of precious materials."],
             "workbenchavian": [ "Avian Construction", "^orange;Tier 3^reset;\n\nYou've learned to make ornate Avian-styled blocks."],
-            "workbenchslime": [ "Slime Construction", "^orange;Tier 1^reset;\n\nYou can shape furniture out of jelly and slime! Why would you want to do this? Unclear."],
+            "workbenchslime": [ "Slime Construction", "^orange;Tier 1^reset;\n\nYou can shape furniture out of jelly and slime! Why would you want to do this? Unclear.\n\nMost recipes require the ^cyan;Biochemist Table^reset;. Research it in the ^green;Geology tree^reset;."],
             "workbenchelduu": [ "Elduu'khar Construction", "^orange;Tier 2^reset;\n\nGleaming, beautiful crystalline furniture awaits if you pursue this particular knowledge!"],
             "workbenchskath": [ "Skath Construction", "^orange;Tier 3^reset;\n\nThe engimatic Skath are quite adept with technology, and this seeps into just about everything they make."],
             "pixelprinter": [ "Pixel Manipulation", "^orange;Tier 3^reset;\n\nYou've learned work with pixels, compressing them into storeable voxels or printing them into decorative furniture that you've scanned."],

--- a/zb/researchTree/fu_warcraft.config
+++ b/zb/researchTree/fu_warcraft.config
@@ -462,25 +462,25 @@
             "densiniumgear"    : [ "Densinium Equipment","^orange;Tier 6^reset;\n\nAs the heaviest and most generally indestructible metal found naturally, the only thing harder than finding veins of Densinium is forging it. Nonetheless, you've succeeded at this Herculean feat, creating nigh-indestructible and unbelievably powerful armor and weapons."],
 
             "pyreitegear"    : [ "Pyreite Equipment","^orange;Tier 6^reset;\n\nFamed for its tendency to be blazingly hot at all times, Pyreite is as much a danger to its user as it is to foes... were that user anyone but you. With your skill, you can create the hottest weapons and armor in existence, which will not only fry the competition to a crisp but protect you from the worst cold the galaxy has to offer."],
-            
+
             "isogengear"    : [ "Isogen Equipment","^orange;Tier 6^reset;\n\nThe fact that Isogen ceaseslessly devours all heat, and somehow remains just above absolute zero, presents an interesting dilemma: how do you forge and work with something like that? Well, you've figured it out with your smart blacksmith brain, and can create the coldest weapons and armor in existence. Not only will they freeze your foes solid, but Isogen armor will let you dive into an ocean of lava and come out no worse for wear."],
 
-            "xithricitegear": [ "Xithricite Equipment","^orange;Tier 6^reset;\n\nXithricite is the only known crystal which naturally radiates Cosmic energy. It can be used in the creation of many absurdly deadly weapons and amazingly durable armors now that you have the know-how and skill to do so."],                
-            
+            "xithricitegear": [ "Xithricite Equipment","^orange;Tier 6^reset;\n\nXithricite is the only known crystal which naturally radiates Cosmic energy. It can be used in the creation of many absurdly deadly weapons and amazingly durable armors now that you have the know-how and skill to do so."],
+
             "aetheriumgear"    : [ "Aetherium Equipment","^orange;Tier 7^reset;\n\nThough you only recently discovered what you've dubbed 'Aetherium' alloy, you've already set about weaponizing it in the creation of the literal best weapons and armor known to man, Floran, and everything in between. You'd have to make a pact with an eldritch god to do better than this."],
 
             "enrichedgear"    : [ "Enriched Isotope Equipment","^orange;Tier 5^reset;\n\nNow that you've learned to enrich isotopes, you can put them to use in useful weapons. Ever gotten shot by a depleted uranium bullet? I wouldn't recommend it."],
 
             "epps1"    : [ "Improved EPPs","^orange;Tier 2^reset;\n\nYou've learned make better EPPs which improve on the basic breathing model or do other useful things like resisting elements or improving your combat capability.\n\n^yellow;Reminder^reset;: EPPs in Frackin' Universe are much different than vanilla! There's no one EPP that is perfect for all situations, and the kind of EPP you choose should be tailored to the planet you want to explore."],
-            
+
             "epps2"    : [ "Advanced EPPs","^orange;Tier 3^reset;\n\nYou can make even better EPPs which serve more functions and perform existing roles better than before."],
 
             "epps3"    : [ "Superior EPPs","^orange;Tier 4^reset;\n\nYou can make extremely good EPPs which can completely neutralize hostile atmospheres and provide even more utility."],
 
             "epps4"    : [ "Peerless EPPs","^orange;Tier 6^reset;\n\nYou've mastered the art of EPP creation and can make the best EPPs around."],
 
-            "ambergear"    : [ "Bee Equipment","^orange;Tier 4^reset;\n\nYou've gotten very good at shaping organic materials, and can now forge hard amber into a variety of bee and honey-themed armors and weapons. (Not by hand, of course!)"],                
-            "slimegear1"    : [ "Slime Equipment","^orange;Tier 2^reset;\n\nIt might seem pretty gross, but with some clever engineering you could form solid slime capable of being used as weapons or armor. Don't argue. Just accept."],                
+            "ambergear"    : [ "Bee Equipment","^orange;Tier 4^reset;\n\nYou've gotten very good at shaping organic materials, and can now forge hard amber into a variety of bee and honey-themed armors and weapons. (Not by hand, of course!)"],
+            "slimegear1"    : [ "Slime Equipment","^orange;Tier 2^reset;\n\nIt might seem pretty gross, but with some clever engineering you could form solid slime capable of being used as weapons or armor. Don't argue. Just accept.\n\nSome recipes require the ^cyan;Biochemist Table^reset;. Research it in the ^green;Geology tree^reset;."],
             "slimegear2"    : [ "Slime Equipment II","^orange;Tier 4^reset;\n\nIt might seem pretty gross, but with some clever engineering you could form solid slime capable of being used as weapons or armor. Don't argue. Just accept."],
             "slimegear3"    : [ "Slime Equipment III","^orange;Tier 5^reset;\n\nIt might seem pretty gross, but with some clever engineering you could form solid slime capable of being used as weapons or armor. Don't argue. Just accept."]
             


### PR DESCRIPTION
- Improved the final loot of the Ancient Temple mission: rolling salvage is now less likely.
- Added loot to two empty containers in the Tower Invincible mission.
- Updated the descriptions of the Slime warcraft and craftsmanship nodes to mention the Biochemist Table.