### PR TITLE
Split off furniture/machines from Precursor treasure pool

### DIFF
--- a/treasure/fumonsters.treasurepools
+++ b/treasure/fumonsters.treasurepools
@@ -114,24 +114,23 @@
 
   "gasbagLoot" : [
     [1, {
-        "pool" : [
-          {"weight" : 0.0333, "item" : [ "liquidmetallichydrogen", 150]},
-          {"weight" : 0.0333, "item" : [ "fuscienceresource", 150]},
-          {"weight" : 0.0200, "item" : [ "unknowngene", 3]},
-          {"weight" : 0.0200, "item" : [ "cell_mutated", 50]},
-          {"weight" : 0.0366, "item" : [ "fuscienceresource", 15]},
-          {"weight" : 0.0366, "item" : [ "iodine", 4]},
-          {"weight" : 0.0366, "item" : [ "ff_mercury", 6]},
-          {"weight" : 0.007, "item" : "protheonshard"}
-        ],
-        "poolRounds" : [
-          [0.90, 1],
-          [0.80, 2],
-          [0.70, 3]
-        ],
+      "pool" : [
+        {"weight" : 0.0333, "item" : [ "liquidmetallichydrogen", 150]},
+        {"weight" : 0.0333, "item" : [ "fuscienceresource", 150]},
+        {"weight" : 0.0200, "item" : [ "unknowngene", 3]},
+        {"weight" : 0.0200, "item" : [ "cell_mutated", 50]},
+        {"weight" : 0.0366, "item" : [ "fuscienceresource", 15]},
+        {"weight" : 0.0366, "item" : [ "iodine", 4]},
+        {"weight" : 0.0366, "item" : [ "ff_mercury", 6]},
+        {"weight" : 0.007, "item" : "protheonshard"}
+      ],
+      "poolRounds" : [
+        [0.90, 1],
+        [0.80, 2],
+        [0.70, 3]
+      ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "dolphinTreasure" : [
     [1, {
@@ -218,8 +217,7 @@
         [0.20, 3]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "warbotTreasure" : [
     [1, {
@@ -231,8 +229,8 @@
         {"weight" : 0.3, "pool" : "ffmetallicbossChest"},
         {"weight" : 0.3, "pool" : "fuEssence" },
         {"weight" : 0.1, "item" : "staticcell"},
-    	  {"weight" : 0.1, "item" : ["ff_spareparts", 1]},
-    	  {"weight" : 0.1, "item" : ["laserdiode", 1]},
+        {"weight" : 0.1, "item" : ["ff_spareparts", 1]},
+        {"weight" : 0.1, "item" : ["laserdiode", 1]},
         {"weight" : 0.004, "item" : "protheonshard"}
       ],
       "poolRounds" : [
@@ -248,8 +246,7 @@
         [0.05, 9]
       ],
       "allowDuplication" : false
-      }
-    ]
+    }]
   ],
 
   "servitorTreasure" : [
@@ -258,8 +255,8 @@
         {"weight" : 0.5, "pool" : "robotTreasure"},
         {"weight" : 0.2, "item" : "stickofram"},
         {"weight" : 0.2, "item" : "staticcell"},
-    	  {"weight" : 0.1, "item" : ["ff_spareparts", 1]},
-    	  {"weight" : 0.1, "item" : ["laserdiode", 1]}
+        {"weight" : 0.1, "item" : ["ff_spareparts", 1]},
+        {"weight" : 0.1, "item" : ["laserdiode", 1]}
       ],
       "poolRounds" : [
         [0.20, 0],
@@ -267,8 +264,7 @@
         [0.80, 2]
       ],
       "allowDuplication" : false
-      }
-    ]
+    }]
   ],
 
   "servitorHunting" : [
@@ -276,16 +272,15 @@
       "pool" : [
         {"weight" : 0.1, "item" : "staticcell"},
         {"weight" : 0.1, "item" : "stickofram"},
-    	  {"weight" : 0.1, "item" : ["ff_spareparts", 1]},
-    	  {"weight" : 0.1, "item" : ["laserdiode", 1]},
+        {"weight" : 0.1, "item" : ["ff_spareparts", 1]},
+        {"weight" : 0.1, "item" : ["laserdiode", 1]},
         {"weight" : 0.5, "pool" : "fusalvageComponent"}
       ],
       "poolRounds" : [
         [1, 1]
       ],
       "allowDuplication" : false
-      }
-    ]
+    }]
   ],
   "webberTreasure" : [
     [1, {
@@ -298,8 +293,7 @@
         [0.80, 1]
       ],
       "allowDuplication" : false
-      }
-    ]
+    }]
   ],
   "webberhuntTreasure" : [
     [1, {
@@ -313,8 +307,7 @@
         [0.80, 1]
       ],
       "allowDuplication" : false
-      }
-    ]
+    }]
   ],
   "sporgus2Treasure" : [
     [1, {
@@ -328,8 +321,7 @@
         [0.80, 1]
       ],
       "allowDuplication" : false
-      }
-    ]
+    }]
   ],
   "icecrabcanoHunting" : [
     [1, {
@@ -339,8 +331,7 @@
         {"weight" : 0.150, "item" : "hardenedcarapace"},
         {"weight" : 0.001, "item" : "crabcanoaf"}
       ]
-      }
-    ]
+    }]
   ],
   "icecrabcanoTreasure" : [
     [1, {
@@ -355,8 +346,7 @@
         [0.80, 1]
       ],
       "allowDuplication" : false
-      }
-    ]
+    }]
   ],
 
   "ffjunkerTreasure" : [
@@ -384,8 +374,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
 
   "ffjunkerTreasureBoss" : [
@@ -415,8 +404,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "ffcannibalTreasure" : [
     [1, {
@@ -440,27 +428,25 @@
         [0.23, 5]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "fleshreaperhuntLoot" : [
     [1, {
-        "pool" : [
-          {"weight" : 0.20, "item" : [ "monsterplating", 4]},
-          {"weight" : 0.20, "item" : [ "cellmatter", 4]},
-          {"weight" : 0.05, "item" : [ "unknowngene", 1]},
-          {"weight" : 0.05, "item" : [ "cell_mutated", 5]},
-          {"weight" : 0.20, "item" : [ "biospore", 5]},
-          {"weight" : 0.20, "item" : [ "cellmatter", 5]},
-          {"weight" : 0.05, "item" : "alienwoodsap"}
-        ],
-        "poolRounds" : [
-          [0.63, 1],
-          [0.33, 2]
-        ],
+      "pool" : [
+        {"weight" : 0.20, "item" : [ "monsterplating", 4]},
+        {"weight" : 0.20, "item" : [ "cellmatter", 4]},
+        {"weight" : 0.05, "item" : [ "unknowngene", 1]},
+        {"weight" : 0.05, "item" : [ "cell_mutated", 5]},
+        {"weight" : 0.20, "item" : [ "biospore", 5]},
+        {"weight" : 0.20, "item" : [ "cellmatter", 5]},
+        {"weight" : 0.05, "item" : "alienwoodsap"}
+      ],
+      "poolRounds" : [
+        [0.63, 1],
+        [0.33, 2]
+      ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "fleshreaperLoot" : [
     [1, {
@@ -480,8 +466,7 @@
           [0.33, 2]
         ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "deeponeTreasure" : [
     [1, {
@@ -498,8 +483,7 @@
         [0.80, 1]
       ],
       "allowDuplication" : false
-      }
-    ]
+    }]
   ],
   "ffelderStarspawnTreasure" : [
     [1, {
@@ -610,8 +594,7 @@
         [0.53, 5]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "ffelderStarspawnTreasureBoss" : [
     [1, {
@@ -692,8 +675,7 @@
         [0.53, 5]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "shadowtopLoot" : [
     [1, {
@@ -709,8 +691,7 @@
         [0.80, 1]
       ],
       "allowDuplication" : false
-      }
-    ]
+    }]
   ],
   "minishoggothLoot" : [
     [1, {
@@ -734,10 +715,11 @@
   ],
   "shoggothFlesh" : [
     [0, {
-      "fill" : [ { "item" : [ "shoggothflesh", 30 ] },
-      		 {"item" : [ "liquidelderfluid", 500]},
-                 { "item" : [ "essence", 2000 ] },
-        	 {"item" : [ "fumadnessresource", 3200]} ],
+      "fill" : [
+        {"item" : [ "shoggothflesh", 30 ] },
+        {"item" : [ "liquidelderfluid", 500]},
+        {"item" : [ "essence", 2000 ] },
+        {"item" : [ "fumadnessresource", 3200]} ],
       "pool" : [
         {"weight" : 0.20, "pool" : "money"},
         {"weight" : 0.02, "pool" : "artifactloot" },
@@ -813,8 +795,7 @@
         [0.23, 9]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "shoggothTreasure" : [
     [0, {
@@ -891,71 +872,66 @@
         [0.33, 9]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "slimemonsterectoTreasure" : [
     [1, {
-        "pool" : [
-          {"weight" : 0.70, "pool" : "money"},
-          {"weight" : 0.03, "item" : "cell_viral"},
-          {"weight" : 0.2, "item" : [ "liquiddarkwater", 2]},
-          {"weight" : 0.3, "item" : [ "endomorphicjelly", 1]}
-        ],
-        "poolRounds" : [
-          [0.23, 1],
-          [0.33, 2]
-        ],
+      "pool" : [
+        {"weight" : 0.70, "pool" : "money"},
+        {"weight" : 0.03, "item" : "cell_viral"},
+        {"weight" : 0.2, "item" : [ "liquiddarkwater", 2]},
+        {"weight" : 0.3, "item" : [ "endomorphicjelly", 1]}
+      ],
+      "poolRounds" : [
+        [0.23, 1],
+        [0.33, 2]
+      ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "slimemonstermagmaTreasure" : [
     [1, {
-        "pool" : [
-          {"weight" : 0.70, "pool" : "money"},
-          {"weight" : 0.03, "item" : "cell_viral"},
-          {"weight" : 0.2, "item" : [ "liquidlava", 2]},
-          {"weight" : 0.3, "item" : [ "volatilepowder", 1]}
-        ],
-        "poolRounds" : [
-          [0.23, 1],
-          [0.33, 2]
-        ],
+      "pool" : [
+        {"weight" : 0.70, "pool" : "money"},
+        {"weight" : 0.03, "item" : "cell_viral"},
+        {"weight" : 0.2, "item" : [ "liquidlava", 2]},
+        {"weight" : 0.3, "item" : [ "volatilepowder", 1]}
+      ],
+      "poolRounds" : [
+        [0.23, 1],
+        [0.33, 2]
+      ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "slimemonstertarTreasure" : [
     [1, {
-        "pool" : [
-          {"weight" : 0.70, "pool" : "money"},
-          {"weight" : 0.3, "item" : [ "liquidblacktar", 2]},
-          {"weight" : 0.3, "item" : [ "liquidoil", 2]}
-        ],
-        "poolRounds" : [
-          [0.23, 1],
-          [0.33, 2]
-        ],
+      "pool" : [
+        {"weight" : 0.70, "pool" : "money"},
+        {"weight" : 0.3, "item" : [ "liquidblacktar", 2]},
+        {"weight" : 0.3, "item" : [ "liquidoil", 2]}
+      ],
+      "poolRounds" : [
+        [0.23, 1],
+        [0.33, 2]
+      ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "slimemonsterTreasure" : [
     [1, {
-        "pool" : [
-          {"weight" : 0.70, "pool" : "money"},
-          {"weight" : 0.3, "item" : [ "greenslime", 1]},
-          {"weight" : 0.2, "item" : [ "liquidslime", 2]},
-          {"weight" : 0.1, "item" : [ "endomorphicjelly", 1]}
-        ],
-        "poolRounds" : [
-          [0.23, 1],
-          [0.33, 2]
-        ],
+      "pool" : [
+        {"weight" : 0.70, "pool" : "money"},
+        {"weight" : 0.3, "item" : [ "greenslime", 1]},
+        {"weight" : 0.2, "item" : [ "liquidslime", 2]},
+        {"weight" : 0.1, "item" : [ "endomorphicjelly", 1]}
+      ],
+      "poolRounds" : [
+        [0.23, 1],
+        [0.33, 2]
+      ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "slimemonsterlargeTreasure" : [
     [1, {
@@ -1028,8 +1004,7 @@
         [0.33, 3]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "lesserBossTreasure" : [
     [1, {
@@ -1048,8 +1023,7 @@
         [0.23, 5]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "ffmetallicbossChest" : [
     [1, {
@@ -1142,11 +1116,11 @@
         {"weight" : 0.015, "item" : ["fuokeahitechtoaster-recipe", 1]},
         {"weight" : 0.015, "item" : ["fuokeahitechtoilet-recipe", 1]},
         {"weight" : 0.015, "item" : ["fuokeahitechvrchair-recipe", 1]},
-    	  {"weight" : 0.001, "item" : "razorneedler"},
-    	  {"weight" : 0.001, "item" : "scorchneedler"},
-    	  {"weight" : 0.001, "item" : "shockneedler"},
-    	  {"weight" : 0.001, "item" : "toxicneedler"},
-    	  {"weight" : 0.004, "item" : "randomharpoongun"},
+        {"weight" : 0.001, "item" : "razorneedler"},
+        {"weight" : 0.001, "item" : "scorchneedler"},
+        {"weight" : 0.001, "item" : "shockneedler"},
+        {"weight" : 0.001, "item" : "toxicneedler"},
+        {"weight" : 0.004, "item" : "randomharpoongun"},
         {"weight" : 0.004, "item" : "protheonshard"}
       ],
       "poolRounds" : [
@@ -1157,8 +1131,7 @@
         [0.23, 5]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
 
   "ffslimebanditTreasure" : [
@@ -1183,8 +1156,7 @@
         [0.30, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "ffbanditTreasure" : [
     [1, {
@@ -1206,8 +1178,7 @@
         [0.30, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "ffelitegregTreasure" : [
     [1, {
@@ -1223,8 +1194,7 @@
         [0.20, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "ffeliteTreasure" : [
     [1, {
@@ -1240,19 +1210,18 @@
         [0.15, 3]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "dinoLoot" : [
     [1, {
       "pool" : [
         {"weight" : 0.40, "pool" : "money"},
-    	  {"weight" : 0.25, "item" : [ "alienmeat", 3]},
-    	  {"weight" : 0.10, "item" : [ "raptoregg", 1]},
-    	  {"weight" : 0.10, "item" : [ "raptoregg2", 1]},
-    	  {"weight" : 0.10, "item" : [ "raptoregg3", 1]},
-    	  {"weight" : 0.10, "item" : [ "raptoregg4", 1]},
-    	  {"weight" : 0.10, "item" : [ "raptoregg5", 1]},
+        {"weight" : 0.25, "item" : [ "alienmeat", 3]},
+        {"weight" : 0.10, "item" : [ "raptoregg", 1]},
+        {"weight" : 0.10, "item" : [ "raptoregg2", 1]},
+        {"weight" : 0.10, "item" : [ "raptoregg3", 1]},
+        {"weight" : 0.10, "item" : [ "raptoregg4", 1]},
+        {"weight" : 0.10, "item" : [ "raptoregg5", 1]},
         {"weight" : 0.20, "item" : [ "monsterplating", 1]},
         {"weight" : 0.25, "item" : [ "sharpenedclaw", 1]},
         {"weight" : 0.15, "item" : [ "fuscienceresource", 1]},
@@ -1265,8 +1234,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "dinoLootHuge" : [
     [1, {
@@ -1285,14 +1253,13 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "dinoLootBoss" : [
     [1, {
       "pool" : [
         {"weight" : 0.40, "pool" : "money"},
-    	  {"weight" : 0.25, "item" : [ "alienmeat", 30]},
+        {"weight" : 0.25, "item" : [ "alienmeat", 30]},
         {"weight" : 0.20, "item" : [ "monsterplating", 20]},
         {"weight" : 0.25, "item" : [ "sharpenedclaw", 5]},
         {"weight" : 0.15, "item" : [ "fuscienceresource", 8]},
@@ -1315,8 +1282,8 @@
         {"weight" : 0.008, "item" : "randomharpoongun"},
         {"weight" : 0.04, "item" : [ "fuearphones-recipe", 1]},
         {"weight" : 0.04, "item" : [ "fuhoodedmask-recipe", 1]},
-    	  {"weight" : 0.004, "item" : [ "verdantcarbine-recipe", 1]},
-    	  {"weight" : 0.004, "item" : [ "verdantrailgun-recipe", 1]},
+        {"weight" : 0.004, "item" : [ "verdantcarbine-recipe", 1]},
+        {"weight" : 0.004, "item" : [ "verdantrailgun-recipe", 1]},
         {"weight" : 0.005, "item" : [ "druidstaff-recipe", 1]},
         {"weight" : 0.003, "item" : [ "biopistol-recipe", 1]}
       ],
@@ -1326,14 +1293,13 @@
         [0.33, 3]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "bogdinoLoot" : [
     [1, {
       "pool" : [
-    	  {"weight" : 0.25, "item" : [ "alienmeat", 3]},
-    	  {"weight" : 0.50, "item" : [ "leather", 1]},
+        {"weight" : 0.25, "item" : [ "alienmeat", 3]},
+        {"weight" : 0.50, "item" : [ "leather", 1]},
         {"weight" : 0.10, "item" : [ "monsterplating", 1]},
         {"weight" : 0.15, "item" : [ "monsterplating", 1]}
       ],
@@ -1342,8 +1308,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "fucaterpillarLoot" : [
     [1, {
@@ -1363,8 +1328,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "shadowhoundLoot" : [
     [1, {
@@ -1383,8 +1347,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
 
   "ashgolemLoot" : [
@@ -1419,8 +1382,7 @@
         [0.33, 1]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "bloodgolemLoot" : [
     [1, {
@@ -1447,8 +1409,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "targolemLoot" : [
     [1, {
@@ -1485,8 +1446,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "toxicgolemLoot" : [
     [1, {
@@ -1514,8 +1474,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "fleshblobLoot" : [
     [1, {
@@ -1532,8 +1491,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "ratthingLoot" : [
     [1, {
@@ -1551,8 +1509,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "corruptflyLoot" : [
     [1, {
@@ -1569,8 +1526,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "fugiantscorpionLoot" : [
     [1, {
@@ -1588,8 +1544,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "fuheadcrabLoot" : [
     [1, {
@@ -1606,8 +1561,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "icetrollLoot" : [
     [1, {
@@ -1625,8 +1579,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "rocktrollLoot" : [
     [1, {
@@ -1643,8 +1596,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "sulphurtrollLoot" : [
     [1, {
@@ -1661,8 +1613,7 @@
         [0.33, 2]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "toxicflyLoot" : [
     [1, {
@@ -1677,8 +1628,7 @@
         [0.75, 1]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "beeLoot" : [
     [1, {
@@ -1693,8 +1643,7 @@
         [0.75, 1]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "evilbeeLoot" : [
     [1, {
@@ -1710,8 +1659,7 @@
         [0.75, 1]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "apexsupermutant" : [
     [1, {
@@ -1753,18 +1701,18 @@
         {"weight" : 0.007, "item" : [ "bloodyknife", 1]},
         {"weight" : 0.02, "item" : [ "carbonblade", 1]},
         {"weight" : 0.02, "item" : [ "hardenedsteelblade", 1]},
-    	  {"weight" : 0.01, "item" : "razorneedler"},
-    	  {"weight" : 0.01, "item" : "scorchneedler"},
-    	  {"weight" : 0.01, "item" : "shockneedler"},
-    	  {"weight" : 0.01, "item" : "toxicneedler"},
-    	  {"weight" : 0.04, "item" : "randomharpoongun"},
-    	  {"weight" : 0.025, "item" : [ "fuearphones-recipe", 1]},
-    	  {"weight" : 0.025, "item" : [ "fuhoodedmask-recipe", 1]},
-    	  {"weight" : 0.004, "item" : [ "verdantcarbine-recipe", 1]},
-    	  {"weight" : 0.004, "item" : [ "verdantrailgun-recipe", 1]},
-    	  {"weight" : 0.004, "item" : [ "druidstaff-recipe", 1]},
-    	  {"weight" : 0.002, "item" : [ "biopistol-recipe", 1]},
-    	  {"weight" : 0.01, "item" : [ "armcannon-recipe", 1]},
+        {"weight" : 0.01, "item" : "razorneedler"},
+        {"weight" : 0.01, "item" : "scorchneedler"},
+        {"weight" : 0.01, "item" : "shockneedler"},
+        {"weight" : 0.01, "item" : "toxicneedler"},
+        {"weight" : 0.04, "item" : "randomharpoongun"},
+        {"weight" : 0.025, "item" : [ "fuearphones-recipe", 1]},
+        {"weight" : 0.025, "item" : [ "fuhoodedmask-recipe", 1]},
+        {"weight" : 0.004, "item" : [ "verdantcarbine-recipe", 1]},
+        {"weight" : 0.004, "item" : [ "verdantrailgun-recipe", 1]},
+        {"weight" : 0.004, "item" : [ "druidstaff-recipe", 1]},
+        {"weight" : 0.002, "item" : [ "biopistol-recipe", 1]},
+        {"weight" : 0.01, "item" : [ "armcannon-recipe", 1]},
         {"weight" : 0.5, "item" : ["throwingspear", 12]},
         {"weight" : 0.5, "item" : ["flare", 10]},
         {"weight" : 0.5, "item" : ["throwingdagger", 12]},
@@ -1799,8 +1747,7 @@
         [0.75, 1]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "fleshreaperTreasure" : [
     [1, {
@@ -1872,8 +1819,7 @@
         [0.23, 5]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "shadowgolemLoot" : [
     [1, {
@@ -1944,8 +1890,7 @@
         [0.23, 5]
       ],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "shadowgolemminiLoot" : [
     [1, {  "fill" : [ { "item" : [ "shadowgasliquid", 2]  }  ] } ]
@@ -1955,13 +1900,12 @@
       "pool" : [
         {"weight" : 0.33, "pool" : "money"},
         {"weight" : 0.33, "item" : [ "liquidpus", 10]},
-	{"weight" : 0.33, "item" : [ "spidersilkblock", 25]}
+        {"weight" : 0.33, "item" : [ "spidersilkblock", 25]}
       ],
       "poolRounds" : [[0.75, 4],[0.25, 6]],
       "allowDuplication" : true,
-	  "fill" : [{ "item" : [ "venomsample", 3]}]
-      }
-    ]
+    "fill" : [{ "item" : [ "venomsample", 3]}]
+    }]
   ],
   "frankLootBoss" : [
     [1, {
@@ -1969,24 +1913,23 @@
       "pool" : [
         {"weight" : 0.33, "pool" : "money"},
         {"weight" : 0.33, "item" : [ "liquidpus", 10]},
-	{"weight" : 0.33, "item" : [ "spidersilkblock", 25]}
+        {"weight" : 0.33, "item" : [ "spidersilkblock", 25]}
       ],
       "poolRounds" : [[0.75, 4],[0.25, 6]],
       "allowDuplication" : true
-      }
-    ]
+    }]
   ],
   "fu_precursorspawnerloot" : [
     [1, {
-	  "pool" : [
-	    {"weight" : 0.001, "item" : [ "gregskittlegunfake", 1]  }
-	  ],
-	  "poolRounds" : [
-		[0.999, 0],
+    "pool" : [
+      {"weight" : 0.001, "item" : [ "gregskittlegunfake", 1]  }
+    ],
+    "poolRounds" : [
+      [0.999, 0],
         [0.001, 1]
       ],
       "allowDuplication" : false
-	  }
-	]
+    }
+  ]
   ]
 }

--- a/treasure/fuquesttreasure.treasurepools
+++ b/treasure/fuquesttreasure.treasurepools
@@ -1,567 +1,588 @@
 {
-  "theTome" : [
+  "theTome": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : "fugrimoire" }
+      "fill": [
+        {"weight": 1.0, "item": "fugrimoire"}
       ],
-      "allowDuplication" : true
+      "allowDuplication": true
     }]
   ],
-  "glitchmissioncodex" : [
+  "glitchmissioncodex": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "pool" : "fucodexRandom" }
+      "fill": [
+        {"weight": 1.0, "pool": "fucodexRandom"}
       ],
-      "allowDuplication" : true
+      "allowDuplication": true
     }]
   ],
-  "fuStarterDungeonTreasure" : [
+  "fuStarterDungeonTreasure": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "pool" : "salvageComponent" },
-        {"weight" : 1.0, "pool" : "salvageComponent" },
-        {"weight" : 1.0, "pool" : "salvageComponent" },
-        {"weight" : 1.0, "pool" : "fucodexRandom" },
-        {"weight" : 0.5, "pool" : "challengeChestTreasure" }
+      "fill": [
+        {"weight": 1.0, "pool": "salvageComponent"},
+        {"weight": 1.0, "pool": "salvageComponent"},
+        {"weight": 1.0, "pool": "salvageComponent"},
+        {"weight": 1.0, "pool": "fucodexRandom"},
+        {"weight": 0.5, "pool": "challengeChestTreasure"}
       ],
-      "allowDuplication" : true
+      "allowDuplication": true
     }]
   ],
-  "ancientpowerconduitLoot" : [
+  "ancientpowerconduitLoot": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : "ancientpowerconduit" }
+      "fill": [
+        {"weight": 1.0, "item": "ancientpowerconduit"}
       ],
-      "allowDuplication" : true
+      "allowDuplication": true
     }]
   ],
-"starterRope" : [
+"starterRope": [
     [1, {
-      "fill" : [
-        {"weight" : 1, "item" : ["climbingrope", 8]}
+      "fill": [
+        {"weight": 1, "item": ["climbingrope", 8]}
       ]
-    } ]
+    }]
   ],
 
-"starterExplosive" : [
+"starterExplosive": [
     [1, {
-      "fill" : [
-        {"weight" : 1, "item" : ["climbingrope", 8]}
+      "fill": [
+        {"weight": 1, "item": ["climbingrope", 8]}
       ],
-      "pool" : [
-        {"weight" : 0.10, "item" : "commonrocketlauncher"},
-        {"weight" : 0.90, "item" : ["bomb", 5]}
+      "pool": [
+        {"weight": 0.10, "item": "commonrocketlauncher"},
+        {"weight": 0.90, "item": ["bomb", 5]}
       ]
-    } ]
+    }]
   ],
-"starterMechTablet" : [
+"starterMechTablet": [
     [1, {
-      "pool" : [
-        {"weight" : 0.90, "item" : ["unrefinedliquidmechfuel", 20]}
+      "pool": [
+        {"weight": 0.90, "item": ["unrefinedliquidmechfuel", 20]}
       ]
-    } ]
+    }]
   ],
-"starterMechFuel" : [
+"starterMechFuel": [
     [1, {
-      "fill" : [
-        {"weight" : 1, "item" : ["unrefinedliquidmechfuel", 100]}
+      "fill": [
+        {"weight": 1, "item": ["unrefinedliquidmechfuel", 100]}
       ]
-    } ]
+    }]
   ],
-"starterTechTablet" : [
+"starterTechTablet": [
     [1, {
-      "pool" : [
-        {"weight" : 0.10, "item" : "commonpistol"},
-        {"weight" : 0.90, "item" : ["bomb", 1]}
+      "pool": [
+        {"weight": 0.10, "item": "commonpistol"},
+        {"weight": 0.90, "item": ["bomb", 1]}
       ]
-    } ]
+    }]
   ],
 
-  "thelusianTreasure" : [
+  "thelusianTreasure": [
     [1, {
-      "pool" : [
-        {"weight" : 0.2, "item" : ["thelusian1-codex", 1]},
-        {"weight" : 0.2, "item" : ["thelusian2-codex", 1]},
-        {"weight" : 0.2, "item" : ["thelusian3-codex", 1]},
-        {"weight" : 0.2, "item" : ["thelusian4-codex", 1]},
-        {"weight" : 0.2, "item" : ["thelusian5-codex", 1]},
-        {"weight" : 0.2, "item" : ["thelusian6-codex", 1]},
-        {"weight" : 0.2, "item" : ["thelusian7-codex", 1]}
+      "pool": [
+        {"weight": 0.2, "item": ["thelusian1-codex", 1]},
+        {"weight": 0.2, "item": ["thelusian2-codex", 1]},
+        {"weight": 0.2, "item": ["thelusian3-codex", 1]},
+        {"weight": 0.2, "item": ["thelusian4-codex", 1]},
+        {"weight": 0.2, "item": ["thelusian5-codex", 1]},
+        {"weight": 0.2, "item": ["thelusian6-codex", 1]},
+        {"weight": 0.2, "item": ["thelusian7-codex", 1]}
       ],
-        "poolRounds" : [
-          [1.0, 1]
+        "poolRounds": [
+        [1.0, 1]
         ],
-      "allowDuplication" : true
+      "allowDuplication": true
     }]
   ],
 
 
-  "fuWastesBookTreasure" : [
-	    [1,
-	      { "fill" : [ {"weight" : 1, "pool" : "fuprecursorLoot"}
-	    ]
+  "fuWastesBookTreasure": [
+      [1,
+        { "fill": [ {"weight": 1, "pool": "fuprecursorLoot"}
+      ]
     }]
   ],
 
-  "gregbookTreasure" : [
+  "gregbookTreasure": [
     [1, {
-      "pool" : [
-        {"weight" : 0.2, "item" : ["greg1-codex", 1]},
-        {"weight" : 0.2, "item" : ["greg2-codex", 1]},
-        {"weight" : 0.2, "item" : ["greg3-codex", 1]},
-        {"weight" : 0.2, "item" : ["greg4-codex", 1]},
-        {"weight" : 0.2, "item" : ["greg5-codex", 1]},
-        {"weight" : 0.2, "item" : ["greg6-codex", 1]},
-        {"weight" : 0.2, "item" : ["greg7-codex", 1]},
-        {"weight" : 0.2, "item" : ["greg8-codex", 1]},
-        {"weight" : 0.2, "item" : ["greg9-codex", 1]},
-        {"weight" : 0.2, "item" : ["greg10-codex", 1]}
+      "pool": [
+        {"weight": 0.2, "item": ["greg1-codex", 1]},
+        {"weight": 0.2, "item": ["greg2-codex", 1]},
+        {"weight": 0.2, "item": ["greg3-codex", 1]},
+        {"weight": 0.2, "item": ["greg4-codex", 1]},
+        {"weight": 0.2, "item": ["greg5-codex", 1]},
+        {"weight": 0.2, "item": ["greg6-codex", 1]},
+        {"weight": 0.2, "item": ["greg7-codex", 1]},
+        {"weight": 0.2, "item": ["greg8-codex", 1]},
+        {"weight": 0.2, "item": ["greg9-codex", 1]},
+        {"weight": 0.2, "item": ["greg10-codex", 1]}
       ],
-        "poolRounds" : [
-          [1.0, 1]
+        "poolRounds": [
+        [1.0, 1]
         ],
-      "allowDuplication" : true
+      "allowDuplication": true
     }]
   ],
 
-  "wagnerTreasure" : [
+  "wagnerTreasure": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "pool" : "fuCorpseMeat" },
-        {"weight" : 1.0, "item" : ["wagner3-codex", 1]},
-        {"weight" : 1.0, "item" : ["wagner5-codex", 1]},
-        {"weight" : 1.0, "item" : ["wagneridcard", 1]}
+      "fill": [
+        {"weight": 1.0, "pool": "fuCorpseMeat"},
+        {"weight": 1.0, "item": ["wagner3-codex", 1]},
+        {"weight": 1.0, "item": ["wagner5-codex", 1]},
+        {"weight": 1.0, "item": ["wagneridcard", 1]}
+      ]
+    }]
+  ],
+
+"titanLoot": [
+    [1, {
+      "fill": [
+        {"item": ["stormwarden", 1]}
       ]
     }]
   ],
 
 
-
-"precursorUnlock" : [
+"precursorUnlock": [
     [1, {
-      "fill" : [
-        {"item" : ["sciencebrochure2", 1]}
+      "fill": [
+        {"item": ["sciencebrochure2", 1]}
       ]
-    } ]
+    }]
   ],
 
-"titanLoot" : [
+"fuprecursorLoottechQuestSpecial": [
     [1, {
-      "fill" : [
-        {"item" : ["stormwarden", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["distortionsphere2_tech", 1]},
+        {"weight": 1.0, "item": ["microsphere_tech", 1]}
       ]
-    } ]
+    }]
   ],
 
-"fuprecursorLoottechQuestSpecial" : [
+  "fuprecursorResources": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["distortionsphere2_tech", 1]},
-        {"weight" : 1.0, "item" : ["microsphere_tech", 1]}
-      ]
-    } ]
-  ],
-
-  "fuprecursorResources" : [
-    [1, {
-      "pool" : [
-        {"weight" : 0.05, "item" : [ "polymer", 5]},
-        {"weight" : 0.05, "item" : [ "siliconboard", 1]},
-        {"weight" : 0.05, "item" : [ "laserdiode", 1]},
-        {"weight" : 0.05, "item" : [ "stickofram", 1]},
-        {"weight" : 0.05, "item" : "teleportercore"},
-    	  {"weight" : 0.05, "item" : ["ff_spareparts", 1]},
-    	  {"weight" : 0.05, "item" : ["laserdiode", 1]},
-    	  {"weight" : 0.05, "item" : ["fuprocessor", 1]},
-        {"weight" : 0.05, "item" : "precursorbattery"},
-        {"weight" : 0.05, "item" : "precursorcharger"},
-        {"weight" : 0.05, "item" : "precursorchip"},
-        {"weight" : 0.05, "item" : "precursorcore"},
-        {"weight" : 0.05, "item" : "precursordatadrive"},
-        {"weight" : 0.05, "item" : "precursorfluid"},
-        {"weight" : 0.05, "item" : "precursorfuelcell"},
-        {"weight" : 0.1, "item" : "precursorgel"},
-        {"weight" : 0.1, "item" : "precursorgrease"},
-        {"weight" : 0.05, "item" : "precursorram"},
-        {"weight" : 0.05, "item" : "exoticmatter"},
-        {"weight" : 0.05, "item" : "honedlunari"}
+      "pool": [
+        {"weight": 0.05, "item": ["polymer", 5]},
+        {"weight": 0.05, "item": ["siliconboard", 1]},
+        {"weight": 0.05, "item": ["laserdiode", 1]},
+        {"weight": 0.05, "item": ["stickofram", 1]},
+        {"weight": 0.05, "item": "teleportercore"},
+        {"weight": 0.05, "item": ["ff_spareparts", 1]},
+        {"weight": 0.05, "item": ["laserdiode", 1]},
+        {"weight": 0.05, "item": ["fuprocessor", 1]},
+        {"weight": 0.05, "item": "precursorbattery"},
+        {"weight": 0.05, "item": "precursorcharger"},
+        {"weight": 0.05, "item": "precursorchip"},
+        {"weight": 0.05, "item": "precursorcore"},
+        {"weight": 0.05, "item": "precursordatadrive"},
+        {"weight": 0.05, "item": "precursorfluid"},
+        {"weight": 0.05, "item": "precursorfuelcell"},
+        {"weight": 0.1, "item": "precursorgel"},
+        {"weight": 0.1, "item": "precursorgrease"},
+        {"weight": 0.05, "item": "precursorram"},
+        {"weight": 0.05, "item": "exoticmatter"},
+        {"weight": 0.05, "item": "honedlunari"}
       ],
-      "poolRounds" : [
+      "poolRounds": [
         [0.33, 1],
         [0.43, 2],
         [0.53, 3]
       ],
-      "allowDuplication" : true
-    } ]
+      "allowDuplication": true
+    }]
   ],
 
-  "fuprecursorMedical" : [
+  "fuprecursorMedical": [
     [1, {
-      "pool" : [
-        {"weight" : 0.04, "item" : [ "ultrastim", 1]},
-        {"weight" : 0.04, "item" : [ "thesauce", 1]},
-        {"weight" : 0.04, "item" : [ "shieldpatch", 1]},
-        {"weight" : 0.04, "item" : [ "thesauce", 1]},
-        {"weight" : 0.04, "item" : [ "uberstim", 1]},
-        {"weight" : 0.04, "item" : [ "waterstim", 1]},
-        {"weight" : 0.04, "item" : [ "protostim", 1]},
-        {"weight" : 0.04, "item" : [ "serumstim", 1]},
-        {"weight" : 0.04, "item" : [ "gravstim", 1]},
-        {"weight" : 0.04, "item" : [ "portaljuice", 1]}
+      "pool": [
+        {"weight": 0.04, "item": ["ultrastim", 1]},
+        {"weight": 0.04, "item": ["thesauce", 1]},
+        {"weight": 0.04, "item": ["shieldpatch", 1]},
+        {"weight": 0.04, "item": ["thesauce", 1]},
+        {"weight": 0.04, "item": ["uberstim", 1]},
+        {"weight": 0.04, "item": ["waterstim", 1]},
+        {"weight": 0.04, "item": ["protostim", 1]},
+        {"weight": 0.04, "item": ["serumstim", 1]},
+        {"weight": 0.04, "item": ["gravstim", 1]},
+        {"weight": 0.04, "item": ["portaljuice", 1]}
       ],
-      "poolRounds" : [
+      "poolRounds": [
         [0.33, 1],
         [0.43, 2],
         [0.53, 3]
       ],
-      "allowDuplication" : true
-    } ]
+      "allowDuplication": true
+    }]
   ],
 
-  "fuprecursorLore" : [
+  "fuprecursorLore": [
     [1, {
-      "pool" : [
-    	  {"weight" : 0.2, "item" : "sentrybotcraft2-recipe"},
-    	  {"weight" : 0.1, "item" : "sentrybotcraft3-recipe"},
-    	  {"weight" : 0.3, "item" : "sentrybotdeathdroid-recipe"},
-        {"weight" : 0.1, "item" : "fuprecursorhead-recipe"},
-        {"weight" : 0.1, "item" : "fuprecursorchest-recipe"},
-        {"weight" : 0.1, "item" : "fuprecursorpants-recipe"},
-        {"weight" : 0.1, "item" : "fu_byosteleporterprecursor-recipe"},
-    	  {"weight" : 0.3, "item" : "precursorcodex1-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex2-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex3-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex4-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex5-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex6-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex7-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex8-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex9-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex10-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex11-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex12-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex13-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex14-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex15-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex16-codex"},
-    	  {"weight" : 0.3, "item" : "precursorcodex17-codex"}
+      "pool": [
+        {"weight": 0.2, "item": "sentrybotcraft2-recipe"},
+        {"weight": 0.1, "item": "sentrybotcraft3-recipe"},
+        {"weight": 0.3, "item": "sentrybotdeathdroid-recipe"},
+        {"weight": 0.1, "item": "fuprecursorhead-recipe"},
+        {"weight": 0.1, "item": "fuprecursorchest-recipe"},
+        {"weight": 0.1, "item": "fuprecursorpants-recipe"},
+        {"weight": 0.1, "item": "fu_byosteleporterprecursor-recipe"},
+        {"weight": 0.3, "item": "precursorcodex1-codex"},
+        {"weight": 0.3, "item": "precursorcodex2-codex"},
+        {"weight": 0.3, "item": "precursorcodex3-codex"},
+        {"weight": 0.3, "item": "precursorcodex4-codex"},
+        {"weight": 0.3, "item": "precursorcodex5-codex"},
+        {"weight": 0.3, "item": "precursorcodex6-codex"},
+        {"weight": 0.3, "item": "precursorcodex7-codex"},
+        {"weight": 0.3, "item": "precursorcodex8-codex"},
+        {"weight": 0.3, "item": "precursorcodex9-codex"},
+        {"weight": 0.3, "item": "precursorcodex10-codex"},
+        {"weight": 0.3, "item": "precursorcodex11-codex"},
+        {"weight": 0.3, "item": "precursorcodex12-codex"},
+        {"weight": 0.3, "item": "precursorcodex13-codex"},
+        {"weight": 0.3, "item": "precursorcodex14-codex"},
+        {"weight": 0.3, "item": "precursorcodex15-codex"},
+        {"weight": 0.3, "item": "precursorcodex16-codex"},
+        {"weight": 0.3, "item": "precursorcodex17-codex"}
       ],
-      "poolRounds" : [
+      "poolRounds": [
         [0.33, 1],
         [0.43, 2],
         [0.53, 3]
       ],
-      "allowDuplication" : true
-    } ]
+      "allowDuplication": true
+    }]
   ],
 
-
-  "fuprecursorWeapons" : [
+  "fuprecursorWeapons": [
     [1, {
-      "pool" : [
-        {"weight" : 0.02, "item" :  "fu_precursorbeerback" },
-        {"weight" : 0.04, "item" :  "fu_portablewaterpumpback" },
-        {"weight" : 0.04, "item" :  "fu_bloodsuckingback" },
-        {"weight" : 0.01, "item" : [ "mmgravgun3-recipe", 1]},
-        {"weight" : 0.02, "item" : [ "precursorpistolgrav", 1]},
-        {"weight" : 0.02, "item" : [ "precursorcannon", 1]},
-        {"weight" : 0.02, "item" : [ "precursorfist", 1]},
-        {"weight" : 0.02, "item" : [ "fuvaporizer", 1]},
-        {"weight" : 0.02, "item" : [ "rockethammer", 1]},
-        {"weight" : 0.02, "item" : [ "fudrillspear", 1]},
-        {"weight" : 0.02, "item" : [ "precursorbroadsword", 1]},
-        {"weight" : 0.02, "item" : [ "precursorpistol", 1]},
-        {"weight" : 0.02, "item" : [ "precursorspear", 1]},
-        {"weight" : 0.03, "item" : [ "precursorpistolbeam", 1]},
-        {"weight" : 0.03, "item" : [ "precursorpistolice", 1]},
-        {"weight" : 0.04, "item" : [ "precursorpistolxray", 1]},
-        {"weight" : 0.03, "item" : [ "precursorpistolshock", 1]},
-        {"weight" : 0.005, "item" : [ "precursorcannonnew", 1]},
-        {"weight" : 0.02, "item" : [ "chargesmg", 1]},
-        {"weight" : 0.032, "item" : [ "precursorrapier", 1]},
-        {"weight" : 0.03, "item" : [ "mechgun", 1]},
-        {"weight" : 0.03, "item" : [ "mechpistol", 1]},
-        {"weight" : 0.02, "item" : [ "precursorboomerang", 1]}
+      "pool": [
+        {"weight": 0.02, "item":  "fu_precursorbeerback"},
+        {"weight": 0.04, "item":  "fu_portablewaterpumpback"},
+        {"weight": 0.04, "item":  "fu_bloodsuckingback"},
+        {"weight": 0.01, "item": ["mmgravgun3-recipe", 1]},
+        {"weight": 0.02, "item": ["precursorpistolgrav", 1]},
+        {"weight": 0.02, "item": ["precursorcannon", 1]},
+        {"weight": 0.02, "item": ["precursorfist", 1]},
+        {"weight": 0.02, "item": ["fuvaporizer", 1]},
+        {"weight": 0.02, "item": ["rockethammer", 1]},
+        {"weight": 0.02, "item": ["fudrillspear", 1]},
+        {"weight": 0.02, "item": ["precursorbroadsword", 1]},
+        {"weight": 0.02, "item": ["precursorpistol", 1]},
+        {"weight": 0.02, "item": ["precursorspear", 1]},
+        {"weight": 0.03, "item": ["precursorpistolbeam", 1]},
+        {"weight": 0.03, "item": ["precursorpistolice", 1]},
+        {"weight": 0.04, "item": ["precursorpistolxray", 1]},
+        {"weight": 0.03, "item": ["precursorpistolshock", 1]},
+        {"weight": 0.005, "item": ["precursorcannonnew", 1]},
+        {"weight": 0.02, "item": ["chargesmg", 1]},
+        {"weight": 0.032, "item": ["precursorrapier", 1]},
+        {"weight": 0.03, "item": ["mechgun", 1]},
+        {"weight": 0.03, "item": ["mechpistol", 1]},
+        {"weight": 0.02, "item": ["precursorboomerang", 1]}
       ],
-      "poolRounds" : [
+      "poolRounds": [
         [0.33, 1],
         [0.43, 2],
         [0.53, 3]
       ],
-      "allowDuplication" : true
-    } ]
+      "allowDuplication": true
+    }]
   ],
 
-
-  "fuprecursorLoot" : [
+  "fuprecursorFurniture": [
     [1, {
-      "pool" : [
-        //Pools
-        {"weight" : 0.1, "pool" : "fuEssence" },
-        {"weight" : 0.15, "pool" : "fuprecursorLore" },
-        {"weight" : 0.3, "pool" : "fuprecursorResources" },
-        {"weight" : 0.08, "pool" : "fuprecursorWeapons" },
-        {"weight" : 0.007, "pool" : "artifactloot" },
-        {"weight" : 0.07, "pool" : "augments"},
-        {"weight" : 0.07, "pool" : "petcollars2"},
-        //Furniture
-        {"weight" : 0.03, "item" : "metallicceiling3"},
-        {"weight" : 0.03, "item" : "metallicceiling4"},
-        {"weight" : 0.04, "item" : "metallicmachine1"},
-        {"weight" : 0.04, "item" : "metallicmachine2"},
-        {"weight" : 0.04, "item" : "metallicmachine3"},
-        {"weight" : 0.04, "item" : "metallicmachine4"},
-        {"weight" : 0.04, "item" : "metallicmachine5"},
-        {"weight" : 0.04, "item" : "metallicmachine6"},
-        {"weight" : 0.04, "item" : "metallicmachine7"},
-        {"weight" : 0.03, "item" : "precursoraltar"},
-        {"weight" : 0.03, "item" : "precursoraltar2"},
-        {"weight" : 0.05, "item" : "precursorbackgrounddoor"},
-        {"weight" : 0.05, "item" : "precursorbed"},
-        {"weight" : 0.04, "item" : "precursorbed2"},
-        {"weight" : 0.04, "item" : "precursorchair"},
-        {"weight" : 0.04, "item" : "precursorchair2"},
-        {"weight" : 0.04, "item" : "precursorcrate"},
-        {"weight" : 0.04, "item" : "precursorcratesmall"},
-        {"weight" : 0.05, "item" : "precursordoor"},
-        {"weight" : 0.05, "item" : "precursordoor2"},
-        {"weight" : 0.01, "item" : "precursordroppod"},
-        {"weight" : 0.04, "item" : "precursorenergypod"},
-        {"weight" : 0.04, "item" : "precursorforcelift"},
-        {"weight" : 0.05, "item" : ["precursorlight",2]},
-        {"weight" : 0.05, "item" : ["precursorlightorb",2]},
-        {"weight" : 0.05, "item" : "precursorlightstrip"},
-        {"weight" : 0.05, "item" : "precursorlightstripdim"},
-        {"weight" : 0.04, "item" : "precursormedcabinet"},
-        {"weight" : 0.04, "item" : "precursormonitor"},
-        {"weight" : 0.04, "item" : "precursormonitorhuge"},
-        {"weight" : 0.03, "item" : "precursorobelisk"},
-        {"weight" : 0.02, "item" : "precursorobeliskdual"},
-        {"weight" : 0.04, "item" : "precursorpillar1"},
-        {"weight" : 0.04, "item" : "precursorpillar2"},
-        {"weight" : 0.04, "item" : "precursorscanner"},
-        {"weight" : 0.06, "item" : "precursorshelf"},
-        {"weight" : 0.07, "item" : "precursortable"},
-        {"weight" : 0.04, "item" : "precursortinyswitch"},
-        {"weight" : 0.04, "item" : "precursortinybuttonkey"},
-        {"weight" : 0.04, "item" : "precursortinyswitchkey"},
-        {"weight" : 0.05, "item" : "precursorverticaldoor2"},
-        {"weight" : 0.06, "item" : "precursorweaponrack"},
-        {"weight" : 0.05, "item" : ["precursorrailing",20]},
-        {"weight" : 0.02, "item" : ["precursortallpipe",5]},
-        {"weight" : 0.02, "item" : ["precursorwidepipe",5]},
-        {"weight" : 0.02, "item" : "precursorwidepipehuge"},
-        {"weight" : 0.02, "item" : "precursormatrix"},
-        //Functional
-        {"weight" : 0.01, "item" : "precursorsmelter"},
-        {"weight" : 0.03, "item" : "precursordatabox"},
-        {"weight" : 0.007, "item" : "precursormainframe"},
-        {"weight" : 0.005, "item" : "fu_precursorduplicator"},
-        {"weight" : 0.009, "item" : "fu_precursorspawner"},
-        {"weight" : 0.007, "item" : "fu_fuelpurifiert5"},
-        {"weight" : 0.008, "item" : "precursorconverter" },
-        {"weight" : 0.005, "item" : "precursorconverter2" },
-        {"weight" : 0.005, "item" : "precursorteleporter-recipe" },
-        {"weight" : 0.01, "item" : "precursorbattery1-recipe"},
+      "pool": [
+        {"weight": 0.07, "item": "precursortable"},
+        {"weight": 0.06, "item": "precursorshelf"},
+        {"weight": 0.06, "item": "precursorweaponrack"},
+        {"weight": 0.05, "item": ["precursorrailing",20]},
+        {"weight": 0.05, "item": ["precursorlight",2]},
+        {"weight": 0.05, "item": ["precursorlightorb",2]},
+        {"weight": 0.05, "item": "precursorlightstrip"},
+        {"weight": 0.05, "item": "precursorlightstripdim"},
+        {"weight": 0.05, "item": "precursorbackgrounddoor"},
+        {"weight": 0.05, "item": "precursordoor"},
+        {"weight": 0.05, "item": "precursordoor2"},
+        {"weight": 0.05, "item": "precursorbed"},
+        {"weight": 0.05, "item": "precursorverticaldoor2"},
+        {"weight": 0.04, "item": "precursorbed2"},
+        {"weight": 0.04, "item": "precursorchair"},
+        {"weight": 0.04, "item": "precursorchair2"},
+        {"weight": 0.04, "item": "precursorcrate"},
+        {"weight": 0.04, "item": "precursorcratesmall"},
+        {"weight": 0.04, "item": "precursorenergypod"},
+        {"weight": 0.04, "item": "precursormedcabinet"},
+        {"weight": 0.04, "item": "precursormonitor"},
+        {"weight": 0.04, "item": "precursormonitorhuge"},
+        {"weight": 0.04, "item": "precursorpillar1"},
+        {"weight": 0.04, "item": "precursorpillar2"},
+        {"weight": 0.04, "item": "precursorscanner"},
+        {"weight": 0.04, "item": "precursortinyswitch"},
+        {"weight": 0.04, "item": "precursortinybuttonkey"},
+        {"weight": 0.04, "item": "precursortinyswitchkey"},
+        {"weight": 0.04, "item": "precursorforcelift"},
+        {"weight": 0.04, "item": "metallicmachine1"},
+        {"weight": 0.04, "item": "metallicmachine2"},
+        {"weight": 0.04, "item": "metallicmachine3"},
+        {"weight": 0.04, "item": "metallicmachine4"},
+        {"weight": 0.04, "item": "metallicmachine5"},
+        {"weight": 0.04, "item": "metallicmachine6"},
+        {"weight": 0.04, "item": "metallicmachine7"},
+        {"weight": 0.03, "item": "metallicceiling3"},
+        {"weight": 0.03, "item": "metallicceiling4"},
+        {"weight": 0.03, "item": "precursoraltar"},
+        {"weight": 0.03, "item": "precursoraltar2"},
+        {"weight": 0.03, "item": "precursorobelisk"},
+        {"weight": 0.02, "item": "precursorobeliskdual"},
+        {"weight": 0.02, "item": ["precursortallpipe",5]},
+        {"weight": 0.02, "item": ["precursorwidepipe",5]},
+        {"weight": 0.02, "item": "precursorwidepipehuge"},
+        {"weight": 0.02, "item": "precursormatrix"},
+        {"weight": 0.01, "item": "precursordroppod"}
+      ],
+      "poolRounds": [
+        [1.0, 1]
+      ],
+      "allowDuplication": true
+    }]
+  ],
+
+  "fuprecursorMachines": [
+    [1, {
+      "pool": [
+        {"weight": 0.3, "item": "precursordatabox"},
+        {"weight": 0.1, "item": "precursorsmelter"},
+        {"weight": 0.1, "item": "precursorbattery1-recipe"},
+        {"weight": 0.09, "item": "fu_precursorspawner"},
+        {"weight": 0.08, "item": "precursorconverter"},
+        {"weight": 0.07, "item": "precursormainframe"},
+        {"weight": 0.07, "item": "fu_fuelpurifiert5"},
+        {"weight": 0.05, "item": "fu_precursorduplicator"},
+        {"weight": 0.05, "item": "precursorconverter2"},
+        {"weight": 0.05, "item": "precursorteleporter-recipe"}
+      ],
+      "poolRounds": [
+        [1.0, 1]
+      ],
+      "allowDuplication": true
+    }]
+  ],
+
+  "fuprecursorLoot": [
+    [1, {
+      "pool": [
+        //Pools - Precursor
+        {"weight": 1.80, "pool": "fuprecursorFurniture"},
+        {"weight": 0.30, "pool": "fuprecursorResources"},
+        {"weight": 0.15, "pool": "fuprecursorLore"},
+        {"weight": 0.10, "pool": "fuprecursorMachines"},
+        {"weight": 0.08, "pool": "fuprecursorWeapons"},
+
+        //Pools - Non-Precursor
+        {"weight": 0.1, "pool": "fuEssence"},
+        {"weight": 0.07, "pool": "augments"},
+        {"weight": 0.07, "pool": "petcollars2"},
+        {"weight": 0.007, "pool": "artifactloot"},
+
         //Other + Tools
-        {"weight" : 0.009, "item" : "crewcontract_precursor"},
-        {"weight" : 0.003, "item" : "cuddlehorse"},
-        {"weight" : 0.009, "item" : "fubonearmor3head-recipe"},
-        {"weight" : 0.009, "item" : "fubonearmor3chest-recipe"},
-        {"weight" : 0.009, "item" : "fubonearmor3legs-recipe"},
-        {"weight" : 0.009, "item" : "perpetualaccelerator"},
-        {"weight" : 0.03, "item" : "precursorhookshot"},
-        {"weight" : 0.05, "item" : "railhook3"}
+        {"weight": 0.05, "item": "railhook3"},
+        {"weight": 0.03, "item": "precursorhookshot"},
+        {"weight": 0.009, "item": "crewcontract_precursor"},
+        {"weight": 0.009, "item": "fubonearmor3head-recipe"},
+        {"weight": 0.009, "item": "fubonearmor3chest-recipe"},
+        {"weight": 0.009, "item": "fubonearmor3legs-recipe"},
+        {"weight": 0.009, "item": "perpetualaccelerator"},
+        {"weight": 0.003, "item": "cuddlehorse"}
       ],
-      "poolRounds" : [
+      "poolRounds": [
         [0.33, 1],
         [0.43, 2],
         [0.53, 3]
       ],
-      "allowDuplication" : true
-    } ]
+      "allowDuplication": true
+    }]
   ],
 
-
-  "fuprecursorLootBoss" : [
+  "fuprecursorLootBoss": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["essence", 1500]},
-        {"weight" : 1.0, "item" : {"name" : "mecharmmegacannon-recipe", "count" : 1, "parameters" : {"price" : 12560}}}
+      "fill": [
+        {"weight": 1.0, "item": ["essence", 1500]},
+        {"weight": 1.0, "item": {"name": "mecharmmegacannon-recipe", "count": 1, "parameters": {"price": 12560}}}
       ],
-      "pool" : [
-        {"weight" : 0.1, "pool" :  "fuEssence" },
-        {"weight" : 0.2, "pool" :  "fuprecursorLore" },
-        {"weight" : 0.5, "pool" :  "fuprecursorResources" },
-        {"weight" : 0.1, "pool" :  "fuprecursorWeapons" },
-        {"weight" : 0.007, "pool" : "artifactloot" },
-        {"weight" : 0.07, "pool" : "augments"},
-        {"weight" : 0.07, "pool" : "petcollars2"},
-        {"weight" : 0.03, "item" : "Bigcannonsml_totalblazing"},
-        {"weight" : 0.03, "item" : "PrecursorRailgunsmll_totalblazing"},
-        {"weight" : 0.03, "item" : "PrecursorSmallGun_totalblazing"}
+      "pool": [
+        {"weight": 0.1, "pool":  "fuEssence"},
+        {"weight": 0.2, "pool":  "fuprecursorLore"},
+        {"weight": 0.5, "pool":  "fuprecursorResources"},
+        {"weight": 0.1, "pool":  "fuprecursorWeapons"},
+        {"weight": 0.007, "pool": "artifactloot"},
+        {"weight": 0.07, "pool": "augments"},
+        {"weight": 0.07, "pool": "petcollars2"},
+        {"weight": 0.03, "item": "Bigcannonsml_totalblazing"},
+        {"weight": 0.03, "item": "PrecursorRailgunsmll_totalblazing"},
+        {"weight": 0.03, "item": "PrecursorSmallGun_totalblazing"}
       ],
-      "poolRounds" : [
+      "poolRounds": [
         [0.33, 1],
         [0.43, 2],
         [0.53, 3]
       ],
-      "allowDuplication" : true
-    } ]
+      "allowDuplication": true
+    }]
   ],
 
 
-  "fuStrangeFood" : [
+  "fuStrangeFood": [
     [1, {
-      "pool" : [
-        {"weight" : 0.07, "item" :  [ "deliciousmeat", 1]},
-        {"weight" : 0.07, "item" :  [ "crunchychick", 1]},
-        {"weight" : 0.07, "item" :  [ "alienmeat", 1]},
-        {"weight" : 0.07, "item" :  [ "honeyham", 1]},
-		{"weight" : 0.07, "item" : ["orphanpaste", 1]},
-        {"weight" : 0.03, "pool" : "foodTreasureMedium"}
+      "pool": [
+        {"weight": 0.07, "item":  ["deliciousmeat", 1]},
+        {"weight": 0.07, "item":  ["crunchychick", 1]},
+        {"weight": 0.07, "item":  ["alienmeat", 1]},
+        {"weight": 0.07, "item":  ["honeyham", 1]},
+        {"weight": 0.07, "item": ["orphanpaste", 1]},
+        {"weight": 0.03, "pool": "foodTreasureMedium"}
       ],
-      "poolRounds" : [
+      "poolRounds": [
         [0.53, 1],
         [0.63, 2],
         [0.73, 3]
       ],
-      "allowDuplication" : true
-    } ]
+      "allowDuplication": true
+    }]
   ],
-  "fuCorpseMeat" : [
+  "fuCorpseMeat": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["deliciousmeat", 1]},
-        {"weight" : 1.0, "item" : ["humaneyeball", 1]},
-        {"weight" : 1.0, "item" : ["humaneyeball", 1]},
-        {"weight" : 1.0, "item" : ["severedear", 1]},
-        {"weight" : 1.0, "item" : ["severedear", 1]},
-        {"weight" : 1.0, "item" : ["faceskin", 1]},
-        {"weight" : 1.0, "item" : ["rawribmeat", 1]},
-		{"weight" : 1.0, "item" : ["orphanpaste", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["deliciousmeat", 1]},
+        {"weight": 1.0, "item": ["humaneyeball", 1]},
+        {"weight": 1.0, "item": ["humaneyeball", 1]},
+        {"weight": 1.0, "item": ["severedear", 1]},
+        {"weight": 1.0, "item": ["severedear", 1]},
+        {"weight": 1.0, "item": ["faceskin", 1]},
+        {"weight": 1.0, "item": ["rawribmeat", 1]},
+        {"weight": 1.0, "item": ["orphanpaste", 1]}
       ]
     }]
   ],
-  "macreadyTreasure" : [
+  "macreadyTreasure": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["elder_research2-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["elder_research2-codex", 1]}
       ]
     }]
   ],
-  "wagner1Treasure" : [
+  "wagner1Treasure": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["wagner1-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["wagner1-codex", 1]}
       ]
     }]
   ],
-  "wagner2Treasure" : [
+  "wagner2Treasure": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["wagner2-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["wagner2-codex", 1]}
       ]
     }]
   ],
-  "cthulurewardtreasure" : [
+  "cthulurewardtreasure": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["cthulureward", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["cthulureward", 1]}
       ]
     }]
   ],
-  "evilbooktreasure1" : [
+  "evilbooktreasure1": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["blackbook2k-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["blackbook2k-codex", 1]}
       ]
     }]
   ],
-  "evilbooktreasure2" : [
+  "evilbooktreasure2": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["blackbook2-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["blackbook2-codex", 1]}
       ]
     }]
   ],
-  "evilbooktreasure3" : [
+  "evilbooktreasure3": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["blackbook3-codex", 1]},
-        {"weight" : 1.0, "item" : ["blackbook8-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["blackbook3-codex", 1]},
+        {"weight": 1.0, "item": ["blackbook8-codex", 1]}
       ]
     }]
   ],
-  "evilbooktreasure3a" : [
+  "evilbooktreasure3a": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["blackbook3-codex", 1]},
-        {"weight" : 1.0, "item" : ["blackbook1k-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["blackbook3-codex", 1]},
+        {"weight": 1.0, "item": ["blackbook1k-codex", 1]}
       ]
     }]
   ],
-  "evilbooktreasure3b" : [
+  "evilbooktreasure3b": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["blackbook3k-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["blackbook3k-codex", 1]}
       ]
     }]
   ],
-  "evilbooktreasure4" : [
+  "evilbooktreasure4": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["blackbook4-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["blackbook4-codex", 1]}
       ]
     }]
   ],
-  "evilbooktreasure4a" : [
+  "evilbooktreasure4a": [
     [1, {
-      "fill" : [
-        {"weight" : 1.0, "item" : ["blackbook2k-codex", 1]}
+      "fill": [
+        {"weight": 1.0, "item": ["blackbook2k-codex", 1]}
       ]
     }]
   ],
-  "evilbooktreasure5" : [
+  "evilbooktreasure5": [
     [1, {
-      "pool" : [
-        {"weight" : 0.07, "item" :  [ "blackbook1-codex", 1]},
-        {"weight" : 0.07, "item" :  [ "blackbook2-codex", 1]},
-        {"weight" : 0.07, "item" :  [ "blackbook3-codex", 1]},
-        {"weight" : 0.07, "item" :  [ "blackbook4-codex", 1]},
-        {"weight" : 0.07, "item" :  [ "blackbook5-codex", 1]},
-        {"weight" : 0.07, "item" :  [ "blackbook6-codex", 1]},
-        {"weight" : 0.07, "item" :  [ "blackbook7-codex", 1]},
-        {"weight" : 0.07, "item" :  [ "blackbook8-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderarmorbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderbladebook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "eldercarbinebook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "eldergrapplerbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderpistolbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderripperbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderspearbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderwhipbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderrepeaterbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "cultarmorchestbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "cultarmorheadbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "cultarmorpantsbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderstaffbook1-codex", 1]},
-        {"weight" : 0.02, "item" :  ["eldershotgunbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderstaffbook2-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderstaffbook3-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderbowbook-codex", 1]},
-        {"weight" : 0.02, "item" :  [ "elderbroadswordbook-codex", 1]},
-          {"weight" : 0.01, "item" : ["attunedpaper", 15]},
-          {"weight" : 0.01, "item" : ["nicepaper", 20]}
+      "pool": [
+        {"weight": 0.07, "item":  ["blackbook1-codex", 1]},
+        {"weight": 0.07, "item":  ["blackbook2-codex", 1]},
+        {"weight": 0.07, "item":  ["blackbook3-codex", 1]},
+        {"weight": 0.07, "item":  ["blackbook4-codex", 1]},
+        {"weight": 0.07, "item":  ["blackbook5-codex", 1]},
+        {"weight": 0.07, "item":  ["blackbook6-codex", 1]},
+        {"weight": 0.07, "item":  ["blackbook7-codex", 1]},
+        {"weight": 0.07, "item":  ["blackbook8-codex", 1]},
+        {"weight": 0.02, "item":  ["elderarmorbook-codex", 1]},
+        {"weight": 0.02, "item":  ["elderbladebook-codex", 1]},
+        {"weight": 0.02, "item":  ["eldercarbinebook-codex", 1]},
+        {"weight": 0.02, "item":  ["eldergrapplerbook-codex", 1]},
+        {"weight": 0.02, "item":  ["elderpistolbook-codex", 1]},
+        {"weight": 0.02, "item":  ["elderripperbook-codex", 1]},
+        {"weight": 0.02, "item":  ["elderspearbook-codex", 1]},
+        {"weight": 0.02, "item":  ["elderwhipbook-codex", 1]},
+        {"weight": 0.02, "item":  ["elderrepeaterbook-codex", 1]},
+        {"weight": 0.02, "item":  ["cultarmorchestbook-codex", 1]},
+        {"weight": 0.02, "item":  ["cultarmorheadbook-codex", 1]},
+        {"weight": 0.02, "item":  ["cultarmorpantsbook-codex", 1]},
+        {"weight": 0.02, "item":  ["elderstaffbook1-codex", 1]},
+        {"weight": 0.02, "item":  ["eldershotgunbook-codex", 1]},
+        {"weight": 0.02, "item":  ["elderstaffbook2-codex", 1]},
+        {"weight": 0.02, "item":  ["elderstaffbook3-codex", 1]},
+        {"weight": 0.02, "item":  ["elderbowbook-codex", 1]},
+        {"weight": 0.02, "item":  ["elderbroadswordbook-codex", 1]},
+        {"weight": 0.01, "item": ["attunedpaper", 15]},
+        {"weight": 0.01, "item": ["nicepaper", 20]}
       ],
-      "poolRounds" : [
+      "poolRounds": [
         [0.23, 1],
         [0.33, 2],
         [0.33, 3],
         [0.33, 4],
         [0.33, 5]
       ],
-      "allowDuplication" : true
+      "allowDuplication": true
       }
     ]
   ]


### PR DESCRIPTION
(Not changelog)
fuprecursorLoot was too large and unwieldy to easily balance new additions, so I split the furniture and machines off into two separate pools, fuprecursorFurniture and fuprecursorMachines, and added the pools back to fuprecursorLoot with ~equal weighting to what the sum of their items originally had.