### PR TITLE
Hotfix: Gamebreaker bug with certain weapon alts

### DIFF
--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -684,6 +684,7 @@ function masteries.load(dt)
 end
 
 function masteries.update(dt)
+	if dt==0 and world.entityType(entity.id())~="player" then return end
 	local args={}
 	args.dt=dt
 

--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -684,7 +684,6 @@ function masteries.load(dt)
 end
 
 function masteries.update(dt)
-	if dt==0 and world.entityType(entity.id())~="player" then return end
 	local args={}
 	args.dt=dt
 

--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -749,12 +749,11 @@ function masteries.update(dt)
 end
 
 function masteries.clearHand(hand)
-	if (type(hand)~="string") or (type(tagCaching[hand.."TagCacheOld"])~="table") then return end
+	if (not type(hand)=="string") or (not type(tagCaching[hand.."TagCacheOld"])=="table") then return end
 	masteries.timers[hand]={}
 	masteries.timers["both"]={}
-	--because for some reason, the game shits itself on NPCs sometimes and acts like the list HAS to have entries in it.
-	status.setPersistentEffects("masteryBonus"..hand, {{stat="maxHealth",amount=0}})
-	status.setPersistentEffects("ammoMasteryBonus"..hand, {{stat="maxHealth",amount=0}})
+	status.setPersistentEffects("masteryBonus"..hand, {})
+	status.setPersistentEffects("ammoMasteryBonus"..hand, {})
 end
 
 function masteries.reset()

--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -749,7 +749,7 @@ function masteries.update(dt)
 end
 
 function masteries.clearHand(hand)
-	if (not type(hand)=="string") or (not type(tagCaching[hand.."TagCacheOld"])=="table") then return end
+	if (type(hand)~="string") or (type(tagCaching[hand.."TagCacheOld"])~="table") then return end
 	masteries.timers[hand]={}
 	masteries.timers["both"]={}
 	status.setPersistentEffects("masteryBonus"..hand, {})

--- a/items/active/weapons/melee/abilities/broadsword/futravelingslash/futravelingslash.weaponability
+++ b/items/active/weapons/melee/abilities/broadsword/futravelingslash/futravelingslash.weaponability
@@ -1,92 +1,92 @@
 {
-  "animationParts" : { },
-  "animationCustom" : {
-    "sounds" : {
-      "fireTravelSlash" : [ "/sfx/melee/travelingslash_fire1.ogg" ],
-      "hellfireTravelSlash" : [ "/sfx/melee/travelingslash_fire1.ogg" ],
-      "iceTravelSlash" : [ "/sfx/melee/travelingslash_ice2.ogg" ],
-      "hoarfrostTravelSlash" : [ "/sfx/melee/travelingslash_ice2.ogg" ],
-      "electricTravelSlash" : [ "/sfx/melee/travelingslash_electric4.ogg" ],
-      "poisonTravelSlash" : [ "/sfx/melee/travelingslash_poison2.ogg" ],
-      "bioweaponTravelSlash" : [ "/sfx/melee/travelingslash_poison2.ogg" ],
-      "shadowTravelSlash" : [ "/sfx/melee/travelingslash_poison2.ogg" ],
-      "cosmicTravelSlash" : [ "/sfx/melee/travelingslash_electric3.ogg" ],
-      "aetherTravelSlash" : [ "/sfx/melee/travelingslash_electric3.ogg" ],
-      "radioactiveTravelSlash" : [ "/sfx/melee/travelingslash_poison3.ogg" ],
-      "silverweaponTravelSlash" : [ "/sfx/melee/travelingslash_fire1.ogg" ]
-    }
-  },
+	"animationParts": {},
+	"animationCustom": {
+		"sounds": {
+			"fireTravelSlash": ["/sfx/melee/travelingslash_fire1.ogg"],
+			"hellfireTravelSlash": ["/sfx/melee/travelingslash_fire1.ogg"],
+			"iceTravelSlash": ["/sfx/melee/travelingslash_ice2.ogg"],
+			"hoarfrostTravelSlash": ["/sfx/melee/travelingslash_ice2.ogg"],
+			"electricTravelSlash": ["/sfx/melee/travelingslash_electric4.ogg"],
+			"poisonTravelSlash": ["/sfx/melee/travelingslash_poison2.ogg"],
+			"bioweaponTravelSlash": ["/sfx/melee/travelingslash_poison2.ogg"],
+			"shadowTravelSlash": ["/sfx/melee/travelingslash_poison2.ogg"],
+			"cosmicTravelSlash": ["/sfx/melee/travelingslash_electric3.ogg"],
+			"aetherTravelSlash": ["/sfx/melee/travelingslash_electric3.ogg"],
+			"radioactiveTravelSlash": ["/sfx/melee/travelingslash_poison3.ogg"],
+			"silverweaponTravelSlash": ["/sfx/melee/travelingslash_fire1.ogg"]
+		}
+	},
 
-  "ability" : {
-    "name" : "Wave Slash",
-    "type" : "futravelingslash",
-    "scripts" : ["/items/active/weapons/melee/abilities/broadsword/futravelingslash/futravelingslash.lua"],
-    "class" : "TravelingSlash",
+	"ability": {
+		"name": "Wave Slash",
+		"type": "futravelingslash",
+		"scripts": ["/items/active/weapons/melee/abilities/broadsword/futravelingslash/futravelingslash.lua"],
+		"class": "TravelingSlash",
 
-    "projectileOffset" : [0,0],
-    "elementalConfig" : { //todo check damageKind
-      "physical" : {},
-      "fire" : {
-        "projectileType" : "waveblast"
-      },
-      "ice" : {
-        "projectileType" : "iceblast1"
-      },
-      "poison" : {
-        "projectileType" : "poisonblast"
-      },
-      "electric" : {
-        "projectileType" : "electricblast"
-      },
-      "shadow" : {
-        "projectileType" : "fudarkbeamshot"
-      },
-      "cosmic" : {
-	"projectileType":"energyburstaetherium"
-      },
-      "radioactive" : {
-        "projectileType" : "miniwobbleshot2"
-      },
-      "aether" : {
-	"projectileType":"energyburstaetherium"
-      },
-      "silverweapon" : {
-        "projectileType" : "waveblast"
-      },
-      "bioweapon" : {
-        "projectileType" : "poisonblast"
-      },
-      "hoarfrost" : {
-        "projectileType" : "iceblast1"
-      },
-      "hellfire" : {
-        "projectileType" : "waveblast"
-      }
-    },
+		"projectileOffset": [0, 0],
+		"elementalConfig": { //todo check damageKind
+			"physical": {},
+			"fire": {
+				"projectileType": "waveblast"
+			},
+			"ice": {
+				"projectileType": "iceblast1"
+			},
+			"poison": {
+				"projectileType": "poisonblast"
+			},
+			"electric": {
+				"projectileType": "electricblast"
+			},
+			"shadow": {
+				"projectileType": "fudarkbeamshot"
+			},
+			"cosmic": {
+				"projectileType": "energyburstaetherium"
+			},
+			"radioactive": {
+				"projectileType": "miniwobbleshot2"
+			},
+			"aether": {
+				"projectileType": "energyburstaetherium"
+			},
+			"silverweapon": {
+				"projectileType": "waveblast"
+			},
+			"bioweapon": {
+				"projectileType": "poisonblast"
+			},
+			"hoarfrost": {
+				"projectileType": "iceblast1"
+			},
+			"hellfire": {
+				"projectileType": "waveblast"
+			}
+		},
 
-    "baseDamage" : 7,
-    "energyUsage" : 120,
-    "cooldownTime" : 1.5,
+		"baseDamage": 7,
+		"energyUsage": 120,
+		"cooldownTime": 1.5,
 
-    "stances" : {
-      "windup" : {
-        "duration" : 0.25,
-        "armRotation" : 70,
-        "weaponRotation" : 0,
-        "twoHanded" : true,
+		"stances": {
+			"windup": {
+				"duration": 0.25,
+				"armRotation": 70,
+				"weaponRotation": 0,
+				"twoHanded": true,
 
-        "allowRotate" : false,
-        "allowFlip" : false
-      },
-      "fire" : {
-        "duration" : 0.4,
-        "armRotation" : -45,
-        "weaponRotation" : -55,
-        "twoHanded" : true,
+				"allowRotate": false,
+				"allowFlip": false
+			},
+			"fire": {
+				"duration": 0.4,
+				"armRotation": -45,
+				"weaponRotation": -55,
+				"twoHanded": true,
 
-        "allowRotate" : false,
-        "allowFlip" : false
-      }
-    }
-  }
+				"allowRotate": false,
+				"allowFlip": false
+			}
+		}
+	}
 }

--- a/projectiles/guns/energyburst/energyburstaetherium.projectile
+++ b/projectiles/guns/energyburst/energyburstaetherium.projectile
@@ -1,154 +1,180 @@
 {
-  "projectileName" : "energyburstaetherium",
-  "image" : "energyburst.png",
-  "animationCycle" : 0.3,
-  "level" : 7,
-  "frameNumber" : 3,
-  "damageKindImage" : "icon.png",
-  "pointLight" : true,
-  "lightColor" : [45,45,155],
-  "power" : 10,
-  "speed" : 42,
-  "timeToLive" : 1,
-  "fullbright" : true,
-  "damagePoly" : [ [-35, 0], [-35, -73], [0, -73], [35, -73], [35, 0], [35, 73], [0, 73], [-35, 73] ],
-  "damageKind" : "electricplasma",
-  "physics" : "laser",
-  "knockback" : -20,
-  "actionOnReap":[
-    {
-      "action" : "config",
-      "file" : "/projectiles/explosions/energyburstexplosion/energyburstexplosion.config"
-    },
-    {
-      "action":"projectile",
-      "type":"deathzone",
-      "inheritDamageFactor":0.5,
-      "angleAdjust":0,
-      "fuzzAngle":0,
-      "config":{
-        "piercing":true,
-        "speed":0,
-        "timeToLive":2,
-        "knockback":0,
-        "periodicActions":[
-          {
-            "action":"particle",
-            "specification":"cosmicswoosh1",
-            "time":0.2,
-            "repeat":true
-          },
-          {
-            "time" : 0.14,
-            "loop" : true,
-            "action":"projectile",
-            "type":"fuhailstrikeshot",
-            "inheritDamageFactor":0.03,
-            "fuzzAngle" : 360,
-            "config":{
-              "damageTeam":{"type":"friendly"}
-            }
-          }
-        ],
-        "actionOnReap":[
-          {
-            "action":"projectile",
-            "type":"fuhailstrikeshot",
-            "inheritDamageFactor":0.5,
-            "fuzzAngle":180,
-            "config":{
-              "timeToLive":0,
-              "actionOnReap":[
-                {
-                  "action":"projectile",
-                  "type":"fuhailstrikeshot",
-                  "inheritDamageFactor":0.03,
-                  "angleAdjust":36,
-                  "config":{
-                    "damageTeam":{"type":"friendly"}
-                  }
-                },
-                {
-                  "action":"projectile",
-                  "type":"fuhailstrikeshot",
-                  "inheritDamageFactor":0.03,
-                  "angleAdjust":72,
-                  "config":{
-                    "damageTeam":{"type":"friendly"}
-                  }
-                },
-                {
-                  "action":"projectile",
-                  "type":"fuhailstrikeshot",
-                  "inheritDamageFactor":0.03,
-                  "angleAdjust":108,
-                  "config":{
-                    "damageTeam":{"type":"friendly"}
-                  }
-                },
-                {
-                  "action":"projectile",
-                  "type":"fuhailstrikeshot",
-                  "inheritDamageFactor":0.03,
-                  "angleAdjust":144,
-                  "config":{
-                    "damageTeam":{"type":"friendly"}
-                  }
-                },
-                {
-                  "action":"projectile",
-                  "type":"fuhailstrikeshot",
-                  "inheritDamageFactor":0.03,
-                  "angleAdjust":180,
-                  "config":{
-                    "damageTeam":{"type":"friendly"}
-                  }
-                },
-                {
-                  "action":"projectile",
-                  "type":"fuhailstrikeshot",
-                  "inheritDamageFactor":0.03,
-                  "angleAdjust":216,
-                  "config":{
-                    "damageTeam":{"type":"friendly"}
-                  }
-                },
-                {
-                  "action":"projectile",
-                  "type":"fuhailstrikeshot",
-                  "inheritDamageFactor":0.03,
-                  "angleAdjust":252,
-                  "config":{
-                    "damageTeam":{"type":"friendly"}
-                  }
-                },
-                {
-                  "action":"projectile",
-                  "type":"fuhailstrikeshot",
-                  "inheritDamageFactor":0.03,
-                  "angleAdjust":288,
-                  "config":{
-                    "damageTeam":{"type":"friendly"}
-                  }
-                },
-                {
-                  "action":"projectile",
-                  "type":"fuhailstrikeshot",
-                  "inheritDamageFactor":0.03,
-                  "angleAdjust":324,
-                  "config":{
-                    "damageTeam":{"type":"friendly"}
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "action":"config",
-            "file":"/projectiles/explosions/burstexplosion/cosmicburstexplosion.config"
-          }
-        ]
-      }
-    }
-  ]
+	"projectileName": "energyburstaetherium",
+	"image": "energyburst.png",
+	"animationCycle": 0.3,
+	"level": 7,
+	"frameNumber": 3,
+	"damageKindImage": "icon.png",
+	"pointLight": true,
+	"lightColor": [45, 45, 155],
+	"power": 10,
+	"speed": 42,
+	"timeToLive": 1,
+	"fullbright": true,
+	"damagePoly": [
+		[-35, 0],
+		[-35, -73],
+		[0, -73],
+		[35, -73],
+		[35, 0],
+		[35, 73],
+		[0, 73],
+		[-35, 73]
+	],
+	"damageKind": "electricplasma",
+	"physics": "laser",
+	"knockback": -20,
+	"actionOnReap": [{
+			"action": "config",
+			"file": "/projectiles/explosions/energyburstexplosion/energyburstexplosion.config"
+		},
+		{
+			"action": "projectile",
+			"type": "deathzone",
+			"inheritDamageFactor": 0.5,
+			"angleAdjust": 0,
+			"fuzzAngle": 0,
+			"config": {
+				"piercing": true,
+				"speed": 0,
+				"timeToLive": 2,
+				"knockback": 0,
+				"periodicActions": [
+					{
+						"action": "particle",
+						"specification": "cosmicswoosh1",
+						"time": 0.2,
+						"repeat": true
+					},
+					{
+						"time": 0.14,
+						"loop": true,
+						"action": "projectile",
+						"type": "fuhailstrikeshot",
+						"inheritDamageFactor": 0.03,
+						"fuzzAngle": 360,
+						"config": {
+							"damageTeam": {
+								"type": "friendly"
+							}
+						}
+					}
+				],
+				"actionOnReap": [{
+						"action": "projectile",
+						"type": "fuhailstrikeshot",
+						"inheritDamageFactor": 0.5,
+						"fuzzAngle": 180,
+						"config": {
+							"timeToLive": 0,
+							"actionOnReap": [{
+									"action": "projectile",
+									"type": "fuhailstrikeshot",
+									"inheritDamageFactor": 0.03,
+									"angleAdjust": 36,
+									"config": {
+										"damageTeam": {
+											"type": "friendly"
+										}
+									}
+								},
+								{
+									"action": "projectile",
+									"type": "fuhailstrikeshot",
+									"inheritDamageFactor": 0.03,
+									"angleAdjust": 72,
+									"config": {
+										"damageTeam": {
+											"type": "friendly"
+										}
+									}
+								},
+								{
+									"action": "projectile",
+									"type": "fuhailstrikeshot",
+									"inheritDamageFactor": 0.03,
+									"angleAdjust": 108,
+									"config": {
+										"damageTeam": {
+											"type": "friendly"
+										}
+									}
+								},
+								{
+									"action": "projectile",
+									"type": "fuhailstrikeshot",
+									"inheritDamageFactor": 0.03,
+									"angleAdjust": 144,
+									"config": {
+										"damageTeam": {
+											"type": "friendly"
+										}
+									}
+								},
+								{
+									"action": "projectile",
+									"type": "fuhailstrikeshot",
+									"inheritDamageFactor": 0.03,
+									"angleAdjust": 180,
+									"config": {
+										"damageTeam": {
+											"type": "friendly"
+										}
+									}
+								},
+								{
+									"action": "projectile",
+									"type": "fuhailstrikeshot",
+									"inheritDamageFactor": 0.03,
+									"angleAdjust": 216,
+									"config": {
+										"damageTeam": {
+											"type": "friendly"
+										}
+									}
+								},
+								{
+									"action": "projectile",
+									"type": "fuhailstrikeshot",
+									"inheritDamageFactor": 0.03,
+									"angleAdjust": 252,
+									"config": {
+										"damageTeam": {
+											"type": "friendly"
+										}
+									}
+								},
+								{
+									"action": "projectile",
+									"type": "fuhailstrikeshot",
+									"inheritDamageFactor": 0.03,
+									"angleAdjust": 288,
+									"config": {
+										"damageTeam": {
+											"type": "friendly"
+										}
+									}
+								},
+								{
+									"action": "projectile",
+									"type": "fuhailstrikeshot",
+									"inheritDamageFactor": 0.03,
+									"angleAdjust": 324,
+									"config": {
+										"damageTeam": {
+											"type": "friendly"
+										}
+									}
+								}
+							]
+						}
+					},
+					{
+						"action": "config",
+						"file": "/projectiles/explosions/burstexplosion/cosmicburstexplosion.config"
+					}
+				]
+			}
+		}
+	]
 }

--- a/stats/effects/fu_effects/entropicward/tentacleeffect.lua
+++ b/stats/effects/fu_effects/entropicward/tentacleeffect.lua
@@ -25,9 +25,9 @@ function update(dt)
 end
 
 function uninit()
-	if world.entityType(entity.id()) ~= "player" then
+	--[[if world.entityType(entity.id()) ~= "player" then
 		status.removeEphemeralEffect("blacktarslow")
 		status.removeEphemeralEffect("insanity")
 		status.removeEphemeralEffect("l6doomed")
-	end
+	end]]
 end


### PR DESCRIPTION
reverted a pointless fix, but implemented one that actually does fix the problem:

removed effect removal in tentacle effect, from uninit block, that was being called in a persistent effect, which was causing crashes and making worlds persistently crash. Yes, this was an FU bug. 