### PR TITLE
Fix swoosh image for combo step fire8 on fusoluskatana_l8

### DIFF
--- a/items/active/weapons/bossdrop/fusoluskatana/fusoluskatana_l8.animation
+++ b/items/active/weapons/bossdrop/fusoluskatana/fusoluskatana_l8.animation
@@ -145,7 +145,7 @@
             "fire5":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh/fusolusswoosh.png:<frame>?flipy", "offset":[-1.0, -2.4], "damageArea":[[-4, 2], [-2.5, 3], [1, 3], [4, 1.75], [5, -0.25], [4, -2.25], [3, -3.25], [0, -2.5]]}},
             "fire6":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh3/fusolusswoosh.png:<frame>", "offset":[1, 0], "damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},
             "fire7":{"properties":{"image": "/items/active/weapons/melee/broadsword/swoosh/fusolusswoosh.png:<frame>?flipy","offset": [-3.625, -2.25],"damageArea":[[-1, 3], [-0.5, 4], [2, 4], [6, 2.75], [7, -1.25], [6, -1.25], [5, -2.25], [1, -1.5]]}},
-            "fire8":{"properties": {"image": "/items/active/weapons/melee/shortsword/swoosh/<elementalType>swoosh.png:<frame>","offset": [1.0, 1.0],"damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},
+            "fire8":{"properties": {"image": "/items/active/weapons/melee/shortsword/swoosh/fusolusswoosh.png:<frame>","offset": [1.0, 1.0],"damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},
             "fire9":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh/fusolusswoosh.png:<frame>", "offset":[-2.0, 2.4], "damageArea":[[-5, 2], [-2.5, 3], [1, 3], [4, 1.75], [5, -0.25], [5, -2.25], [4, -3.25], [0, -2.5]]}},
             "fire10":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh3/fusolusswoosh.png:<frame>", "offset":[2,0], "damageArea":[[-3.4, 1], [4, 1], [4, -1], [-3.4, -1]]}},
 			"fire11":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh2/fusolusswoosh.png:<frame>?flipy", "offset":[0.0, 0], "damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},


### PR DESCRIPTION
One of the combo steps of the upgraded solus katana seems to use the default attack swoosh instead of the unique swoosh that's supposed to be for the weapon, so I made this pull request with a fix.