### PR TITLE
Fix fire8 combo step swoosh image on other solus katana variants

### DIFF
--- a/items/active/weapons/bossdrop/fusoluskatana/fusoluskatana.animation
+++ b/items/active/weapons/bossdrop/fusoluskatana/fusoluskatana.animation
@@ -145,7 +145,7 @@
             "fire5":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh/solusswoosh.png:<frame>?flipy", "offset":[-1.0, -2.4], "damageArea":[[-4, 2], [-2.5, 3], [1, 3], [4, 1.75], [5, -0.25], [4, -2.25], [3, -3.25], [0, -2.5]]}},
             "fire6":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh3/solusswoosh.png:<frame>", "offset":[1, 0], "damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},
             "fire7":{"properties":{"image": "/items/active/weapons/melee/broadsword/swoosh/solusswoosh.png:<frame>?flipy","offset": [-3.625, -2.25],"damageArea":[[-1, 3], [-0.5, 4], [2, 4], [6, 2.75], [7, -1.25], [6, -1.25], [5, -2.25], [1, -1.5]]}},
-            "fire8":{"properties": {"image": "/items/active/weapons/melee/shortsword/swoosh/<elementalType>swoosh.png:<frame>","offset": [1.0, 1.0],"damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},
+            "fire8":{"properties": {"image": "/items/active/weapons/melee/shortsword/swoosh/solusswoosh.png:<frame>","offset": [1.0, 1.0],"damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},
             "fire9":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh/solusswoosh.png:<frame>", "offset":[-2.0, 2.4], "damageArea":[[-5, 2], [-2.5, 3], [1, 3], [4, 1.75], [5, -0.25], [5, -2.25], [4, -3.25], [0, -2.5]]}},
             "fire10":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh3/solusswoosh.png:<frame>", "offset":[2,0], "damageArea":[[-3.4, 1], [4, 1], [4, -1], [-3.4, -1]]}},
 			"fire11":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh2/solusswoosh.png:<frame>?flipy", "offset":[0.0, 0], "damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},

--- a/items/active/weapons/bossdrop/fusoluskatana/fusoluskatana_l5.animation
+++ b/items/active/weapons/bossdrop/fusoluskatana/fusoluskatana_l5.animation
@@ -145,7 +145,7 @@
             "fire5":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh/fusolusswoosh2.png:<frame>?flipy", "offset":[-1.0, -2.4], "damageArea":[[-4, 2], [-2.5, 3], [1, 3], [4, 1.75], [5, -0.25], [4, -2.25], [3, -3.25], [0, -2.5]]}},
             "fire6":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh3/fusolusswoosh2.png:<frame>", "offset":[1, 0], "damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},
             "fire7":{"properties":{"image": "/items/active/weapons/melee/broadsword/swoosh/fusolusswoosh2.png:<frame>?flipy","offset": [-3.625, -2.25],"damageArea":[[-1, 3], [-0.5, 4], [2, 4], [6, 2.75], [7, -1.25], [6, -1.25], [5, -2.25], [1, -1.5]]}},
-            "fire8":{"properties": {"image": "/items/active/weapons/melee/shortsword/swoosh/<elementalType>swoosh.png:<frame>","offset": [1.0, 1.0],"damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},
+            "fire8":{"properties": {"image": "/items/active/weapons/melee/shortsword/swoosh/fusolusswoosh2.png:<frame>","offset": [1.0, 1.0],"damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},
             "fire9":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh/fusolusswoosh2.png:<frame>", "offset":[-2.0, 2.4], "damageArea":[[-5, 2], [-2.5, 3], [1, 3], [4, 1.75], [5, -0.25], [5, -2.25], [4, -3.25], [0, -2.5]]}},
             "fire10":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh3/fusolusswoosh2.png:<frame>", "offset":[2,0], "damageArea":[[-3.4, 1], [4, 1], [4, -1], [-3.4, -1]]}},
 			"fire11":{"properties":{"image":"/items/active/weapons/melee/broadsword/swoosh2/fusolusswoosh2.png:<frame>?flipy", "offset":[0.0, 0], "damageArea":[[-3, 1], [3, 1], [3, -1], [-3, -1]]}},


### PR DESCRIPTION
Apparently that issue with the wrong swoosh image being on this specific combo step was also a problem with the other 2 variants of it, so I guess I'm pull requesting these as well...