### PR TITLE
EZ Voxels, round 2

### DIFF
--- a/items/active/unsorted/easyvoxel/easyvoxel10k.activeitem
+++ b/items/active/unsorted/easyvoxel/easyvoxel10k.activeitem
@@ -4,7 +4,7 @@
   "level" : 1,
   "maxStack" : 999999,
   "rarity" : "Common",
-  "category" : "resourceItem",
+  "category" : "currency",
   "description" : "10000 pixels compressed into a voxel. Now with easy decompress.",
   "shortdescription" : "10k Voxel (EZ)",
   "twoHanded" : true,

--- a/items/active/unsorted/easyvoxel/easyvoxel1k.activeitem
+++ b/items/active/unsorted/easyvoxel/easyvoxel1k.activeitem
@@ -4,7 +4,7 @@
   "level" : 1,
   "maxStack" : 999999,
   "rarity" : "Common",
-  "category" : "resourceItem",
+  "category" : "currency",
   "description" : "1000 pixels compressed into a voxel. Now with easy decompress.",
   "shortdescription" : "1k Voxel (EZ)",
   "twoHanded" : true,

--- a/items/active/unsorted/easyvoxel/easyvoxel2k.activeitem
+++ b/items/active/unsorted/easyvoxel/easyvoxel2k.activeitem
@@ -4,7 +4,7 @@
   "level" : 1,
   "maxStack" : 999999,
   "rarity" : "Common",
-  "category" : "resourceItem",
+  "category" : "currency",
   "description" : "2000 pixels compressed into a voxel. Now with easy decompress.",
   "shortdescription" : "2k Voxel (EZ)",
   "twoHanded" : true,

--- a/items/active/unsorted/easyvoxel/easyvoxel5k.activeitem
+++ b/items/active/unsorted/easyvoxel/easyvoxel5k.activeitem
@@ -4,7 +4,7 @@
   "level" : 1,
   "maxStack" : 999999,
   "rarity" : "Common",
-  "category" : "resourceItem",
+  "category" : "currency",
   "description" : "5000 pixels compressed into a voxel. Now with easy decompress.",
   "shortdescription" : "5k Voxel (EZ)",
   "twoHanded" : true,

--- a/recipes/hypercompressor/compress/voxel10kez.recipe
+++ b/recipes/hypercompressor/compress/voxel10kez.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "money", "count" : 10000 }
+    { "item" : "money", "count" : 10020 }
   ],
   "output" : { "item" : "easyvoxel10k", "count" : 1 },
   "duration" : 0,

--- a/recipes/hypercompressor/compress/voxel10kez.recipe
+++ b/recipes/hypercompressor/compress/voxel10kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "money", "count" : 10000 }
   ],
   "output" : { "item" : "easyvoxel10k", "count" : 1 },
-  "duration" : 0.9,
-  "groups" : [ "compressor", "pixelcompress" ]
+  "duration" : 0,
+  "groups" : [ "hypercompressor", "pixelcompress" ]
 }

--- a/recipes/hypercompressor/compress/voxel1kez.recipe
+++ b/recipes/hypercompressor/compress/voxel1kez.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "money", "count" : 1000 }
+    { "item" : "money", "count" : 1002 }
   ],
   "output" : { "item" : "easyvoxel1k", "count" : 1 },
   "duration" : 0,

--- a/recipes/hypercompressor/compress/voxel1kez.recipe
+++ b/recipes/hypercompressor/compress/voxel1kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "money", "count" : 1000 }
   ],
   "output" : { "item" : "easyvoxel1k", "count" : 1 },
-  "duration" : 0.9,
-  "groups" : [ "compressor", "pixelcompress" ]
+  "duration" : 0,
+  "groups" : [ "hypercompressor", "pixelcompress" ]
 }

--- a/recipes/hypercompressor/compress/voxel2kez.recipe
+++ b/recipes/hypercompressor/compress/voxel2kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "money", "count" : 2000 }
   ],
   "output" : { "item" : "easyvoxel2k", "count" : 1 },
-  "duration" : 0.9,
-  "groups" : [ "compressor", "pixelcompress" ]
+  "duration" : 0,
+  "groups" : [ "hypercompressor", "pixelcompress" ]
 }

--- a/recipes/hypercompressor/compress/voxel2kez.recipe
+++ b/recipes/hypercompressor/compress/voxel2kez.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "money", "count" : 2000 }
+    { "item" : "money", "count" : 2004 }
   ],
   "output" : { "item" : "easyvoxel2k", "count" : 1 },
   "duration" : 0,

--- a/recipes/hypercompressor/compress/voxel5kez.recipe
+++ b/recipes/hypercompressor/compress/voxel5kez.recipe
@@ -1,6 +1,6 @@
 {
   "input" : [
-    { "item" : "money", "count" : 5000 }
+    { "item" : "money", "count" : 5010 }
   ],
   "output" : { "item" : "easyvoxel5k", "count" : 1 },
   "duration" : 0,

--- a/recipes/hypercompressor/compress/voxel5kez.recipe
+++ b/recipes/hypercompressor/compress/voxel5kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "money", "count" : 5000 }
   ],
   "output" : { "item" : "easyvoxel5k", "count" : 1 },
-  "duration" : 0.9,
-  "groups" : [ "compressor", "pixelcompress" ]
+  "duration" : 0,
+  "groups" : [ "hypercompressor", "pixelcompress" ]
 }

--- a/recipes/hypercompressor/refine/voxel10kez.recipe
+++ b/recipes/hypercompressor/refine/voxel10kez.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "easyvoxel10k", "count" : 1 }
+  ],
+  "output" : { "item" : "money", "count" : 9990 },
+  "duration" : 0,
+  "groups" : [ "hypercompressor", "pixeldecompress" ]
+}

--- a/recipes/hypercompressor/refine/voxel10kez.recipe
+++ b/recipes/hypercompressor/refine/voxel10kez.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "easyvoxel10k", "count" : 1 }
   ],
-  "output" : { "item" : "money", "count" : 9990 },
+  "output" : { "item" : "money", "count" : 9980 },
   "duration" : 0,
   "groups" : [ "hypercompressor", "pixeldecompress" ]
 }

--- a/recipes/hypercompressor/refine/voxel1kez.recipe
+++ b/recipes/hypercompressor/refine/voxel1kez.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "easyvoxel1k", "count" : 1 }
+  ],
+  "output" : { "item" : "money", "count" : 999 },
+  "duration" : 0,
+  "groups" : [ "hypercompressor", "pixeldecompress" ]
+}

--- a/recipes/hypercompressor/refine/voxel1kez.recipe
+++ b/recipes/hypercompressor/refine/voxel1kez.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "easyvoxel1k", "count" : 1 }
   ],
-  "output" : { "item" : "money", "count" : 999 },
+  "output" : { "item" : "money", "count" : 998 },
   "duration" : 0,
   "groups" : [ "hypercompressor", "pixeldecompress" ]
 }

--- a/recipes/hypercompressor/refine/voxel2kez.recipe
+++ b/recipes/hypercompressor/refine/voxel2kez.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "easyvoxel2k", "count" : 1 }
+  ],
+  "output" : { "item" : "money", "count" : 1998 },
+  "duration" : 0,
+  "groups" : [ "hypercompressor", "pixeldecompress" ]
+}

--- a/recipes/hypercompressor/refine/voxel2kez.recipe
+++ b/recipes/hypercompressor/refine/voxel2kez.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "easyvoxel2k", "count" : 1 }
   ],
-  "output" : { "item" : "money", "count" : 1998 },
+  "output" : { "item" : "money", "count" : 1996 },
   "duration" : 0,
   "groups" : [ "hypercompressor", "pixeldecompress" ]
 }

--- a/recipes/hypercompressor/refine/voxel5kez.recipe
+++ b/recipes/hypercompressor/refine/voxel5kez.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "easyvoxel5k", "count" : 1 }
   ],
-  "output" : { "item" : "money", "count" : 4995 },
+  "output" : { "item" : "money", "count" : 4990 },
   "duration" : 0,
   "groups" : [ "hypercompressor", "pixeldecompress" ]
 }

--- a/recipes/hypercompressor/refine/voxel5kez.recipe
+++ b/recipes/hypercompressor/refine/voxel5kez.recipe
@@ -1,0 +1,8 @@
+{
+  "input" : [
+    { "item" : "easyvoxel5k", "count" : 1 }
+  ],
+  "output" : { "item" : "money", "count" : 4995 },
+  "duration" : 0,
+  "groups" : [ "hypercompressor", "pixeldecompress" ]
+}

--- a/recipes/pixelcompressor/compress/voxel10kez.recipe
+++ b/recipes/pixelcompressor/compress/voxel10kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "money", "count" : 10000 }
   ],
   "output" : { "item" : "easyvoxel10k", "count" : 1 },
-  "duration" : 0.9,
+  "duration" : 1.2,
   "groups" : [ "compressor", "pixelcompress" ]
 }

--- a/recipes/pixelcompressor/compress/voxel1kez.recipe
+++ b/recipes/pixelcompressor/compress/voxel1kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "money", "count" : 1000 }
   ],
   "output" : { "item" : "easyvoxel1k", "count" : 1 },
-  "duration" : 0.9,
+  "duration" : 1.2,
   "groups" : [ "compressor", "pixelcompress" ]
 }

--- a/recipes/pixelcompressor/compress/voxel2kez.recipe
+++ b/recipes/pixelcompressor/compress/voxel2kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "money", "count" : 2000 }
   ],
   "output" : { "item" : "easyvoxel2k", "count" : 1 },
-  "duration" : 0.9,
+  "duration" : 1.2,
   "groups" : [ "compressor", "pixelcompress" ]
 }

--- a/recipes/pixelcompressor/compress/voxel5kez.recipe
+++ b/recipes/pixelcompressor/compress/voxel5kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "money", "count" : 5000 }
   ],
   "output" : { "item" : "easyvoxel5k", "count" : 1 },
-  "duration" : 0.9,
+  "duration" : 1.2,
   "groups" : [ "compressor", "pixelcompress" ]
 }

--- a/recipes/pixelcompressor/refine/voxel10kez.recipe
+++ b/recipes/pixelcompressor/refine/voxel10kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "easyvoxel10k", "count" : 1 }
   ],
   "output" : { "item" : "money", "count" : 10000 },
-  "duration" : 0.9,
+  "duration" : 1.2,
   "groups" : [ "compressor", "pixeldecompress" ]
 }

--- a/recipes/pixelcompressor/refine/voxel10kez.recipe
+++ b/recipes/pixelcompressor/refine/voxel10kez.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "easyvoxel10k", "count" : 1 }
   ],
-  "output" : { "item" : "voxel10k", "count" : 1 },
-  "duration" : 0.0,
-  "groups" : [ "compressor", "pixeldecompress","hypercompressor" ]
+  "output" : { "item" : "money", "count" : 10000 },
+  "duration" : 0.9,
+  "groups" : [ "compressor", "pixeldecompress" ]
 }

--- a/recipes/pixelcompressor/refine/voxel1kez.recipe
+++ b/recipes/pixelcompressor/refine/voxel1kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "easyvoxel1k", "count" : 1 }
   ],
   "output" : { "item" : "money", "count" : 1000 },
-  "duration" : 0.9,
+  "duration" : 1.2,
   "groups" : [ "compressor", "pixeldecompress" ]
 }

--- a/recipes/pixelcompressor/refine/voxel1kez.recipe
+++ b/recipes/pixelcompressor/refine/voxel1kez.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "easyvoxel1k", "count" : 1 }
   ],
-  "output" : { "item" : "voxel1k", "count" : 1 },
-  "duration" : 0.0,
-  "groups" : [ "compressor", "pixeldecompress","hypercompressor"]
+  "output" : { "item" : "money", "count" : 1000 },
+  "duration" : 0.9,
+  "groups" : [ "compressor", "pixeldecompress" ]
 }

--- a/recipes/pixelcompressor/refine/voxel2kez.recipe
+++ b/recipes/pixelcompressor/refine/voxel2kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "easyvoxel2k", "count" : 1 }
   ],
   "output" : { "item" : "money", "count" : 2000 },
-  "duration" : 0.9,
+  "duration" : 1.2,
   "groups" : [ "compressor", "pixeldecompress" ]
 }

--- a/recipes/pixelcompressor/refine/voxel2kez.recipe
+++ b/recipes/pixelcompressor/refine/voxel2kez.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "easyvoxel2k", "count" : 1 }
   ],
-  "output" : { "item" : "voxel2k", "count" : 1 },
-  "duration" : 0.0,
-  "groups" : [ "compressor", "pixeldecompress","hypercompressor" ]
+  "output" : { "item" : "money", "count" : 2000 },
+  "duration" : 0.9,
+  "groups" : [ "compressor", "pixeldecompress" ]
 }

--- a/recipes/pixelcompressor/refine/voxel5kez.recipe
+++ b/recipes/pixelcompressor/refine/voxel5kez.recipe
@@ -2,7 +2,7 @@
   "input" : [
     { "item" : "easyvoxel5k", "count" : 1 }
   ],
-  "output" : { "item" : "voxel5k", "count" : 1 },
-  "duration" : 0.0,
-  "groups" : [ "compressor", "pixeldecompress","hypercompressor" ]
+  "output" : { "item" : "money", "count" : 5000 },
+  "duration" : 0.9,
+  "groups" : [ "compressor", "pixeldecompress" ]
 }

--- a/recipes/pixelcompressor/refine/voxel5kez.recipe
+++ b/recipes/pixelcompressor/refine/voxel5kez.recipe
@@ -3,6 +3,6 @@
     { "item" : "easyvoxel5k", "count" : 1 }
   ],
   "output" : { "item" : "money", "count" : 5000 },
-  "duration" : 0.9,
+  "duration" : 1.2,
   "groups" : [ "compressor", "pixeldecompress" ]
 }


### PR DESCRIPTION
The EZ Voxels line in my other PR is now invalid, use these in the changenotes instead

- EZ Voxels are now crafted directly to and from pixels, but are 33% slower to craft in the pixel compressor and have doubled taxes in the hypercompressor in exchange for this convenience.
- EZ Voxels are now sorted into the currency section of the inventory.