### PR TITLE
Post-commit tests: warn about newly added non-optimized PNG files

### DIFF
--- a/.github/scripts/detect-unoptimized-png-images.sh
+++ b/.github/scripts/detect-unoptimized-png-images.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+###############################################################################
+# This test runs "optipng" on every PNG image and detects non-optimized ones.
+###############################################################################
+
+# Report failure if filesize of the image was reduced by more than THRESHOLD percent:
+THRESHOLD=1
+
+# Run optipng with "-o1", which is much faster than default (-o2)
+OPTIPNG_COMMAND="optipng -o1"
+
+###############################################################################
+
+fails=0
+
+IFS=$'\n' # To iterate over filenames with spaces.
+for FILENAME in $(find . -name '*.png'); do
+	unset IFS
+	PERCENT=$($OPTIPNG_COMMAND $FILENAME 2>&1 | grep 'Output file size' | grep -E -o '([0-9.]+)%' | cut -d% -f1)
+
+	if [ "x$PERCENT" != 'x' ]; then
+		if [ $(echo "$PERCENT > $THRESHOLD" | bc) -eq 1 ]; then
+			echo "Error: $FILENAME is not optimized: can reduce by $PERCENT% with lossless compression." >&2
+			fails=$(( fails + 1 ))
+		fi
+	fi
+done
+
+if [ $fails -gt 0 ]; then
+	echo "Test failed: found $fails unoptimized image(s)." >&2
+	exit 1
+fi
+
+# Success.
+exit 0

--- a/.github/scripts/detect-unoptimized-png-images.sh
+++ b/.github/scripts/detect-unoptimized-png-images.sh
@@ -12,9 +12,21 @@ OPTIPNG_COMMAND="optipng -o1"
 ###############################################################################
 
 fails=0
-
 IFS=$'\n' # To iterate over filenames with spaces.
-for FILENAME in $(find . -name '*.png'); do
+
+# If some image wasn't added/modified compared to the master branch, then it won't be checked,
+# because we have 30k+ images, and rechecking them every time would take ~8 minutes.
+git fetch --depth=1 origin master
+FILES=$(git diff origin/master --name-only --no-renames --diff-filter=ACM | grep -E '\.png$' | sort)
+
+if [ "x$FILES" == 'x' ]; then
+	echo "Nothing to check: no images changed since the master branch."
+	exit 0
+fi
+
+echo "Checking PNG images: $FILES"
+
+for FILENAME in $FILES; do
 	unset IFS
 	PERCENT=$($OPTIPNG_COMMAND $FILENAME 2>&1 | grep 'Output file size' | grep -E -o '([0-9.]+)%' | cut -d% -f1)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,16 @@ jobs:
       - name: RUN -- luacheck .
         run: luacheck --no-color --quiet .
 
+  # Detect non-optimized PNG images (where lossless compression can seriously reduce their filesize).
+  unoptimized-png-images:
+    if: ${{ github.ref != 'refs/heads/master' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: sudo apt-get install -y optipng
+      - run: .github/scripts/detect-unoptimized-png-images.sh
+
   # Create .pak file for each GitHub release.
   pack-assets:
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
 
   # Detect non-optimized PNG images (where lossless compression can seriously reduce their filesize).
   unoptimized-png-images:
-    if: ${{ github.ref != 'refs/heads/master' }}
+    if: ${{ github.base_ref || github.ref != 'refs/heads/master' }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This test warns if filesize of newly added PNG image can be reduced by more than 1% via lossless compression. Percent is configurable (e.g. can be replaced with 5% later).

Note: only new files are checked (those added/modified since the "master" branch), because rechecking 34000+ images on every commit wouldn't be practical. This test doesn't run for direct commits to the master branch (only for PRs and other branches).