### PR TITLE
Minor fix: Leather Shield groups

### DIFF
--- a/recipes/armory/shield/leathershield.recipe
+++ b/recipes/armory/shield/leathershield.recipe
@@ -7,5 +7,5 @@
     "item" : "leathershield",
     "count" : 1
   },
-  "groups" : [  "craftinganvil", "armours", "all", "armory1" ]
+  "groups" : [ "armory1", "shield", "craftinganvil", "weapons", "all" ]
 }


### PR DESCRIPTION
"Leather Shield" appearing in the armor group on "Assembly Line".
![009](https://user-images.githubusercontent.com/29846693/148445093-e755abf4-7f5a-4439-887b-7ce02fd80693.png)
I fixed bug similar to this a year ago ( #2944 ) and this PR based on it.