### PR TITLE
Mites spawn and Mite resist changes

### DIFF
--- a/bees/apiary.lua
+++ b/bees/apiary.lua
@@ -895,8 +895,10 @@ end
 function miteGrowth()
 	if storage.mites > 0 then
 
-	        --display an infested hive image over the normal hive appearance if its infested enough
-		if storage.mites > 50 then  --if mites pass 100, display a rotten looking apiary
+		--display an infested hive image over the normal hive appearance if its infested enough
+		if storage.mites > 1 then --display warning but dont change apiary look
+		  animator.setAnimationState("warning", "on", true) --show symbol for mite infestation, but dont change apiary look
+		elseif storage.mites > 50 then  --if mites pass 100, display a rotten looking apiary
 		  animator.setAnimationState("base", "infested", true)
 		  animator.setAnimationState("warning", "on", true)
 		elseif storage.mites > 200 then  --if mites pass 200, display a really rotten looking apiary
@@ -918,7 +920,7 @@ function miteGrowth()
 			local item = contents[slot]
 			if item and root.itemHasTag(item.name, "bee") and root.itemHasTag(item.name, "drone") then
 				hiveMiteResistance = hiveMiteResistance + genelib.statFromGenomeToValue(item.parameters.genome, "miteResistance") + frameBonuses.miteResistance
-				droneCount = droneCount + 1
+				droneCount = droneCount + contents[slot].count --loops through drone slots and adds them together
 			end
 		end
 
@@ -927,10 +929,10 @@ function miteGrowth()
 		-- If the value is negative, the hive is weaker to mites, and the multiplier is multiplied by the stat (a non-negative version of it that is)
 		if droneCount > 0 then
 			hiveMiteResistance = hiveMiteResistance / droneCount
-
 			-- we create a little function that improves as resistance does
 			if hiveMiteResistance > 0 then
-				mult = math.max(mult / (hiveMiteResistance*100), beeData.mites.growthPercentileMinimum)
+				mult = math.max(mult / (hiveMiteResistance*3125), beeData.mites.growthPercentileMinimum)
+				-- 3125 makes mite resist 4.0 stop mites with full apiary, 50 drones balances at 0.2 mite resist. Change if different balance desired
 			elseif hiveMiteResistance < 0 then
 				mult = mult + mult * math.abs(hiveMiteResistance)
 			end
@@ -938,7 +940,7 @@ function miteGrowth()
 
 		-- remove the hive resistance from the mite total if over a certain threshold, otherwise increment them
 		if hiveMiteResistance > 0 then
-		  storage.mites = storage.mites - (hiveMiteResistance)
+		  storage.mites = storage.mites + (storage.mites * mult) - (hiveMiteResistance) -- added storage.mites*mult to balance mite growth against hive resistance
 		else
 	          storage.mites = storage.mites + (storage.mites * mult) + beeData.mites.growthStatic
 		end

--- a/bees/beeData.config
+++ b/bees/beeData.config
@@ -181,7 +181,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 1200,
 				"mutationChance" : 3,
-				"miteResistance" : 25,
+				"miteResistance" : 2.5,
 				"workTime" : 0,
 
 				"production" : {
@@ -202,7 +202,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 900,
 				"mutationChance" : 5,
-				"miteResistance" : 23,
+				"miteResistance" : 2.3,
 				"workTime" : 0,
 
 				"production" : {
@@ -226,7 +226,7 @@
 				"queenBreedRate" : 2,
 				"queenLifespan" : 1000,
 				"mutationChance" : 2,
-				"miteResistance" : 2,
+				"miteResistance" : 0.4,
 				"workTime" : 0,
 
 				"production" : {
@@ -248,7 +248,7 @@
 				"queenBreedRate" : 2,
 				"queenLifespan" : 800,
 				"mutationChance" : 8,
-				"miteResistance" : 1,
+				"miteResistance" : 0.8,
 				"workTime" : 0,
 
 				"production" : {
@@ -273,7 +273,7 @@
 				"queenBreedRate" : 3,
 				"queenLifespan" : 450,
 				"mutationChance" : 8,
-				"miteResistance" : 13,
+				"miteResistance" : 1.3,
 				"workTime" : 2,
 
 				"production" : {
@@ -298,7 +298,7 @@
 				"queenBreedRate" : 7,
 				"queenLifespan" : 330,
 				"mutationChance" : 24,
-				"miteResistance" : 11,
+				"miteResistance" : 1.2,
 				"workTime" : 0,
 
 				"production" : {
@@ -327,7 +327,7 @@
 				"queenBreedRate" : 3,
 				"queenLifespan" : 600,
 				"mutationChance" : 3.34,
-				"miteResistance" : 9,
+				"miteResistance" : 3.7,
 				"workTime" : 1,
 
 				"production" : {
@@ -349,7 +349,7 @@
 				"queenBreedRate" : 3,
 				"queenLifespan" : 600,
 				"mutationChance" : 3.34,
-				"miteResistance" : 12,
+				"miteResistance" : 2.7,
 				"workTime" : 1,
 
 				"production" : {
@@ -374,7 +374,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 1200,
 				"mutationChance" : 1.2,
-				"miteResistance" : 6,
+				"miteResistance" : 1.5,
 				"workTime" : 1,
 
 				"production" : {
@@ -397,7 +397,7 @@
 				"queenBreedRate" : 3,
 				"queenLifespan" : 700,
 				"mutationChance" : 1,
-				"miteResistance" : 16,
+				"miteResistance" : 1.8,
 				"workTime" : 1,
 
 				"production" : {
@@ -423,7 +423,7 @@
 				"queenBreedRate" : 4,
 				"queenLifespan" : 400,
 				"mutationChance" : 3,
-				"miteResistance" : 9,
+				"miteResistance" : 2.3,
 				"workTime" : 0,
 
 				"production" : {
@@ -445,7 +445,7 @@
 				"queenBreedRate" : 2,
 				"queenLifespan" : 600,
 				"mutationChance" : 0.6,
-				"miteResistance" : 7,
+				"miteResistance" : 2.5,
 				"workTime" : 0,
 
 				"production" : {
@@ -470,7 +470,7 @@
 				"queenBreedRate" : 2,
 				"queenLifespan" : 500,
 				"mutationChance" : 15,
-				"miteResistance" : 9,
+				"miteResistance" : 2.3,
 				"workTime" : 1,
 
 				"production" : {
@@ -493,7 +493,7 @@
 				"queenBreedRate" : 2,
 				"queenLifespan" : 1200,
 				"mutationChance" : 1,
-				"miteResistance" : 22,
+				"miteResistance" : 3.5,
 				"workTime" : 1,
 
 				"production" : {
@@ -518,7 +518,7 @@
 				"queenBreedRate" : 4,
 				"queenLifespan" : 600,
 				"mutationChance" : 3.34,
-				"miteResistance" : 36,
+				"miteResistance" : 3.6,
 				"workTime" : 1,
 
 				"production" : {
@@ -547,7 +547,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 600,
 				"mutationChance" : 0.05,
-				"miteResistance" : 24,
+				"miteResistance" : 2.4,
 				"workTime" : 0,
 
 				"production" : {
@@ -724,7 +724,7 @@
 				"queenBreedRate" : 2,
 				"queenLifespan" : 1000,
 				"mutationChance" : 1,
-				"miteResistance" : 13,
+				"miteResistance" : 1.3,
 				"workTime" : 0,
 
 				"production" : {
@@ -747,7 +747,7 @@
 				"queenBreedRate" : 2,
 				"queenLifespan" : 550,
 				"mutationChance" : 1,
-				"miteResistance" : 11,
+				"miteResistance" : 1.1,
 				"workTime" : 1,
 
 				"production" : {
@@ -864,7 +864,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 450,
 				"mutationChance" : 8,
-				"miteResistance" : 23,
+				"miteResistance" : 4,
 				"workTime" : 2,
 
 				"production" : {
@@ -920,7 +920,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 500,
 				"mutationChance" : 1.5,
-				"miteResistance" : 7,
+				"miteResistance" : 5,
 				"workTime" : 1,
 
 				"production" : {
@@ -947,7 +947,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 700,
 				"mutationChance" : 2,
-				"miteResistance" : 8,
+				"miteResistance" : 4,
 				"workTime" : 1,
 
 				"production" : {
@@ -1068,7 +1068,7 @@
 		"aquarum" : [
 			{
 				"name" : "aquarum",
-				"baseProduction" : 0.8,
+				"baseProduction" : 1,
 				"droneToughness" : 22,
 				"droneBreedRate" : 2,
 				"queenBreedRate" : 1,
@@ -1097,7 +1097,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 900,
 				"mutationChance" : 1,
-				"miteResistance" : 11,
+				"miteResistance" : 5.5,
 				"workTime" : 2,
 
 				"production" : {
@@ -1122,7 +1122,7 @@
 				"queenBreedRate" : 2,
 				"queenLifespan" : 300,
 				"mutationChance" : 5,
-				"miteResistance" : 13,
+				"miteResistance" : 4,
 				"workTime" : 0,
 
 				"production" : {
@@ -1146,7 +1146,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 900,
 				"mutationChance" : 2,
-				"miteResistance" : 9,
+				"miteResistance" : 4,
 				"workTime" : 0,
 
 				"production" : {
@@ -1201,7 +1201,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 562,
 				"mutationChance" : 1,
-				"miteResistance" : 8,
+				"miteResistance" : 2.2,
 				"workTime" : 1,
 
 				"production" : {
@@ -1232,7 +1232,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 600,
 				"mutationChance" : 3,
-				"miteResistance" : 16,
+				"miteResistance" : 1.6,
 				"workTime" : 0,
 
 				"production" : {
@@ -1288,7 +1288,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 1100,
 				"mutationChance" : 1,
-				"miteResistance" : 25,
+				"miteResistance" : 2.5,
 				"workTime" : 1,
 
 				"production" : {
@@ -1315,7 +1315,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 900,
 				"mutationChance" : 2,
-				"miteResistance" : 55,
+				"miteResistance" : 5.5,
 				"workTime" : 2,
 
 				"production" : {
@@ -1488,7 +1488,7 @@
 				"queenBreedRate" : 3,
 				"queenLifespan" : 1300,
 				"mutationChance" : 1,
-				"miteResistance" : 14,
+				"miteResistance" : 4,
 				"workTime" : 0,
 
 				"production" : {
@@ -1511,7 +1511,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 800,
 				"mutationChance" : 2,
-				"miteResistance" : 19,
+				"miteResistance" : 5,
 				"workTime" : 0,
 
 				"production" : {
@@ -1628,7 +1628,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 821,
 				"mutationChance" : 3,
-				"miteResistance" : 11,
+				"miteResistance" : 3.4,
 				"workTime" : 0,
 
 				"production" : {
@@ -1670,7 +1670,7 @@
 				"queenBreedRate" : 1,
 				"queenLifespan" : 800,
 				"mutationChance" : 7,
-				"miteResistance" : 7,
+				"miteResistance" : 5,
 				"workTime" : 2,
 
 				"production" : {
@@ -1760,7 +1760,7 @@
 				"queenBreedRate" : 2,
 				"queenLifespan" : 500,
 				"mutationChance" : 2,
-				"miteResistance" : 15,
+				"miteResistance" : 3.6,
 				"workTime" : 2,
 
 				"production" : {


### PR DESCRIPTION
Mite spawns were changed in the apiary to allow for them to spawn when mite resist is positive.
Starting values for wild bees have been changed to be compliant with the mite resists stats prior to my changes (i.e., above 6.47) and other bees' mite resists were lowered to introduce new players to the mite mechanic (e.g., honey bees)