### PR TITLE
Cheeseburger effect foods description clarity

### DIFF
--- a/items/generic/food/tier2/cheeseburger.consumable.patch
+++ b/items/generic/food/tier2/cheeseburger.consumable.patch
@@ -20,6 +20,6 @@
   {
     "op": "replace",
     "path": "/description",
-    "value": "A juicy hamburger, topped with cheese. ^orange;Type: Cooked Meat^reset;"
+    "value": "A juicy hamburger, topped with cheese. ^orange;Type: Cooked Meat^reset; ^green;Veggie^reset; Dairy"
   }
 ]

--- a/items/generic/food/tier2/pizza.consumable.patch
+++ b/items/generic/food/tier2/pizza.consumable.patch
@@ -9,6 +9,6 @@
   {
     "op": "replace",
     "path": "/description",
-    "value": "A whole pizza! Are you going to eat all that? ^orange;Type: Cooked Meat^reset;"
+    "value": "A whole pizza! Are you going to eat all that? ^orange;Type: Cooked Meat^reset; ^green;Veggie^reset; Dairy"
   }
 ]

--- a/items/generic/food/tier2/pizzaslice.consumable.patch
+++ b/items/generic/food/tier2/pizzaslice.consumable.patch
@@ -9,6 +9,6 @@
   {
     "op": "replace",
     "path": "/description",
-    "value": "A hot slice of pepperoni pizza. ^orange;Type: Cooked Meat.^reset;"
+    "value": "A hot slice of pepperoni pizza. ^orange;Type: Cooked Meat.^reset; ^green;Veggie^reset; Dairy"
   }
 ]


### PR DESCRIPTION
Foods using the cheeseburger effect do not list that they also count as veggie and dairy in their item description, only cooked meat. Has resulted in some modded races experiencing food poisoning from thinking the food item only counted as cooked meat. This will help clarify this issue.