### PR TITLE
Coral Katana unlock

### DIFF
--- a/recipes/armory/melee/katana/coralkatana.recipe
+++ b/recipes/armory/melee/katana/coralkatana.recipe
@@ -1,8 +1,8 @@
 {
   "input" : [
     { "item" : "coralfragment", "count" : 12 },
-    { "item" : "venomsample", "count" : 2 }
+    { "item" : "protocitebar", "count" : 2 }
   ],
   "output" : { "item" : "coralkatana", "count" : 1 },
-  "groups" : [ "armory2", "melee2", "all" ]
+  "groups" : [ "armory3", "melee2", "all" ]
 }

--- a/zb/researchTree/fu_warcraft.config
+++ b/zb/researchTree/fu_warcraft.config
@@ -174,7 +174,7 @@
                 "position" : [180, 0],
                 "children" : [ "advancealloygear" ],
                 "price" : [["fuscienceresource", 800],["protocitebar", 10]],
-                "unlocks" : [ "glowbomb", "chargepistol", "magnorbproto", "funeochakram", "protobow", "protocitestaff", "protocitewand", "pistolprotofu", "protopistol", "protorifle", "protogun", "quiverbackenergy", "spacefarerpants", "spacefarerchest", "spacefarerhead", "fujunkerpants", "fujunkerchest", "fujunkerhead", "fusteampunklegs", "fusteampunkchest", "fusteampunkhead" ]
+                "unlocks" : [ "glowbomb", "chargepistol", "magnorbproto", "funeochakram", "protobow", "protocitestaff", "protocitewand", "pistolprotofu", "protopistol", "protorifle", "protogun", "coralkatana", "quiverbackenergy", "spacefarerpants", "spacefarerchest", "spacefarerhead", "fujunkerpants", "fujunkerchest", "fujunkerhead", "fusteampunklegs", "fusteampunkchest", "fusteampunkhead" ]
             },    
             "penumbritegear" : {
                 "icon" : "/items/generic/crafting/fissionfurnace/penumbriteshard.png",
@@ -494,7 +494,7 @@
     },
 
     "versions":{
-      "fu_warcraft" : "0.177"
+      "fu_warcraft" : "0.178"
     },    
     "initiallyResearched" : {
         "fu_warcraft" : [ "BASICTRAINING" ]


### PR DESCRIPTION
- The Coral Katana can now be unlocked through the Protocite node in the Armour and Weapons research tree.