### PR TITLE
Repairo nerfs

### DIFF
--- a/interface/scripted/fuvehiclerepair/fuvehiclerepairgui.config
+++ b/interface/scripted/fuvehiclerepair/fuvehiclerepairgui.config
@@ -130,5 +130,5 @@
   "scripts" : ["/interface/scripted/fuvehiclerepair/fuvehiclerepairgui.lua"],
   "scriptDelta" : 30,
 
-  "chipRepairAmount" : 0.005
+  "chipRepairAmount" : 0.003
 }

--- a/objects/outpost/furepairo/furepairo.object
+++ b/objects/outpost/furepairo/furepairo.object
@@ -39,7 +39,7 @@
   "scripts" : [ "/objects/outpost/furepairo/furepairo.lua" ],
   "scriptDelta" : 20,
 
-  "chipRepairFactor" : 0.005,
+  "chipRepairFactor" : 0.003,
 
   "chatRadius" : 10,
   "chatCooldown" : 15,

--- a/objects/outpost/shipyardcaptain/shipyardcaptain.object.patch
+++ b/objects/outpost/shipyardcaptain/shipyardcaptain.object.patch
@@ -32,11 +32,11 @@
     {
     "op": "add",
     "path": "/interactData/items/-",
-    "value": {"item": "repairo"}
+    "value": {"item": "repairo", "price" : 4000}
     },
     {
     "op": "add",
     "path": "/interactData/items/-",
-    "value": {"item": "furepairo"}
+    "value": {"item": "furepairo", "price" : 12000}
     }
 ]


### PR DESCRIPTION
- Increased the cost of purchasing Rob and Roger Repairos from Penguin Pete, and decreased the discount of Roger Repairos.