### PR TITLE
GPS Year Fix

### DIFF
--- a/interface/kukagps/kukadatetime.lua
+++ b/interface/kukagps/kukadatetime.lua
@@ -145,15 +145,17 @@ end
 function getDate(days)
     local year=0
     local month=1
-    local daysperyear=365
-    while (days>=daysperyear) do
+    local daysperyear=365.242--365
+    --[[while (days>=daysperyear) do
        daysperyear=365
        if ((year%4)==0) or (((year%100)==0) and ((year%400)==0)) then
           daysperyear=366
        end
        days=days-daysperyear
        year=year+1
-    end
+    end]]--
+	year = math.floor(days / daysperyear)
+	days = math.floor(days % daysperyear)
     local dayspermonth={31,28,31,30,31,30,31,31,30,31,30,31}
     if ((year%4)==0) or (((year%100)==0) and ((year%400)==0)) then
        dayspermonth={31,29,31,30,31,30,31,31,30,31,30,31}

--- a/interface/kukagps/kukadatetime.lua
+++ b/interface/kukagps/kukadatetime.lua
@@ -143,18 +143,9 @@ function timeConversion()
 end
 
 function getDate(days)
-    local year=0
     local month=1
-    local daysperyear=365.242--365
-    --[[while (days>=daysperyear) do
-       daysperyear=365
-       if ((year%4)==0) or (((year%100)==0) and ((year%400)==0)) then
-          daysperyear=366
-       end
-       days=days-daysperyear
-       year=year+1
-    end]]--
-	year = math.floor(days / daysperyear)
+    local daysperyear=365.242
+	local year = math.floor(days / daysperyear)
 	days = math.floor(days % daysperyear)
     local dayspermonth={31,28,31,30,31,30,31,31,30,31,30,31}
     if ((year%4)==0) or (((year%100)==0) and ((year%400)==0)) then

--- a/interface/kukagps/kukagps.lua
+++ b/interface/kukagps/kukagps.lua
@@ -319,18 +319,9 @@ function timeConversion()
 end
 
 function getDate(days)
-    local year=0
     local month=1
-    local daysperyear=365.242--365
-    --[[while (days>=daysperyear) do
-       daysperyear=365
-       if ((year%4)==0) or (((year%100)==0) and ((year%400)==0)) then
-          daysperyear=366
-       end
-       days=days-daysperyear
-       year=year+1
-    end]]--
-	year = math.floor(days / daysperyear)
+    local daysperyear=365.242
+	local year = math.floor(days / daysperyear)
 	days = math.floor(days % daysperyear)
     local dayspermonth={31,28,31,30,31,30,31,31,30,31,30,31}
     if ((year%4)==0) or (((year%100)==0) and ((year%400)==0)) then

--- a/interface/kukagps/kukagps.lua
+++ b/interface/kukagps/kukagps.lua
@@ -321,15 +321,17 @@ end
 function getDate(days)
     local year=0
     local month=1
-    local daysperyear=365
-    while (days>=daysperyear) do
+    local daysperyear=365.242--365
+    --[[while (days>=daysperyear) do
        daysperyear=365
        if ((year%4)==0) or (((year%100)==0) and ((year%400)==0)) then
           daysperyear=366
        end
        days=days-daysperyear
        year=year+1
-    end
+    end]]--
+	year = math.floor(days / daysperyear)
+	days = math.floor(days % daysperyear)
     local dayspermonth={31,28,31,30,31,30,31,31,30,31,30,31}
     if ((year%4)==0) or (((year%100)==0) and ((year%400)==0)) then
        dayspermonth={31,29,31,30,31,30,31,31,30,31,30,31}


### PR DESCRIPTION
- Fixes an error with the GPS that made it not properly take into account the every year that is a multiple of 100 and not a multiple of 400 isn't a leap year.
- Made it so that the GPS can handle a large amount of days without erroring (though this fix could make the year, month and time in the GPS a bit less accurate)