### PR TITLE
Typo fix for the Vegan Cakes

### DIFF
--- a/items/generic/food/tier2/cakevegan.consumable
+++ b/items/generic/food/tier2/cakevegan.consumable
@@ -4,7 +4,7 @@
   "price" : 240,
   "category" : "preparedFood",
   "inventoryIcon" : "cake.png",
-  "description" : "It's a delicious vegan cake! Like the original, but for ^green;herbivores.^reset;/n^green;Type: Herb Sugar^reset;",
+  "description" : "It's a delicious vegan cake! Like the original, but for ^green;herbivores.^reset;\n^green;Type: Herb Sugar^reset;",
   "shortdescription" : "Vegan Cake",
   "effects" : [ [
     {

--- a/items/generic/food/tier2/carrotcakevegan.consumable
+++ b/items/generic/food/tier2/carrotcakevegan.consumable
@@ -4,7 +4,7 @@
   "price" : 315,
   "category" : "preparedFood",
   "inventoryIcon" : "carrotcake.png",
-  "description" : "It's a delicious carrot cake! Like the original, but for ^green;herbivores.^reset;/n^green;Type: Herb Sugar^reset;",
+  "description" : "It's a delicious carrot cake! Like the original, but for ^green;herbivores.^reset;\n^green;Type: Herb Sugar^reset;",
   "shortdescription" : "Vegan Carrot Cake",
   "effects" : [ [
     {

--- a/items/generic/food/tier2/chocolatecakevegan.consumable
+++ b/items/generic/food/tier2/chocolatecakevegan.consumable
@@ -4,7 +4,7 @@
   "price" : 380,
   "category" : "preparedFood",
   "inventoryIcon" : "chocolatecake.png",
-  "description" : "A vegan chocolate cake. Like the original, but for ^green;herbivores.^reset;/n^green;Type: Herb Sugar^reset;",
+  "description" : "A vegan chocolate cake. Like the original, but for ^green;herbivores.^reset;\n^green;Type: Herb Sugar^reset;",
   "shortdescription" : "Vegan Chocolate Cake",
   "effects" : [ [
     {

--- a/items/generic/food/tier2/coffeecakevegan.consumable
+++ b/items/generic/food/tier2/coffeecakevegan.consumable
@@ -4,7 +4,7 @@
   "price" : 350,
   "category" : "preparedFood",
   "inventoryIcon" : "coffeecake.png",
-  "description" : "A moist vegan cake enriched with coffee. Like the original, but for ^green;herbivores.^reset;/n^green;Type: Herb Sugar^reset;",
+  "description" : "A moist vegan cake enriched with coffee. Like the original, but for ^green;herbivores.^reset;\n^green;Type: Herb Sugar^reset;",
   "shortdescription" : "Vegan Coffee Cake",
   "effects" : [ [
     {


### PR DESCRIPTION
All 4 vegan cakes had "/n" showing in their descriptions. The original intent was probably a new line "\n" instead.