### PR TITLE
Geodes, sneodes and armeodes

### DIFF
--- a/asteroids_worlds.config.patch
+++ b/asteroids_worlds.config.patch
@@ -1,10 +1,7 @@
 [
-{"op":"replace",
- "path":"/threatRange",
- "value": [1,6]
- },
+  {"op": "replace", "path": "/threatRange", "value": [1,6]},
+  {"op": "replace", "path": "/ambientLightLevel", "value":  [70, 70, 70]},
 
-  { "op": "replace","path": "/ambientLightLevel","value":  [70, 70, 70] },
   {
     "op": "add",
     "path": "/terrains/-",

--- a/items/armors/biome/copperarmor/copperarmor.chest.patch
+++ b/items/armors/biome/copperarmor/copperarmor.chest.patch
@@ -64,7 +64,7 @@
       "op": "replace",
       "path": "/description",
       "value": "^orange;Set Bonuses^reset;:
-^yellow;^reset; Mining Laser: Damage x^green;1.5^reset;, Energy x^green;1.2^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;1.5^reset;, Energy x^green;1.2^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Mud"
     },
     {

--- a/items/armors/biome/copperarmor/copperarmor.head.patch
+++ b/items/armors/biome/copperarmor/copperarmor.head.patch
@@ -64,7 +64,7 @@
       "op": "replace",
       "path": "/description",
       "value": "^orange;Set Bonuses^reset;:
-^yellow;^reset; Mining Laser: Damage x^green;1.5^reset;, Energy x^green;1.2^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;1.5^reset;, Energy x^green;1.2^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Mud"
     },
     {

--- a/items/armors/biome/copperarmor/copperarmor.legs.patch
+++ b/items/armors/biome/copperarmor/copperarmor.legs.patch
@@ -64,7 +64,7 @@
       "op": "replace",
       "path": "/description",
       "value": "^orange;Set Bonuses^reset;:
-^yellow;^reset; Mining Laser: Damage x^green;1.5^reset;, Energy x^green;1.2^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;1.5^reset;, Energy x^green;1.2^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Mud"
     },
     {

--- a/items/armors/tier3/dweller/hooded.chest
+++ b/items/armors/tier3/dweller/hooded.chest
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Mining Laser: Damage x^green;2.2^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;2.2^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Slime, Mud, Ice, Snow, Tar",
   "shortdescription" : "Dweller Chest",
   "category" : "chestarmour",

--- a/items/armors/tier3/dweller/hooded.head
+++ b/items/armors/tier3/dweller/hooded.head
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Mining Laser: Damage x^green;2.2^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;2.2^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Slime, Mud, Ice, Snow, Tar",
   "shortdescription" : "Dweller Cowl",
   "category" : "headarmour",

--- a/items/armors/tier3/dweller/hooded.legs
+++ b/items/armors/tier3/dweller/hooded.legs
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Mining Laser: Damage x^green;2.2^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;2.2^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Slime, Mud, Ice, Snow, Tar",
   "shortdescription" : "Dweller Greaves",
   "category" : "legarmour",

--- a/items/armors/tier3/spacefarer/spacefarer.chest
+++ b/items/armors/tier3/spacefarer/spacefarer.chest
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Mining Laser: Damage x^green;2^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;2^reset;
 ^yellow;^reset; +^green;175^reset;s Oxygen
 ^yellow;^reset; +^green;50^reset;% Defense Tech Efficiency
 ^cyan;Immune^reset;: Burning, Proto-Poison, Gas",

--- a/items/armors/tier3/spacefarer/spacefarer.head
+++ b/items/armors/tier3/spacefarer/spacefarer.head
@@ -6,7 +6,7 @@
   "rarity" : "uncommon",
   "description" : "^cyan;Headlamp^reset;
 ^orange;Set Bonuses^reset;:
-^yellow;^reset; Mining Laser: Damage x^green;2^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;2^reset;
 ^yellow;^reset; +^green;175^reset;s Oxygen
 ^yellow;^reset; +^green;50^reset;% Defense Tech Efficiency
 ^cyan;Immune^reset;: Burning, Proto-Poison, Gas",

--- a/items/armors/tier3/spacefarer/spacefarer.legs
+++ b/items/armors/tier3/spacefarer/spacefarer.legs
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Mining Laser: Damage x^green;2^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;2^reset;
 ^yellow;^reset; +^green;175^reset;s Oxygen
 ^yellow;^reset; +^green;50^reset;% Defense Tech Efficiency
 ^cyan;Immune^reset;: Burning, Proto-Poison, Gas",

--- a/items/armors/tier4/fieldscience/fieldscientist.chest
+++ b/items/armors/tier4/fieldscience/fieldscientist.chest
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
    "description" : "^orange;Set Bonuses^reset;: 
-^yellow;^reset; Mining Laser: Damage x^green;1.5^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;1.5^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Liq. Nitrogen, Poison, Pus
 ^yellow;^reset; Research Bonus +^green;2^reset;",
   "shortdescription" : "Geologist's Coat",

--- a/items/armors/tier4/fieldscience/fieldscientist.head
+++ b/items/armors/tier4/fieldscience/fieldscientist.head
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;: 
-^yellow;^reset; Mining Laser: Damage x^green;1.5^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;1.5^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Liq. Nitrogen, Poison, Pus
 ^yellow;^reset; Research Bonus +^green;2^reset;",
   "shortdescription" : "Geologist's Bright Goggles",

--- a/items/armors/tier4/fieldscience/fieldscientist.legs
+++ b/items/armors/tier4/fieldscience/fieldscientist.legs
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;: 
-^yellow;^reset; Mining Laser: Damage x^green;1.5^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;1.5^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Liq. Nitrogen, Poison, Pus
 ^yellow;^reset; Research Bonus +^green;2^reset;",
   "shortdescription" : "Geologist's Slacks",

--- a/items/armors/tier4/spacefareradv/spacefareradv.chest
+++ b/items/armors/tier4/spacefareradv/spacefareradv.chest
@@ -6,7 +6,7 @@
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;: 
 ^yellow;^reset; ^cyan;Gravity Normalization^reset;
-^yellow;^reset; Mining Laser: Damage x^green;2.4^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;2.4^reset;
 ^yellow;^reset; +^cyan;50^reset;% Defense Tech Efficiency
 ^yellow;^reset; ^cyan;Immune^reset;: Burning, Proto-Poison, Pressure, Gas, Ice Slip, Oxygen", 
   "shortdescription" : "Spacefarer mk2 Chest",

--- a/items/armors/tier4/spacefareradv/spacefareradv.head
+++ b/items/armors/tier4/spacefareradv/spacefareradv.head
@@ -7,7 +7,7 @@
   "description" : "^cyan;Headlamp 2^reset;
 ^orange;Set Bonuses^reset;: 
 ^yellow;^reset; ^cyan;Gravity Normalization^reset;
-^yellow;^reset; Mining Laser: Damage x^green;2.4^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;2.4^reset;
 ^yellow;^reset; +^cyan;50^reset;% Defense Tech Efficiency
 ^yellow;^reset; ^cyan;Immune^reset;: Burning, Proto-Poison, Pressure, Gas, Ice Slip, Oxygen", 
   "shortdescription" : "Spacefarer mk2 Helm",

--- a/items/armors/tier4/spacefareradv/spacefareradv.legs
+++ b/items/armors/tier4/spacefareradv/spacefareradv.legs
@@ -6,7 +6,7 @@
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;: 
 ^yellow;^reset; ^cyan;Gravity Normalization^reset;
-^yellow;^reset; Mining Laser: Damage x^green;2.4^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;2.4^reset;
 ^yellow;^reset; +^cyan;50^reset;% Defense Tech Efficiency
 ^yellow;^reset; ^cyan;Immune^reset;: Burning, Proto-Poison, Pressure, Gas, Ice Slip, Oxygen", 
   "shortdescription" : "Spacefarer mk2 Greaves",

--- a/items/armors/tier5/fuwarphunter/fuwarphunter.chest
+++ b/items/armors/tier5/fuwarphunter/fuwarphunter.chest
@@ -7,7 +7,7 @@
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^cyan;Gravity Normalization^reset;
-^yellow;^reset; Mining Laser: Damage x^green;3.4^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;3.4^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Burning, Proto-Poison, Pressure, Oxygen, Gas, Ice Slip, Grav-Rain", 
   "shortdescription" : "Warp Miner Techjacket",
   "category" : "chestarmour",

--- a/items/armors/tier5/fuwarphunter/fuwarphunter.head
+++ b/items/armors/tier5/fuwarphunter/fuwarphunter.head
@@ -8,7 +8,7 @@
   "description" : "^cyan;Headlamp 3^reset;
 ^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^cyan;Gravity Normalization^reset;
-^yellow;^reset; Mining Laser: Damage x^green;3.4^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;3.4^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Burning, Proto-Poison, Pressure, Oxygen, Gas, Ice Slip, Grav-Rain", 
   "shortdescription" : "Warp Miner Helm",
   "category" : "headarmour",

--- a/items/armors/tier5/fuwarphunter/fuwarphunter.legs
+++ b/items/armors/tier5/fuwarphunter/fuwarphunter.legs
@@ -7,7 +7,7 @@
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^cyan;Gravity Normalization^reset;
-^yellow;^reset; Mining Laser: Damage x^green;3.4^reset;
+^yellow;^reset; Mining Laser: Combat Damage x^green;3.4^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Burning, Proto-Poison, Pressure, Oxygen, Gas, Ice Slip, Grav-Rain", 
   "shortdescription" : "Warp Miner Techpants",
   "category" : "legarmour",

--- a/objects/peglaci/snowpeople/heads/snowhead1.object
+++ b/objects/peglaci/snowpeople/heads/snowhead1.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowhead1.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowhead2.object
+++ b/objects/peglaci/snowpeople/heads/snowhead2.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowhead2.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowheadapex.object
+++ b/objects/peglaci/snowpeople/heads/snowheadapex.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowheadapex.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowheadavian.object
+++ b/objects/peglaci/snowpeople/heads/snowheadavian.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowheadavian.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowheadfloran.object
+++ b/objects/peglaci/snowpeople/heads/snowheadfloran.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowheadfloran.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowheadglitch.object
+++ b/objects/peglaci/snowpeople/heads/snowheadglitch.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowheadglitch.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowheadhuman.object
+++ b/objects/peglaci/snowpeople/heads/snowheadhuman.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowheadhuman.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowheadhyotl.object
+++ b/objects/peglaci/snowpeople/heads/snowheadhyotl.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowheadhyotl.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowheadmantizi.object
+++ b/objects/peglaci/snowpeople/heads/snowheadmantizi.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowheadmantizi.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowheadpeglaci.object
+++ b/objects/peglaci/snowpeople/heads/snowheadpeglaci.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowheadpeglaci.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/objects/peglaci/snowpeople/heads/snowheadskellie.object
+++ b/objects/peglaci/snowpeople/heads/snowheadskellie.object
@@ -14,7 +14,7 @@
     {
       "dualImage" : "snowheadskellie.png:default",
 
-      "imagePosition" : [-8, 0],
+      "imagePosition" : [0, 0],
       "frames" : 1,
       "animationCycle" : 0.5,
 

--- a/treasure/common.treasurepools.patch
+++ b/treasure/common.treasurepools.patch
@@ -22,17 +22,17 @@
   },   
 
   //super ultra rare chance for transmutation matrix
-   {
+  {
     "op": "add",
     "path": "/tool/0/1/pool/-",
     "value": {"weight": 0.0035,"item": ["cuddlehorse",1]}
   },         
-   {
+  {
     "op": "add",
     "path": "/tool/0/1/pool/-",
     "value": {"weight": 0.01,"item": ["pocketanchor",1]}
   },   
-   {
+  {
     "op": "add",
     "path": "/tool/0/1/pool/-",
     "value": {"weight": 0.01,"item": ["gyrostabilizer",1]}
@@ -132,9 +132,9 @@
     "path": "/rareMelee/0/1/pool/-",
     "value": {"weight": 0.003,"item": "rareshortspear"}
   },
-  
-  
- 
+
+
+
   {
     "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
@@ -201,357 +201,357 @@
   },
 
 
-{
-  "op": "add",
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformercactiplace"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformercactiplace"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformercellfield"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformercellfield"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformercloudforest"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformercloudforest"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformercorrupt"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformercorrupt"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformercorruptedforest"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformercorruptedforest"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformercorruptmoon"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformercorruptmoon"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformercrystaldesert"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformercrystaldesert"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformercrystalplain"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformercrystalplain"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformercrystalswamp"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformercrystalswamp"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerdeadwood"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerdeadwood"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerdesertoasis"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerdesertoasis"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerdryriverbed"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerdryriverbed"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.001,
-    "item": "microformerelder"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.001,
+      "item": "microformerelder"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerenergyorbforest"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerenergyorbforest"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerffhive"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerffhive"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformergoreforest"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformergoreforest"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerhauntedforest"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerhauntedforest"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerhauntedgraveyard"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerhauntedgraveyard"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerhellfirefield"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerhellfirefield"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerhellhive"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerhellhive"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerhotsprings"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerhotsprings"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformericefire"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformericefire"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerirradiatedwaste"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerirradiatedwaste"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformermagicsnowland"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformermagicsnowland"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformermeadow"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformermeadow"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformermetalhive"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformermetalhive"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformermetaljungle"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformermetaljungle"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerpineforest"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerpineforest"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerpitchfield"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerpitchfield"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerprimevalforest"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerprimevalforest"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerrainbowforest"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerrainbowforest"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerreddesert"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformerreddesert"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformersnowyforest"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformersnowyforest"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformersulphuricmagma"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformersulphuricmagma"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.003,
-    "item": "microformersupermatterzone"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.003,
+      "item": "microformersupermatterzone"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformertaiga"
-  }
-},
-{
-  "op": "add",
+      "weight": 0.007,
+      "item": "microformertaiga"
+    }
+  },
+  {
+    "op": "add",
     "path": "/microformerTreasure/0/1/pool/-",
     "value": {
-    "weight": 0.007,
-    "item": "microformerwartfield"
-  }
-},
+      "weight": 0.007,
+      "item": "microformerwartfield"
+    }
+  },
 
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonrevolver" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonbeampistol" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonsubmachinegun" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonsawedoffshotgun" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonbattlerifle" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonsaw" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonbeamrifle" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonantimaterialrifle" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonautoshotgun" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonflakcannon" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonmultigrenadelauncher" } },
-{"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonminirocketlauncher" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonrevolver" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonbeampistol" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonsubmachinegun" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonsawedoffshotgun" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonbattlerifle" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonsaw" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonbeamrifle" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonantimaterialrifle" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_commonautoshotgun" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonflakcannon" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonmultigrenadelauncher" } },
+  {"op" : "add", "path" : "/commonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_commonminirocketlauncher" } },
 
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonrevolver" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonbeampistol" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonsubmachinegun" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonsawedoffshotgun" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonbattlerifle" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonsaw" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonbeamrifle" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonantimaterialrifle" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonautoshotgun" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonflakcannon" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonmultigrenadelauncher" } },
-{"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonminirocketlauncher" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonrevolver" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonbeampistol" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonsubmachinegun" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonsawedoffshotgun" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonbattlerifle" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonsaw" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonbeamrifle" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonantimaterialrifle" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_uncommonautoshotgun" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonflakcannon" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonmultigrenadelauncher" } },
+  {"op" : "add", "path" : "/uncommonGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_uncommonminirocketlauncher" } },
 
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rarerevolver" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rarebeampistol" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_raresubmachinegun" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_raresawedoffshotgun" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rarebattlerifle" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_raresaw" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rarebeamrifle" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_rareantimaterialrifle" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rareautoshotgun" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_rareflakcannon" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_raremultigrenadelauncher" } },
-{"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_rareminirocketlauncher" } },
-{
-	"op": "add",
-	"path": "/uniqueWeapon/2/1/pool/-",
-	"value": {
-		"weight": 0.008,
-		"item": "khetastrophae"
-	}
-},
-{
-	"op": "add",
-	"path": "/uniqueWeapon/2/1/pool/-",
-	"value": {
-		"weight": 0.008,
-		"item": "angryrocket"
-	}
-},
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rarerevolver" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rarebeampistol" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_raresubmachinegun" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_raresawedoffshotgun" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rarebattlerifle" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_raresaw" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rarebeamrifle" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_rareantimaterialrifle" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 1.0, "item" : "swtjc_ewg_rareautoshotgun" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_rareflakcannon" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_raremultigrenadelauncher" } },
+  {"op" : "add", "path" : "/rareGun/1/1/pool/-", "value" : {"weight" : 0.7, "item" : "swtjc_ewg_rareminirocketlauncher" } },
+  {
+    "op": "add",
+    "path": "/uniqueWeapon/2/1/pool/-",
+    "value": {
+      "weight": 0.008,
+      "item": "khetastrophae"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/uniqueWeapon/2/1/pool/-",
+    "value": {
+      "weight": 0.008,
+      "item": "angryrocket"
+    }
+  },
 
   {
     "op": "add",
@@ -966,45 +966,45 @@
       "pool": "rareBow"
     }
   },
-	
-  
+
+
   {
     "op": "add",
     "path": "/commonBow",
     "value": [
-	  [
+    [
       0, {
         "pool": [
           {"weight" : 1, "item" : "neb-commonbow"}
         ]
       }
-	  ]
+    ]
     ]
   },
   {
     "op": "add",
     "path": "/uncommonBow",
     "value": [
-	  [
+    [
       0, {
         "pool": [
           {"weight" : 1, "item" : "neb-uncommonbow"}
         ]
       }
-	  ]
+    ]
     ]
   },
   {
     "op": "add",
     "path": "/rareBow",
     "value": [
-	  [
+    [
       0, {
         "pool": [
           {"weight" : 1, "item" : "neb-rarebow"}
         ]
       }
-	  ]
+    ]
     ]
   },
  {
@@ -1021,110 +1021,5 @@
    "weight": 0.2,
    "pool": "fuGenericQuestLoot"
   }
- },
-
- {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0015,
-      "item": "densiniumore"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0015,
-      "item": "xithriciteore"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0015,
-      "item": "pyreiteore"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0015,
-      "item": "isogenore"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0025,
-      "item": "irradiumore"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0025,
-      "item": "fuamberchunk"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0025,
-      "item": "quietusore"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0025,
-      "item": "blooddiamond"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0025,
-      "item": "penumbriteore"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0025,
-      "item": "protociteore"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0005,
-      "item": "nocxiumore"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0025,
-      "item": "solarishard"
-    }
-  },
-  {
-    "op": "add",
-    "path": "/geodeRewards/0/1/pool/-",
-    "value": {
-      "weight": 0.0025,
-      "item": "zerchesiumore"
-    }
-  }
+ }
 ]


### PR DESCRIPTION
- Removed FU ores from the geode manually-opened treasurepool, increasing the droprate of samples.
- Horizontally aligned the heads of Peglaci Snowpeople with their other parts.
- Armour sets which buff mining laser damage now specify that they only buff combat damage and not mining damage.