### PR TITLE
Reduce lava efficiency in dynamo

### DIFF
--- a/objects/power/hydraulicdynamo/hydraulicdynamo.object
+++ b/objects/power/hydraulicdynamo/hydraulicdynamo.object
@@ -44,7 +44,7 @@
   "fuels" : {
       "corefragmentore" :  { "power" : 5,  "decayRate" : 40  },
       "liquidnitrogenitem" : { "power" : 6,  "decayRate" : 20 },
-      "liquidlava" :  { "power" : 5,  "decayRate" : 15  },
+      "liquidlava" :  { "power" : 4,  "decayRate" : 10  },
       "liquidironfu" :  { "power" : 6,  "decayRate" : 32  },
       "volatilepowder" :  { "power" : 7,  "decayRate" : 40  },
       "scorchedcore" :  { "power" : 7,  "decayRate" : 180  }


### PR DESCRIPTION
Lava dynamos are a little too good. They're an excellent tutorial on power automation (hook up a well and a pump to the core and start producing cheap power) but lava was good enough that the other fuels weren't good enough of a step up IMO. It's still a clear improvement over the alternator but it should also incentivize producing more complex fuels (such as core fragments, volatile powder, or liquid iron, which can be refined from centrifigued lava as an example). 15w was just a little bit too high for the ease of automating it had and 12w is a little more fair.

It could even go down to 3w per lava but this may be too extreme.
