### PR TITLE
Fixed typo

### DIFF
--- a/scripts/fr_diets.config
+++ b/scripts/fr_diets.config
@@ -89,7 +89,7 @@
 		"piscivore"       : [ { "ORGANIC" : false, "FISH" : true },{ "PLANT" : true, "MEAT" : true } ],
 		"herbivore"       : [ { "ORGANIC" : false, "PLANT" : true }, { "MEAT" : true, "EGG" : true } ],
 		"robot"           : [ { "ROBOT_PLANT" : true } ],
-		"lithivore"       : [ { "ROCK": true } ],
+		"lithovore"       : [ { "ROCK": true } ],
 
 		// Entities - like Novakids, X'i, etc. can eat pretty much anything, but they don't get any bonuses
 		"entity"          : [ { "ORGANIC" : false, "INORGANIC" : false, "ROBOT_PLANT" : false } ]


### PR DESCRIPTION
(Not changelog) Lithivore -> Lithovore. This is a change to code and not visible text, but no supported races are lithovores (or lithivores) so it's unlikely to cause problems.