### PR TITLE
Minor tweaks in Agriculture nodes and Tricorder quest rewards

### DIFF
--- a/items/active/weapons/ranged/unique/furepairgun.activeitem
+++ b/items/active/weapons/ranged/unique/furepairgun.activeitem
@@ -4,7 +4,7 @@
   "inventoryIcon" : "repairgun.png",
   "maxStack" : 1,
   "rarity" : "rare",
-  "description" : "Repairs damaged mecha. Upgrade using your ^orange;Tricorder^reset;.",
+  "description" : "Repairs damaged mechs. Upgrade using your ^orange;Tricorder^reset;.",
   "shortdescription" : "Mech Repair Tool",
   "category" : "mechrepairtool",
   "level" : 1,

--- a/items/generic/food/fupest.consumable
+++ b/items/generic/food/fupest.consumable
@@ -4,7 +4,7 @@
 	"price" : 10,
 	"category" : "preparedFood",
 	"inventoryIcon" : "fupest.png",
-	"description" : "A small mammalian pest. Edible, and nutritious. ^green;Type: Raw Meat^reset;",
+	"description" : "A small mammalian pest. Edible, and nutritious. ^red;Type: Raw Meat^reset;",
 	"shortdescription" : "Pest",
 	"foodValue" : 5,
 	"tooltipKind" : "food",

--- a/quests/fu_questlines/byos/fu_byoscrew.questtemplate
+++ b/quests/fu_questlines/byos/fu_byoscrew.questtemplate
@@ -5,7 +5,7 @@
   "text" : "If you want to ^orange;Hire Crewmates^reset; then you first need to build a ^green;Crappy Crew Bed^reset;. Build one at a ^orange;Ship Component Assembler^reset; and place it on your ship!",
   "completionText" : "For each additional crewmate you'll need a new bed. Some beds can house more than one, such as Bunk Beds.",
   "moneyRange" : [0, 0],
-  "rewards" : [ [ [ "salvagetier4", 12 ] ] ],
+  "rewards" : [ [ [ "crewcontract_janitor", 1 ] ] ],
   "speaker" : "player",
 
   "updateDelta" : 10,

--- a/quests/fu_questlines/byos/fu_byoscrewdeed.questtemplate
+++ b/quests/fu_questlines/byos/fu_byoscrewdeed.questtemplate
@@ -5,7 +5,7 @@
   "text" : "^green;Crew Deeds^reset; allow you to ^orange;Hire Crewmates^reset; if you place them in an enclosed room that contains at least 1 ^orange;Door^reset;, 1 ^orange;Light^reset; and 1 ^orange;Bed^reset;. Build one at a ^orange;Ship Component Assembler^reset; and place it on your ship!",
   "completionText" : "For each additional crewmate you'll need a new crew deed. Interacting with the ^green;Crew Deed^reset; when it has issues will show what they are.",
   "moneyRange" : [0, 0],
-  "rewards" : [ [ [ "salvagetier4", 12 ] ] ],
+  "rewards" : [ [ [ "crewcontract", 1 ] ] ],
   "speaker" : "player",
 
   "updateDelta" : 10,

--- a/quests/fu_questlines/tutorial/vinj/create_growingtray.questtemplate
+++ b/quests/fu_questlines/tutorial/vinj/create_growingtray.questtemplate
@@ -3,7 +3,7 @@
   "prerequisites" : [ "create_matterassembler" ],
   "title" : "Growing",
   "text" : "While you can farm the old-fashioned way with a hoe , dirt and your own two hands there is another option: ^orange;Growing Trays^reset;. Build one of these at a ^orange;Foraging Table^reset; now, if you have researched it in ^oraange;Agriculture^reset;.",
-  "completionText" : "In the first slot, place a seed. In the second, place a liquid to feed the plant with. The third slot is for fertilizer. ^green;Different fertilizers^reset; will result in ^green;different production and growth rates^reset; for plants.",
+  "completionText" : "In the first slot, place 3 seeds. In the second, place a liquid to feed the plant with. The third slot is for fertilizer. ^green;Different fertilizers^reset; will result in ^green;different production and growth rates^reset; for plants.",
   "moneyRange" : [0, 0],
   "rewards" : [ [ [ "rewardbag", 1 ] ] ],
   "speaker" : "questGiver",

--- a/quests/fu_questlines/tutorial/vinj/mechparts.questtemplate
+++ b/quests/fu_questlines/tutorial/vinj/mechparts.questtemplate
@@ -4,7 +4,7 @@
 	"text" : "Mechs are quite useful, but basic models are barely space-worthy and generally clunky. You'll want to ^green;Research^reset; into ^cyan;Engineering^reset; and build some ^orange;Stock Mech Legs^reset; to replace the awful basic model.",
 	"completionText" : "You can further improve on those legs, too, by upgrading them once more into ^orange;Improved Mech Legs^reset;. The same applies to your ^green;Boosters^reset;.",
 	"rewards" : [
-		[ [ "salvagebooster", 6] ]
+		[ [ "ff_spareparts", 30] ]
 	],
 	"moneyRange" : [100, 250],
 

--- a/zb/questList/data.config
+++ b/zb/questList/data.config
@@ -32,7 +32,7 @@
 			"sublines" : [ "fu_vinj", "fu_extractor" ],
 			"requirements" : [ ],//"create_matterassembler" ],
 			"moneyRange" : [100, 150],
-			"rewards" : [ [ "fu_pickuprangeaugment1", 1 ], ["salvagebody", 5],["salvagetier4", 5], ["fu_lootbox", 3, {"level" : 3}]],
+			"rewards" : [ [ "fu_pickuprangeaugment1", 1 ], ["colonydeed", 2],["teleportercore", 1], ["fu_lootbox", 3, {"level" : 3}]],
 			"secret" : false
 		},
 		{
@@ -40,7 +40,7 @@
 			"sublines" : [ "fu_byosbasics" ],
 			"requirements" : [ "fu_byos" ],
 			"moneyRange" : [0, 0],
-			"rewards" : [ ["salvagebody", 5],["salvagebooster", 5],["salvagetier4", 5], ["fu_lootbox", 3, {"level" : 2}] ],
+			"rewards" : [ ["fu_booster_small1", 1], ["fu_ftlBooster_small", 1], ["fu_lootbox", 3, {"level" : 2}] ],
 			"secret" : true
 		},
 		{

--- a/zb/researchTree/fu_agriculture.config
+++ b/zb/researchTree/fu_agriculture.config
@@ -486,7 +486,7 @@
       "bees3" : ["Advanced Beekeeping","^orange;Tier 4^reset;\n\nYou can make even more powerful Frames that drastically improve your bees' efficiency."],
       "bees4" : ["Efficient Beekeeping","^orange;Tier 5^reset;\n\nYou can make advanced Frames that drastically improve your hives."],
       "bees5" : ["Ultimate Beekeeping","^orange;Tier 6^reset;\n\nYou have achieved a truly enviable master's degree. You have managed to make your hives produce efficiently."],
-      "fishing1" : ["Basic Fishing","^orange;Tier 3^reset;\n\nFishing is both a useful survival skill and a relaxing hobby. You can now create a basic fishing rod and use it to catch fish in bodies of water."],
+      "fishing1" : ["Basic Fishing","^orange;Tier 3^reset;\n\nFishing is both a useful survival skill and a relaxing hobby. You can now create a basic fishing rod and use it to catch fish in bodies of water.\n\n^red;Only works on ocean-like planets (Ocean, Arctic, Tidewater, etc.), not in lakes and puddles.^reset;"],
       "fishing2" : ["Fishing Techniques","^orange;Tier 4^reset;\n\nYou can craft better quality fishing tackle, enabling you to catch fish with greater ease."],
       "fishing3" : ["Master Wrangler","^orange;Tier 5^reset;\n\nWith your knowledge of fishing, you can create a nearly perfect fishing rod."]
     }

--- a/zb/researchTree/fu_agriculture.config
+++ b/zb/researchTree/fu_agriculture.config
@@ -238,7 +238,7 @@
         "icon" : "/objects/power/isn_hydroponicstray/isn_hydroponicstray_inv.png",
         "position" : [-20, -130],
         "children" : [ ],
-        "price" : [["fuscienceresource", 1050], ["irongrowingtray", 1]],
+        "price" : [["fuscienceresource", 1050], ["liquidpumpwell", 1]],
         "unlocks" : [ "isn_hydroponicstray","fu_portablewaterpumpback","HarvesterBeam3"  ]
       },
       "gathering1" : {


### PR DESCRIPTION
- Removed obsolete resources (such as Interface Chip) from Tricorder quest rewards.
- Tricorder quest about crew bed now gives 1 Custodian Contract.
- Tricorder quest about crew deed now gives 1 Red Shirt Contract.
- Tricorder quest about mech legs now gives 30 Spare Parts.
- Completing all Tutorial quests in Tricorder now gives 2 Colony Deeds and 1 Teleporter Core.
- Completing all BYOS quests in Tricoder now gives 1 Small FTL Booster and 1 Small Ship Booster Mk1.
- Basic Fishing node now warns that fishing only works on ocean-like planets.
- Farming Mastery node now requires Water Generator (was: Heatlamp Tray).
- Fixed Raw Meat warning not using the red font in description of Pest.