### PR TITLE
craft swamp water

### DIFF
--- a/recipes/chemlab/liquids/swampwater.recipe
+++ b/recipes/chemlab/liquids/swampwater.recipe
@@ -1,0 +1,13 @@
+{
+  "input" : [
+    { "item" : "liquidwater", "count" : 3 },
+    { "item" : "algaegreen", "count" : 2 },
+    { "item" : "mud", "count" : 1 }
+  ],
+  "output" : {
+    "item" : "swampwater",
+    "count" : 3
+  },
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
+  "duration" : 0.25
+}

--- a/zb/researchTree/fu_chemistry.config
+++ b/zb/researchTree/fu_chemistry.config
@@ -155,7 +155,7 @@
         "position" : [40, -35],
         "children" : [ "liquidcrafting2", "mechfuel" ],
         "price" : [["fuscienceresource", 350], ["liquidwater", 50], ["fu_hydrogen", 15]],
-        "unlocks" : [ "cellmateria", "liquidblacktar", "liquidpoison", "liquidwater", "fusaltwater", "liquidpus", "waterball" ]
+        "unlocks" : [ "cellmateria", "liquidblacktar", "liquidpoison", "liquidwater", "fusaltwater", "liquidpus", "swampwater", "waterball" ]
       },
       "liquidcrafting2" : {
         "icon" : "/items/liquids/ff_mercury.png",


### PR DESCRIPTION
Allows you to craft swamp water, unlocked at basic liquid crafting. Nothing too special.
It may be better to leave this liquid as a biome exclusive resource (assuming you want to centrifuge it for an infinite quantity of mud for some reason) however I am using salt water as a precedent for its inclusion as its circumstances and creation are similar to that of salt water.
I need to test this in game just to make sure it's fine first. I'm pretty sure I have the ids correct here but it doesn't hurt to be on the safe side. 