### PR TITLE
NPC Throwing Items

### DIFF
--- a/items/active/weapons/npc/crystalliteshardnpc.activeitem
+++ b/items/active/weapons/npc/crystalliteshardnpc.activeitem
@@ -1,0 +1,84 @@
+{
+  "itemName" : "crystalliteshardnpc",
+  "level" : 1,
+  "price" : 1,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "boomerang",
+  "description" : "throwing stars for NPCs.",
+  "shortdescription" : "Crystalite Shard for NPCs",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon", "ranged", "pistol"],
+
+  "inventoryIcon" : "/items/throwables/ise3/crystalliteshard.png",
+  "animation" : "fakethrowingitem.animation",
+  "animationParts" : {
+    "boomerang" : "/items/throwables/ise3/crystalliteshard.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 2.4,
+  "edgeTrigger" : true,
+  "projectileType" : "crystalliteshard",
+  "projectileParameters" : {
+    "power" : 12,
+    "level" : 3,
+    "knockback" : 0,
+    "flippable" : true,
+
+    "ignoreTerrain" : false,
+    "controlForce" : 1,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 20.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -90,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true,
+	  "aimAngle" : 0,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : -80,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 12,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/items/active/weapons/npc/deathblossomnpc.activeitem
+++ b/items/active/weapons/npc/deathblossomnpc.activeitem
@@ -1,0 +1,84 @@
+{
+  "itemName" : "deathblossomnpc",
+  "level" : 1,
+  "price" : 1,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "boomerang",
+  "description" : "throwing stars for NPCs.",
+  "shortdescription" : "Deathbloom for NPCs",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon", "ranged", "bow"],
+
+  "inventoryIcon" : "/items/throwables/deathblossom.png",
+  "animation" : "fakethrowingitem.animation",
+  "animationParts" : {
+    "boomerang" : "/items/throwables/deathblossom.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 2.4,
+  "edgeTrigger" : true,
+  "projectileType" : "deathblossomblast",
+  "projectileParameters" : {
+    "speed" : 45,
+    "power" : 8,
+    "level" : 3,
+    "knockback" : 0,
+
+    "ignoreTerrain" : false,
+    "controlForce" : 1,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 20.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -90,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true,
+	  "aimAngle" : 0,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : -80,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 12,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/items/active/weapons/npc/fakethrowingitem.animation
+++ b/items/active/weapons/npc/fakethrowingitem.animation
@@ -1,0 +1,47 @@
+{
+  "animatedParts" : {
+    "stateTypes" : {
+      "weapon" : {
+        "default" : "visible",
+        "states" : {
+          "visible" : {},
+          "hidden" : {}
+        }
+      }
+    },
+
+    "parts" : {
+      "boomerang" : {
+        "properties" : {
+          "centered" : true,
+          "offset" : [0.0, 0.0],
+          //"offset" : [0.625, 0.75],
+          "transformationGroups" : [ "weapon" ]
+        },
+
+        "partStates" : {
+          "weapon" : {
+            "visible" : {
+              "properties" : {
+                "image" : "<partImage>"
+              }
+            },
+            "hidden" : {
+              "properties" : {
+                "image" : ""
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+
+  "transformationGroups" : {
+    "weapon" : {}
+  },
+
+  "sounds" : {
+    "throw" : [ "/sfx/melee/swing_dagger.ogg" ]
+  }
+}

--- a/items/active/weapons/npc/ignuschili2npc.activeitem
+++ b/items/active/weapons/npc/ignuschili2npc.activeitem
@@ -1,0 +1,84 @@
+{
+  "itemName" : "ignuschili2npc",
+  "level" : 1,
+  "price" : 1,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "boomerang",
+  "description" : "throwing stars for NPCs.",
+  "shortdescription" : "Adv. Ignus Chili for NPCs",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon", "ranged", "bow"],
+
+  "inventoryIcon" : "/items/throwables/ignuschili2.png",
+  "animation" : "fakethrowingitem.animation",
+  "animationParts" : {
+    "boomerang" : "/items/throwables/ignuschili2.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 2.4,
+  "edgeTrigger" : true,
+  "projectileType" : "ignus2",
+  "projectileParameters" : {
+    "speed" : 65,
+    "power" : 11,
+    "level" : 4,
+    "knockback" : 0,
+
+    "ignoreTerrain" : false,
+    "controlForce" : 1,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 20.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -90,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true,
+	  "aimAngle" : 0,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : -80,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 12,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/items/active/weapons/npc/ignuschilinpc.activeitem
+++ b/items/active/weapons/npc/ignuschilinpc.activeitem
@@ -1,0 +1,84 @@
+{
+  "itemName" : "ignuschilinpc",
+  "level" : 1,
+  "price" : 1,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "boomerang",
+  "description" : "throwing stars for NPCs.",
+  "shortdescription" : "Ingus Chili for NPCs",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon", "ranged", "bow"],
+
+  "inventoryIcon" : "/items/throwables/ignuschili.png",
+  "animation" : "fakethrowingitem.animation",
+  "animationParts" : {
+    "boomerang" : "/items/throwables/ignuschili.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 2.4,
+  "edgeTrigger" : true,
+  "projectileType" : "ignus",
+  "projectileParameters" : {
+    "speed" : 45,
+    "power" : 9,
+    "level" : 2,
+    "knockback" : 0,
+
+    "ignoreTerrain" : false,
+    "controlForce" : 1,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 20.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -90,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true,
+	  "aimAngle" : 0,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : -80,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 12,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/items/active/weapons/npc/magmabombnpc.activeitem
+++ b/items/active/weapons/npc/magmabombnpc.activeitem
@@ -1,0 +1,84 @@
+{
+  "itemName" : "magmabombnpc",
+  "level" : 1,
+  "price" : 1,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "boomerang",
+  "description" : "throwing stars for NPCs.",
+  "shortdescription" : "Magma Nodule for NPCs",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon", "ranged", "bow"],
+
+  "inventoryIcon" : "/items/throwables/magmabomb.png",
+  "animation" : "fakethrowingitem.animation",
+  "animationParts" : {
+    "boomerang" : "/items/throwables/magmabomb.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 2.4,
+  "edgeTrigger" : true,
+  "projectileType" : "magmaburst",
+  "projectileParameters" : {
+    "speed" : 65,
+    "power" : 11,
+    "level" : 4,
+    "knockback" : 0,
+
+    "ignoreTerrain" : false,
+    "controlForce" : 1,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 20.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -90,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true,
+	  "aimAngle" : 0,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : -80,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 12,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/items/active/weapons/npc/shockshroomnpc.activeitem
+++ b/items/active/weapons/npc/shockshroomnpc.activeitem
@@ -1,0 +1,84 @@
+{
+  "itemName" : "shockshroomnpc",
+  "level" : 1,
+  "price" : 1,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "boomerang",
+  "description" : "throwing stars for NPCs.",
+  "shortdescription" : "Shock Shroom for NPCs",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon", "ranged", "bow"],
+
+  "inventoryIcon" : "/items/throwables/shockshroom.png",
+  "animation" : "fakethrowingitem.animation",
+  "animationParts" : {
+    "boomerang" : "/items/throwables/shockshroom.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 2.4,
+  "edgeTrigger" : true,
+  "projectileType" : "shroomshock",
+  "projectileParameters" : {
+    "speed" : 45,
+    "power" : 8,
+    "level" : 3,
+    "knockback" : 0,
+
+    "ignoreTerrain" : false,
+    "controlForce" : 1,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 20.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -90,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true,
+	  "aimAngle" : 0,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : -80,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 12,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/items/active/weapons/npc/throwingkunainpc.activeitem
+++ b/items/active/weapons/npc/throwingkunainpc.activeitem
@@ -1,0 +1,84 @@
+{
+  "itemName" : "throwingkunainpc",
+  "level" : 1,
+  "price" : 1,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "boomerang",
+  "description" : "throwing stars for NPCs.",
+  "shortdescription" : "Throwing Kunai for NPCs",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon", "ranged", "bow"],
+
+  "inventoryIcon" : "/items/throwables/throwingkunai.png",
+  "animation" : "fakethrowingitem.animation",
+  "animationParts" : {
+    "boomerang" : "/items/throwables/throwingkunai.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 2.4,
+  "edgeTrigger" : true,
+  "projectileType" : "throwingkunai",
+  "projectileParameters" : {
+    "speed" : 80,
+    "power" : 17.5,
+    "knockback" : 10,
+    "flippable" : true,
+
+    "ignoreTerrain" : false,
+    "controlForce" : 1,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 20.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -90,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true,
+	  "aimAngle" : 0,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : -80,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 12,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/items/active/weapons/npc/throwingspearnpc.activeitem
+++ b/items/active/weapons/npc/throwingspearnpc.activeitem
@@ -1,0 +1,83 @@
+{
+  "itemName" : "throwingspearnpc",
+  "level" : 1,
+  "price" : 1,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "boomerang",
+  "description" : "throwing stars for NPCs.",
+  "shortdescription" : "Throwing Spear for NPCs",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon", "ranged", "bow"],
+
+  "inventoryIcon" : "/items/throwables/throwingspear.png",
+  "animation" : "fakethrowingitem.animation",
+  "animationParts" : {
+    "boomerang" : "/items/throwables/throwingspear.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 2.4,
+  "edgeTrigger" : true,
+  "projectileType" : "throwingspearnpc",
+  "projectileParameters" : {
+    "speed" : 50,
+    "power" : 33.75,
+    "knockback" : 20,
+
+    "ignoreTerrain" : false,
+    "controlForce" : 1,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 20.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -90,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true,
+	  "aimAngle" : 0,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : -80,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 12,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/items/active/weapons/npc/throwingstarnpc.activeitem
+++ b/items/active/weapons/npc/throwingstarnpc.activeitem
@@ -1,0 +1,84 @@
+{
+  "itemName" : "throwingstarnpc",
+  "level" : 1,
+  "price" : 1,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "boomerang",
+  "description" : "throwing stars for NPCs.",
+  "shortdescription" : "Throwing Star",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon", "ranged", "pistol"],
+
+  "inventoryIcon" : "/items/throwables/throwingstar.png",
+  "animation" : "fakethrowingitem.animation",
+  "animationParts" : {
+    "boomerang" : "/items/throwables/throwingstar.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 0.9,
+  "edgeTrigger" : true,
+  "projectileType" : "throwingstar",
+  "projectileParameters" : {
+    "speed" : 75,
+    "power" : 8,
+    "knockback" : 10,
+    "persistentAudio" : "/sfx/projectiles/throwingstar_loop.ogg",
+
+    "ignoreTerrain" : false,
+    "controlForce" : 1,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 20.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -90,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true,
+	  "aimAngle" : 0,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : -80,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false,
+      "weaponOffset" : [ -0.2, -0.6]
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 12,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/items/active/weapons/npc/woodenboomerangnpc.activeitem
+++ b/items/active/weapons/npc/woodenboomerangnpc.activeitem
@@ -1,0 +1,80 @@
+{
+  "itemName" : "woodenboomerangnpc",
+  "level" : 1,
+  "price" : 10,
+  "maxStack" : 1,
+  "rarity" : "common",
+  "category" : "uniqueWeapon",
+  "description" : "An aboriginal design made in the bush.
+^cyan;Hunting weapon^reset;",
+  "shortdescription" : "Wooden Boomerang NPC",
+  "tooltipKind" : "boomerang",
+  "twoHanded" : false,
+  "itemTags" : ["weapon","boomerang","upgradeableWeapon","wood", "ranged","pistol"],
+
+  "inventoryIcon" : "/items/active/weapons/boomerang/woodboomerang.png",
+  "animation" : "/items/active/weapons/boomerang/boomerang.animation",
+  "animationParts" : {
+    "boomerang" : "/items/active/weapons/boomerang/woodboomerang.png"
+  },
+  "animationCustom" : { },
+  "scripts" : ["/items/active/weapons/boomerang/boomerang.lua"],
+  "fireOffset" : [1.25, 0.5],
+
+  "cooldownTime" : 0.6,
+
+  "projectileType" : "woodboomerang",
+  "projectileParameters" : {
+    "power" : 5,
+    "knockback" : 20,
+
+    "ignoreTerrain" : false,
+    "controlForce" : 65,
+    "pickupDistance" : 1.0,
+    "snapDistance" : 2.0
+  },
+
+  "stances" : {
+    "idle" : {
+      "armRotation" : -20,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "windup" : {
+      "duration" : 0.1,
+      "transition" : "throw",
+      "transitionFunction" : "fire",
+      "armRotation" : 70,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : false
+    },
+    "throw" : {
+      "armRotation" : 0,
+      "animationState" : {
+        "weapon" : "hidden"
+      },
+      "allowRotate" : true,
+      "allowFlip" : true
+    },
+    "catch" : {
+      "duration" : 0.2,
+      "transition" : "idle",
+      "armRotation" : 60,
+      "animationState" : {
+        "weapon" : "visible"
+      },
+      "allowRotate" : false,
+      "allowFlip" : true
+    }
+  },
+  "critChance" : 4,
+  "critBonus" : 2,
+
+  "builder" : "/items/buildscripts/buildboomerang.lua"
+}

--- a/npcs/biome/feneroxguard.npctype.patch
+++ b/npcs/biome/feneroxguard.npctype.patch
@@ -1,0 +1,9 @@
+[
+  {
+    "op": "add",
+    "path": "/items/override/0/1/0/sheathedprimary/-",
+    "value": {
+      "name": "woodenboomerangnpc"
+    }
+  }
+]

--- a/npcs/pavillion/pavillionarcher.npctype
+++ b/npcs/pavillion/pavillionarcher.npctype
@@ -35,7 +35,6 @@
       "jumpSpeed" : 45
     }
   },
-
   "items" : {
     "override" : [
       [0, [
@@ -52,9 +51,144 @@
             "primary" : [
               "npcpetcapturepod"
             ],
-            "sheathedprimary" : [ { "name" : "npctungstenbow", "parameters" : { "primaryAbility" : { "projectileType" : "chargedflamearrow", "powerProjectileType" : "chargedflamearrow" } } } ]
+			"sheathedprimary" : [ "throwingstarnpc" ]
           }
-        ] ]
+        ]
+	  ],
+      [3, [
+          {
+            "head" : [
+              { "name" : "hylotltier3head", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "chest" : [
+              { "name" : "hylotltier3chest", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "legs" : [
+              { "name" : "hylotltier3pants", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "primary" : [
+              "npcpetcapturepod"
+            ],
+			"sheathedprimary" : [ { "name" : "throwingstarnpc" } ]
+          }
+        ] ,[
+          {
+            "head" : [
+              { "name" : "hylotltier3head", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "chest" : [
+              { "name" : "hylotltier3chest", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "legs" : [
+              { "name" : "hylotltier3pants", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "primary" : [
+              "npcpetcapturepod"
+            ],
+			"sheathedprimary" : [ "throwingstarnpc" ]
+          }
+        ] ,[
+          {
+            "head" : [
+              { "name" : "hylotltier3head", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "chest" : [
+              { "name" : "hylotltier3chest", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "legs" : [
+              { "name" : "hylotltier3pants", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "primary" : [
+              "npcpetcapturepod"
+            ],
+			"sheathedprimary" : [ "ignuschilinpc", "shockshroomnpc"]
+          }
+        ]
+	  ],
+      [4, [
+          {
+            "head" : [
+              { "name" : "hylotltier3head", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "chest" : [
+              { "name" : "hylotltier3chest", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "legs" : [
+              { "name" : "hylotltier3pants", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "primary" : [
+              "npcpetcapturepod"
+            ],
+			"sheathedprimary" : [ { "name" : "throwingstarnpc" } ]
+          }
+        ] ,[
+          {
+            "head" : [
+              { "name" : "hylotltier3head", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "chest" : [
+              { "name" : "hylotltier3chest", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "legs" : [
+              { "name" : "hylotltier3pants", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "primary" : [
+              "npcpetcapturepod"
+            ],
+			"sheathedprimary" : [ "throwingstarnpc" ]
+          }
+        ] ,[
+          {
+            "head" : [
+              { "name" : "hylotltier3head", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "chest" : [
+              { "name" : "hylotltier3chest", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "legs" : [
+              { "name" : "hylotltier3pants", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "primary" : [
+              "npcpetcapturepod"
+            ],
+			"sheathedprimary" : [ "ignuschili2npc", "deathblossomnpc"]
+          }
+        ]
+	  ],
+      [5, [
+          {
+            "head" : [
+              { "name" : "hylotltier3head", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "chest" : [
+              { "name" : "hylotltier3chest", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "legs" : [
+              { "name" : "hylotltier3pants", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "primary" : [
+              "npcpetcapturepod"
+            ],
+			"sheathedprimary" : [ { "name" : "throwingstarnpc" } ]
+          }
+        ] ,[
+          {
+            "head" : [
+              { "name" : "hylotltier3head", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "chest" : [
+              { "name" : "hylotltier3chest", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "legs" : [
+              { "name" : "hylotltier3pants", "parameters" : { "colorIndex" : 3 } }
+            ],
+            "primary" : [
+              "npcpetcapturepod"
+            ],
+			"sheathedprimary" : [ "magmabombnpc"]
+          }
+        ]
+	  ]
     ]
   },
 

--- a/stagehands/coordinator.stagehand.patch
+++ b/stagehands/coordinator.stagehand.patch
@@ -3849,6 +3849,100 @@
     }
   },
 
+  //
+  //Thrown Weapons
+  //
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/crystalliteshardnpc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 50,
+      "forceMoveRange": 50
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/deathblossomnpc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 20,
+      "forceMoveRange": 20
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ignuschilinpc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 19,
+      "forceMoveRange": 20
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/ignuschili2npc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 30,
+      "forceMoveRange": 35
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/magmabombnpc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 20,
+      "forceMoveRange": 20
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/shockshroomnpc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 20,
+      "forceMoveRange": 20
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/throwingkunainpc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 50,
+      "forceMoveRange": 50
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/throwingspearnpc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 35,
+      "forceMoveRange": 35
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/throwingstarnpc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 50,
+      "forceMoveRange": 50
+    }
+  },
+  {
+    "op": "add",
+    "path": "/npcCombat/rangedWeaponRanges/woodenboomerangnpc",
+    "value": {
+      "minRange": 5,
+      "maxRange": 30,
+      "forceMoveRange": 30
+    }
+  },
+
   //...
   //Melees
   //


### PR DESCRIPTION
A few throwing items for NPCs. 

Unfortunately, the throwing spear, throwing kunai,  and crystallite shard have an issue where the projectile doesn't flip like it should. I can't figure it out and need help with it. I've left these items out of the NPC's weapons list for now. But if someone could get those three working I'll add them to the fenerox guards and pavilian archer (ninjas) respectively.

Currently, Fenerox Guards use wooden boomerangs sometimes instead of bows. Ninjas no longer use bows, but now use a variety of throwing items. Most of the time ninja stars, but sometimes weapon-plants (ignus, shock shroom, deathblosom, etc)