### PR TITLE
Added flamethrower tag to vanilla flamethrower

### DIFF
--- a/items/active/weapons/ranged/flamethrower/flamethrower.activeitem.patch
+++ b/items/active/weapons/ranged/flamethrower/flamethrower.activeitem.patch
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "add",
+    "path": "/itemTags/-",
+    "value": "flamethrower"
+  }
+]


### PR DESCRIPTION
- The vanilla Flamethrower is now buffed by flamethrower-boosting sets.