### PR TITLE
Fixed Undead Precursor Problem

### DIFF
--- a/npcs/mobs/precursormob.npctype
+++ b/npcs/mobs/precursormob.npctype
@@ -18,9 +18,50 @@
             ""
           ]
         }
+      },
+      "reattack" : {
+        "default" : {
+          "default" : [
+            ""
+          ]
+        }
+      },
+      "killedTarget" : {
+        "default" : {
+          "default" : [
+            ""
+          ]
+        }
+      },
+      "lostTarget" : {
+        "default" : {
+          "default" : [
+            ""
+          ]
+        }
+      },
+      "outOfSight" : {
+        "default" : {
+          "default" : [
+            ""
+          ]
+        }
+      },
+      "cheerOn" : {
+        "default" : {
+          "default" : [
+            ""
+          ]
+        }
+      },
+      "cantReach" : {
+        "default" : {
+          "default" : [
+            ""
+          ]
+        }
       }
     },
-
     "behaviorConfig" : {
       "leapWindup" : 0.35,
       "rangedAimTime" : 0.05,

--- a/npcs/mobs/precursormob.npctype
+++ b/npcs/mobs/precursormob.npctype
@@ -11,6 +11,16 @@
   "scriptConfig" : {
     "behavior" : "hostileguard",
 
+    "dialog" : {
+      "attack" : {
+        "default" : {
+          "default" : [
+            ""
+          ]
+        }
+      }
+    },
+
     "behaviorConfig" : {
       "leapWindup" : 0.35,
       "rangedAimTime" : 0.05,


### PR DESCRIPTION
Found an issue with Precursor robots sometimes not properly dying due to dialog-related error (trying to find attack dialog when there was none).
Now they properly die when killed.