### PR TITLE
Vine and medicine fix

### DIFF
--- a/biomes/core/puscorelayer.biome
+++ b/biomes/core/puscorelayer.biome
@@ -129,7 +129,7 @@
           "type" : "tree",
           "treeFoliageHueShiftMax" : 220,
           "treeStemHueShiftMax" : 220,
-          "treeStemList" : [  "fleshvine_atropus", "fleshvine2", "podvine" ],
+          "treeStemList" : [  "fleshvine_atropus", "fleshvine2", "podvine2" ],
           "treeFoliageList" : [ "nofoliagevine" ]
         },
         {

--- a/biomes/surface/thickjungle.biome
+++ b/biomes/surface/thickjungle.biome
@@ -829,7 +829,7 @@
           "type" : "tree",
           "treeFoliageHueShiftMax" : 180,
           "treeStemHueShiftMax" : 40,
-          "treeStemList" : [ "vineroot2", "vine2a", "floweryvine", "twistedvine2", "wildernessvine" ],
+          "treeStemList" : [ "vineroot2", "vine2a", "floweryvine2", "twistedvine2", "wildernessvine" ],
           "treeFoliageList" : [ "nofoliagevine", "starry2", "dreamy2", "starry2", "dreamy", "flowery", "starry" ]
         }
       ]

--- a/biomes/surface_detached/flowerforest.biome
+++ b/biomes/surface_detached/flowerforest.biome
@@ -432,8 +432,8 @@
         "type" : "tree",
         "treeFoliageHueShiftMax" : 0,
         "treeStemHueShiftMax" : 40,
-        "treeStemList" : [ "floweryvine" ],
-        "treeFoliageList" : [ "" ]
+        "treeStemList" : [ "floweryvine2" ],
+        "treeFoliageList" : [ "nofoliagevine" ]
       }
     ]
   }

--- a/biomes/surface_detached/spring.biome.patch
+++ b/biomes/surface_detached/spring.biome.patch
@@ -145,6 +145,16 @@
     }
   },
   {
+    "op": "replace",
+    "path": "/undergroundPlaceables/items/1/treeStemList/0",
+    "value": "floweryvine2"
+  },
+  {
+    "op": "replace",
+    "path": "/undergroundPlaceables/items/1/treeFoliageList/0",
+    "value": "nofoliagevine"
+  },
+  {
     "op": "add",
     "path": "/undergroundPlaceables/items/-",
     "value":

--- a/biomes/underground/atropusunderground.biome
+++ b/biomes/underground/atropusunderground.biome
@@ -218,7 +218,7 @@
           "type" : "tree",
           "treeFoliageHueShiftMax" : 220,
           "treeStemHueShiftMax" : 220,
-          "treeStemList" : [ "fleshvine_atropus", "fleshvine2", "podvine", "bloodvine"],
+          "treeStemList" : [ "fleshvine_atropus", "fleshvine2", "podvine2", "bloodvine"],
           "treeFoliageList" : [ "nofoliagevine" ]
         },
         {

--- a/biomes/underground/chromaticunderground.biome
+++ b/biomes/underground/chromaticunderground.biome
@@ -280,7 +280,7 @@
           "type" : "tree",
           "treeFoliageHueShiftMax" : 180,
           "treeStemHueShiftMax" : 180,
-          "treeStemList" : [ "vineroot2", "vine2a", "floweryvine", "twistedvine2" ],
+          "treeStemList" : [ "vineroot2", "vine2a", "floweryvine2", "twistedvine2" ],
           "treeFoliageList" : [ "nofoliagevine", "starry2", "dreamy2", "starry2" ]
         },
       {

--- a/biomes/underground/sulphuricunderground.biome
+++ b/biomes/underground/sulphuricunderground.biome
@@ -232,8 +232,8 @@
         "type" : "tree",
         "treeFoliageHueShiftMax" : 180,
         "treeStemHueShiftMax" : 180,
-        "treeStemList" : [ "twistedvine" ],
-        "treeFoliageList" : [ "dreamy" ]
+        "treeStemList" : [ "twistedvine2" ],
+        "treeFoliageList" : [ "dreamy2" ]
       },
       {
         "mode" : "floor",

--- a/biomes/underground/thickjungleunderground.biome
+++ b/biomes/underground/thickjungleunderground.biome
@@ -254,7 +254,7 @@
           "type" : "tree",
           "treeFoliageHueShiftMax" : 180,
           "treeStemHueShiftMax" : 180,
-          "treeStemList" : [ "vineroot2", "vine2a", "floweryvine", "twistedvine2" ],
+          "treeStemList" : [ "vineroot2", "vine2a", "floweryvine2", "twistedvine2" ],
           "treeFoliageList" : [ "nofoliagevine", "starry2", "dreamy2", "starry2" ]
         },
       {

--- a/biomes/underground_detached/atropusboneunderground.biome
+++ b/biomes/underground_detached/atropusboneunderground.biome
@@ -236,7 +236,7 @@
           "type" : "tree",
           "treeFoliageHueShiftMax" : 220,
           "treeStemHueShiftMax" : 220,
-          "treeStemList" : [ "fleshvine_atropus", "fleshvine2", "podvine" ],
+          "treeStemList" : [ "fleshvine_atropus", "fleshvine2", "podvine2" ],
           "treeFoliageList" : [ "nofoliagevine" ]
         },
         {

--- a/biomes/underground_detached/atropusrotunderground.biome
+++ b/biomes/underground_detached/atropusrotunderground.biome
@@ -218,7 +218,7 @@
           "type" : "tree",
           "treeFoliageHueShiftMax" : 220,
           "treeStemHueShiftMax" : 220,
-          "treeStemList" : [ "fleshvine_atropus", "fleshvine2", "podvine" ],
+          "treeStemList" : [ "fleshvine_atropus", "fleshvine2", "podvine2" ],
           "treeFoliageList" : [ "nofoliagevine" ]
         },
         {

--- a/biomes/underground_detached/old/hive/hiveold.biome.patch
+++ b/biomes/underground_detached/old/hive/hiveold.biome.patch
@@ -67,5 +67,15 @@
 
     "items" : []
   }
-}
+},
+  {
+    "op": "replace",
+    "path": "/undergroundPlaceables/items/3/treeStemList/0",
+    "value": "podvine2"
+  },
+  {
+    "op": "add",
+    "path": "/undergroundPlaceables/items/3/treeFoliageList",
+    "value": [ "nofoliagevine" ]
+  }
 ]

--- a/items/generic/loot/devilsbargain.consumable
+++ b/items/generic/loot/devilsbargain.consumable
@@ -8,5 +8,6 @@
   "shortdescription": "The Devil's Bargain",
   "effects": [["devilsbargain", "madnessgain2"]],
   "tooltipKind": "food",
+  "emitters": [ "stimuse" ],
   "blockingEffects": ["wellfed", "devilsbargain"]
 }

--- a/items/generic/loot/drugdirt.consumable
+++ b/items/generic/loot/drugdirt.consumable
@@ -7,5 +7,6 @@
   "description": "Dirt, but in dose-size quantities for X'i to use recreationally as a psychotropic.\n^red;Drunk^gray;, ^white;35% ^red;Slow^gray;, ^red;-^white;20 ^red;HP ^gray;(^white;4m^gray;) (^white;X'i Only^gray;)^reset;",
   "shortdescription": "Dirt (5g)",
   "tooltipKind": "food",
-  "effects": [["radiendirt"]]
+  "effects": [["radiendirt"]],
+  "emitters": [ "bandageuse" ]
 }

--- a/items/generic/loot/fudeathstick.consumable
+++ b/items/generic/loot/fudeathstick.consumable
@@ -13,5 +13,6 @@
     {"effect" : "maxenergyboost2", "duration" : 220}
   ] ],
   "tooltipKind" : "food",
+  "emitters" : [ "bandageuse" ],
   "blockingEffects" : [ "strongcoffee4" ]
 }

--- a/items/generic/loot/fudietpill.consumable
+++ b/items/generic/loot/fudietpill.consumable
@@ -10,5 +10,6 @@
     "dietpill",
     {"effect" : "defenseboostneg20", "duration" : 300}
   ] ],
-  "tooltipKind" : "food"
+  "tooltipKind" : "food",
+  "emitters" : [ "drinking" ]
 }

--- a/items/generic/loot/fupilldrug.consumable
+++ b/items/generic/loot/fupilldrug.consumable
@@ -14,5 +14,6 @@
     {"effect" : "insanity", "duration" : 220}
   ] ],
   "tooltipKind" : "food",
+  "emitters" : [ "drinking" ],
   "blockingEffects" : [ "strongcoffee4" ]
 }

--- a/items/generic/loot/fushroomspore.consumable
+++ b/items/generic/loot/fushroomspore.consumable
@@ -13,5 +13,6 @@
     {"effect" : "insanity", "duration" : 520}
   ] ],
   "tooltipKind" : "food",
+  "emitters" : [ "bandageuse" ],
   "blockingEffects" : [ "strongcoffee4" ]
 }

--- a/items/generic/loot/futeltikparasite.consumable
+++ b/items/generic/loot/futeltikparasite.consumable
@@ -13,5 +13,6 @@
     {"effect" : "insanity", "duration" : 220}
   ] ],
   "tooltipKind" : "food",
+  "emitters" : [ "bandageuse" ],
   "blockingEffects" : [ "strongcoffee4" ]
 }

--- a/items/generic/loot/gravstim.consumable
+++ b/items/generic/loot/gravstim.consumable
@@ -7,6 +7,7 @@
   "description": "Temporarily alters your gravity. Don't ask how.\n^cyan;-^white;30% ^cyan;Gravity ^gray;(^white;2m^gray;)^reset;",
   "shortdescription": "Grav-Stim",
   "effects": [["lowgrav_stim"]],
-  "tooltipKind": "food"//,
+  "tooltipKind": "food",
+  "emitters": [ "stimuse" ]//,
   //"learnBlueprintsOnPickup": ["gravstim"]
 }

--- a/items/generic/loot/healing/antipsychotics.consumable
+++ b/items/generic/loot/healing/antipsychotics.consumable
@@ -8,7 +8,7 @@
   "shortdescription" : "^#77acc3;Anti-Psychotics^reset;",
   "effects" : [ [ "buffStatMentalProtection" ] ],
   "emote" : "",
-  "emitters" : [ "bandageuse" ],
+  "emitters" : [ "drinking" ],
   "blockingEffects" : [
     "insanitynew"
   ]

--- a/items/generic/loot/healing/hermespill.consumable
+++ b/items/generic/loot/healing/hermespill.consumable
@@ -8,7 +8,7 @@
   "shortdescription" : "^#77acc3;Hermes Pill^reset;",
   "effects" : [ [ "runboost15" ] ],
   "emote" : "",
-  "emitters" : [ "bandageuse" ],
+  "emitters" : [ "drinking" ],
   "blockingEffects" : [
     "runboost15"
   ]

--- a/items/generic/loot/honeyboon.consumable
+++ b/items/generic/loot/honeyboon.consumable
@@ -7,6 +7,7 @@
   "description": "A long-lasting honey repellant.\n^pink;Honey Slow ^cyan;Immunity ^gray;(^white;5m^gray;)^reset;",
   "shortdescription": "Honeyboon Stim",
   "effects": [["honeyslowimmunity"]],
-  "tooltipKind": "food"//,
+  "tooltipKind": "food",
+  "emitters": [ "stimuse" ]//,
   //"learnBlueprintsOnPickup": ["honeyboon"]
 }

--- a/items/generic/loot/honorcoin.consumable
+++ b/items/generic/loot/honorcoin.consumable
@@ -9,5 +9,6 @@
   "description": "When consumed it provides a defense boost.",
   "shortdescription": "Honor Coin",
 
-  "effects": [["defense4"]]
+  "effects": [["defense4"]],
+  "emitters": [ "drinking" ]
 }

--- a/items/generic/loot/myphisinjector.consumable
+++ b/items/generic/loot/myphisinjector.consumable
@@ -16,5 +16,6 @@
       { "effect": "stun", "duration": 13 }
     ]
   ],
+  "emitters": [ "stimuse" ],
   "blockingEffects": ["strongcoffee4"]
 }

--- a/items/generic/loot/novaglowjuice.consumable
+++ b/items/generic/loot/novaglowjuice.consumable
@@ -7,5 +7,6 @@
   "description": "Your skin gives off light for a while when consuming this illicit substance. Makes you feel sloppy.\n^cyan;Cosmetic Effect ^gray;(^white;220s^gray;)^reset;",
   "shortdescription": "Novaglow",
   "tooltipKind": "food",
-  "effects": [["novakidglowdrug"]]
+  "effects": [["novakidglowdrug"]],
+  "emitters": [ "drinking" ]
 }

--- a/items/generic/loot/portablelight.consumable
+++ b/items/generic/loot/portablelight.consumable
@@ -7,6 +7,7 @@
   "description": "A handy portable light source.\n^#ffd700;Glow ^gray;(^white;20m^gray;)^reset;",
   "shortdescription": "Disposable Light",
   "effects": [["portablelightsource"]],
-  "tooltipKind": "food"//,
+  "tooltipKind": "food",
+  "emitters": [ "drinking" ]//,
   //"learnBlueprintsOnPickup": ["portablelight"]
 }

--- a/items/generic/loot/portaljuice.consumable
+++ b/items/generic/loot/portaljuice.consumable
@@ -8,5 +8,6 @@
   "shortdescription" : "Portal Juice",
   "effects" : [ [ "madnessgain05", "portaljuice" ] ],
   "tooltipKind" : "food",
+  "emitters" : [ "drinking" ],
   "blockingEffects" : [ "portaljuice" ]
 }

--- a/items/generic/loot/powderednarcotics.consumable
+++ b/items/generic/loot/powderednarcotics.consumable
@@ -15,5 +15,6 @@
     {"effect" : "weakpoison", "duration" : 220}
   ] ],
   "tooltipKind" : "food",
+  "emitters" : [ "bandageuse" ],
   "blockingEffects" : [ "strongcoffee4" ]
 }

--- a/items/generic/loot/protostim.consumable
+++ b/items/generic/loot/protostim.consumable
@@ -7,6 +7,7 @@
   "description" : "A long-lasting energy enhancer.\n^cyan;+^white;25% ^cyan;EP ^gray;(^white;2m^gray;)^reset;",
   "shortdescription" : "Organic Energy Stim",
   "effects" : [ [ "percentenergybooststim" ] ],
-  "tooltipKind" : "food"//,
+  "tooltipKind" : "food",
+  "emitters" : [ "stimuse" ]//,
  // "learnBlueprintsOnPickup" : [ "protostim" ]
 }

--- a/items/generic/loot/serumstim.consumable
+++ b/items/generic/loot/serumstim.consumable
@@ -8,6 +8,7 @@
   "shortdescription" : "Blood Serum Stim",
   "effects" : [ [ "percenthealthbooststim","madnessgain05" ] ],
   "tooltipKind" : "food",
+  "emitters" : [ "stimuse" ],
  // "learnBlueprintsOnPickup" : [ "serumstim" ],
   "blockingEffects" : [ "percenthealthbooststim" ]
 }

--- a/items/generic/loot/shieldpatch.consumable
+++ b/items/generic/loot/shieldpatch.consumable
@@ -8,5 +8,6 @@
   "shortdescription": "Shield Patch",
   "effects": [["shieldregen2","defensetechbonus"]],
   "tooltipKind": "food",
+  "emitters": [ "bandageuse" ],
   "blockingEffects": ["shieldregen1", "shieldregen3", "shieldregen4"]
 }

--- a/items/generic/loot/thesauce.consumable
+++ b/items/generic/loot/thesauce.consumable
@@ -8,5 +8,6 @@
   "shortdescription" : "The Sauce",
   "tooltipKind" : "food",
   "effects" : [ ["madnessgain3","percentarmorboost30"] ],
+  "emitters" : [ "stimuse" ],
   "blockingEffects" : [ "percentarmorboost30" ]
 }

--- a/items/generic/loot/uberstim.consumable
+++ b/items/generic/loot/uberstim.consumable
@@ -7,5 +7,6 @@
   "description": "A VERY high dosage a performance enhancers.\n^cyan;+^white;350% ^cyan;Run^gray;, ^cyan;+^white;150% ^cyan;Jump^gray;, ^cyan;Feather Fall ^gray;(^white;24s^gray;)\n^blue;+^white;2 ^blue;Madness^reset;",
   "shortdescription": "Uber-Stim",
   "tooltipKind": "food",
-  "effects": [["fusupermovementstim", "madnessgain2"]]
+  "effects": [["fusupermovementstim", "madnessgain2"]],
+  "emitters": [ "stimuse" ]
 }

--- a/items/generic/loot/ultrastim.consumable
+++ b/items/generic/loot/ultrastim.consumable
@@ -10,6 +10,7 @@
   "effects": [
     ["regeneration2", "shieldregen3", "defense4", "lowgrav", "madnessgain2"]
   ],
+  "emitters": [ "stimuse" ],
   "blockingEffects": [
     "defense01",
     "defense2",

--- a/items/generic/loot/waterstim.consumable
+++ b/items/generic/loot/waterstim.consumable
@@ -7,6 +7,7 @@
   "description" : "^cyan;Swim Boost 2 ^gray;(^white;220s^gray;)^reset;",
   "tooltipKind" : "food",
   "shortdescription" : "Deepwater Stim",
-  "effects" : [ [ "swimboost2" ] ]//,
+  "effects" : [ [ "swimboost2" ] ],
+  "emitters" : [ "stimuse" ]//,
 //  "learnBlueprintsOnPickup" : [ "waterstim" ]
 }

--- a/particles/shards/bioplant2shard.particle
+++ b/particles/shards/bioplant2shard.particle
@@ -9,8 +9,6 @@
     "timeToLive" : 0.5,
     "layer" : "middle",
     "collidesForeground" : true,
-    "light" : [113, 27, 150],
-    "fade" : 0.5,
     "variance" : {
       "position" : [1, 1],
       "initialVelocity" : [5, 3],

--- a/particles/shards/bioplant3shard.particle
+++ b/particles/shards/bioplant3shard.particle
@@ -9,8 +9,6 @@
     "timeToLive" : 0.5,
     "layer" : "middle",
     "collidesForeground" : true,
-    "light" : [113, 27, 150],
-    "fade" : 0.5,
     "variance" : {
       "position" : [1, 1],
       "initialVelocity" : [5, 3],

--- a/particles/shards/darkoshroomshard.particle
+++ b/particles/shards/darkoshroomshard.particle
@@ -9,7 +9,7 @@
     "timeToLive" : 0.5,
     "layer" : "middle",
     "collidesForeground" : true,
-    "light" : [113, 27, 150],
+    "light" : [14, 140, 167],
     "fade" : 0.5,
     "variance" : {
       "position" : [1, 1],

--- a/particles/shards/penumball2shard.particle
+++ b/particles/shards/penumball2shard.particle
@@ -9,8 +9,6 @@
     "timeToLive" : 0.5,
     "layer" : "middle",
     "collidesForeground" : true,
-    "light" : [113, 27, 150],
-    "fade" : 0.5,
     "variance" : {
       "position" : [1, 1],
       "initialVelocity" : [5, 3],

--- a/plants/trees/ceilingtest/stems/astralvine/astralvine.modularstem
+++ b/plants/trees/ceilingtest/stems/astralvine/astralvine.modularstem
@@ -49,8 +49,8 @@
       "damageTree" : {
         "density" : 1,
         "options" : [ {
-          "type" : "textured",
-          "image" : "/particles/treestems/something.png",
+          "type" : "ember",
+          "color" : [0, 0, 0],
           "timeToLive" : 10,
             "initialVelocity" : [0, 0],
             "finalVelocity" : [0, -30],

--- a/plants/trees/ceilingtest/stems/bloodvine/bloodvine.modularstem
+++ b/plants/trees/ceilingtest/stems/bloodvine/bloodvine.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "plantfibre", "count" : 3 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [54, 0, 0],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/bubblevine/bubblevine.modularstem
+++ b/plants/trees/ceilingtest/stems/bubblevine/bubblevine.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "plantfibre", "count" : 3 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [88, 68, 96],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/crystallinevine/crystallinevine.modularstem
+++ b/plants/trees/ceilingtest/stems/crystallinevine/crystallinevine.modularstem
@@ -47,8 +47,8 @@
       "damageTree" : {
         "density" : 1,
         "options" : [ {
-          "type" : "textured",
-          "image" : "/particles/treestems/something.png",
+          "type" : "ember",
+          "color" : [75, 74, 120],
           "timeToLive" : 10,
             "initialVelocity" : [0, 0],
             "finalVelocity" : [0, -30],

--- a/plants/trees/ceilingtest/stems/fleshvine2/fleshvine2.modularstem
+++ b/plants/trees/ceilingtest/stems/fleshvine2/fleshvine2.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "fleshstrand", "count" : 1 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [75, 27, 28],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/fleshvine_atropus/fleshvine_atropus.modularstem
+++ b/plants/trees/ceilingtest/stems/fleshvine_atropus/fleshvine_atropus.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "fleshstrand", "count" : 1 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [75, 27, 28],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/floweryvine2/floweryvine2.modularstem
+++ b/plants/trees/ceilingtest/stems/floweryvine2/floweryvine2.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "plantfibre", "count" : 3 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [37, 116, 16],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/glitteringroot2/glitteringroot2.modularstem
+++ b/plants/trees/ceilingtest/stems/glitteringroot2/glitteringroot2.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "plantfibre", "count" : 3 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [59, 46, 7],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/metalvine/metalvine.modularstem
+++ b/plants/trees/ceilingtest/stems/metalvine/metalvine.modularstem
@@ -47,8 +47,8 @@
       "damageTree" : {
         "density" : 1,
         "options" : [ {
-          "type" : "textured",
-          "image" : "/particles/treestems/something.png",
+          "type" : "ember",
+          "color" : [75, 75, 75],
           "timeToLive" : 10,
             "initialVelocity" : [0, 0],
             "finalVelocity" : [0, -30],

--- a/plants/trees/ceilingtest/stems/metalvine2/metalvine2.modularstem
+++ b/plants/trees/ceilingtest/stems/metalvine2/metalvine2.modularstem
@@ -47,8 +47,8 @@
       "damageTree" : {
         "density" : 1,
         "options" : [ {
-          "type" : "textured",
-          "image" : "/particles/treestems/something.png",
+          "type" : "ember",
+          "color" : [75, 75, 75],
           "timeToLive" : 10,
             "initialVelocity" : [0, 0],
             "finalVelocity" : [0, -30],

--- a/plants/trees/ceilingtest/stems/penumbriteroot/penumbriteroot.modularstem
+++ b/plants/trees/ceilingtest/stems/penumbriteroot/penumbriteroot.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "penumbriteore", "count" : 1 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [38, 13, 43],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/podvine2/podvine2.modularstem
+++ b/plants/trees/ceilingtest/stems/podvine2/podvine2.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "fuscienceresource", "count" : 1 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [13, 39, 7],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/twistedvine2/twistedvine2.modularstem
+++ b/plants/trees/ceilingtest/stems/twistedvine2/twistedvine2.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "plantfibre", "count" : 3 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [46, 66, 0],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/vine2a/vine2a.modularstem
+++ b/plants/trees/ceilingtest/stems/vine2a/vine2a.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "plantfibre", "count" : 3 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [37, 116, 16],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/ceilingtest/stems/vineroot2/vineroot2.modularstem
+++ b/plants/trees/ceilingtest/stems/vineroot2/vineroot2.modularstem
@@ -7,16 +7,59 @@
     "drops" : [
       [ { "item" : "plantfibre", "count" : 3 } ]
     ],
+    "sounds" : {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    },
     "particles" : {
       "breakTree" : {
         "density" : 3,
         "options" : [ {
             "image" : "/particles/treestems/vine.png",
-            "timeToLive" : 10
+            "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
           } ]
       },
-      "hitGround" : { "density" : 3, "options" : [ { "animation" : "/animations/dusttest/dusttest.animation", "initial" : "drift", "rotation" : 3.14, "timeToLive" : 3 } ] },
-      "damageTree" : { "density" : 1, "options" : [ { "image" : "/particles/treestems/something.png", "timeToLive" : 10 } ] }
+      "hitGround" : {
+        "density" : 3,
+        "options" : [ {
+          "type" : "animated",
+          "animation" : "/animations/dusttest/dusttest.animation",
+          "timeToLive" : 3,
+          "destructionAction" : "shrink",
+          "destructionTime" : 1.0,
+          "variance" : {
+            "rotation" : 180,
+            "timeToLive" : 1.0,
+            "initialPosition" : [1.0, 1.0],
+            "initialVelocity" : [1.0, 1.0]
+          }
+        } ]
+      },
+      "damageTree" : {
+        "density" : 1,
+        "options" : [ {
+          "type" : "ember",
+          "color" : [59, 46, 7],
+          "timeToLive" : 10,
+            "initialVelocity" : [0, 0],
+            "finalVelocity" : [0, -30],
+            "approach" : [0, 5],
+            "variance" : {
+              "timeToLive" : 3.0,
+              "initialPosition" : [1.0, 1.0],
+              "initialVelocity" : [1.0, 1.0]
+            }
+        } ]
+      }
     }
   },
   "base" : {

--- a/plants/trees/forestceiling/stems/alpinevine/alpinevine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/alpinevine/alpinevine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [63, 94, 49]
+  }
+]

--- a/plants/trees/forestceiling/stems/bluevein/bluevein.modularstem.patch
+++ b/plants/trees/forestceiling/stems/bluevein/bluevein.modularstem.patch
@@ -1,0 +1,25 @@
+[
+  {
+    "op": "add",
+    "path": "/dropConfig/sounds",
+    "value": {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [10, 28, 54]
+  }
+]

--- a/plants/trees/forestceiling/stems/bone/bone.modularstem.patch
+++ b/plants/trees/forestceiling/stems/bone/bone.modularstem.patch
@@ -1,0 +1,25 @@
+[
+  {
+    "op": "add",
+    "path": "/dropConfig/sounds",
+    "value": {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [23, 35, 15]
+  }
+]

--- a/plants/trees/forestceiling/stems/colourfulvine/colourfulvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/colourfulvine/colourfulvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [51, 36, 36]
+  }
+]

--- a/plants/trees/forestceiling/stems/darkvine/darkvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/darkvine/darkvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [0, 0, 0]
+  }
+]

--- a/plants/trees/forestceiling/stems/desertvine/desertvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/desertvine/desertvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [55, 44, 34]
+  }
+]

--- a/plants/trees/forestceiling/stems/eyevein/eyevein.modularstem.patch
+++ b/plants/trees/forestceiling/stems/eyevein/eyevein.modularstem.patch
@@ -1,0 +1,25 @@
+[
+  {
+    "op": "add",
+    "path": "/dropConfig/sounds",
+    "value": {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [54, 10, 14]
+  }
+]

--- a/plants/trees/forestceiling/stems/geodevine/geodevine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/geodevine/geodevine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [32, 17, 29]
+  }
+]

--- a/plants/trees/forestceiling/stems/hivevine/hivevine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/hivevine/hivevine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [0, 0, 0]
+  }
+]

--- a/plants/trees/forestceiling/stems/mushroomstalk/stalk.modularstem.patch
+++ b/plants/trees/forestceiling/stems/mushroomstalk/stalk.modularstem.patch
@@ -1,0 +1,25 @@
+[
+  {
+    "op": "add",
+    "path": "/dropConfig/sounds",
+    "value": {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [84, 95, 74]
+  }
+]

--- a/plants/trees/forestceiling/stems/oasisvine/oasisvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/oasisvine/oasisvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [78, 54, 26]
+  }
+]

--- a/plants/trees/forestceiling/stems/purplevine/purplevine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/purplevine/purplevine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [50, 12, 64]
+  }
+]

--- a/plants/trees/forestceiling/stems/rootvine/rootvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/rootvine/rootvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [71, 43, 19]
+  }
+]

--- a/plants/trees/forestceiling/stems/rootvine2/rootvine2.modularstem.patch
+++ b/plants/trees/forestceiling/stems/rootvine2/rootvine2.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [71, 43, 19]
+  }
+]

--- a/plants/trees/forestceiling/stems/rootvine3/rootvine3.modularstem.patch
+++ b/plants/trees/forestceiling/stems/rootvine3/rootvine3.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [71, 43, 19]
+  }
+]

--- a/plants/trees/forestceiling/stems/shadowvine/shadowvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/shadowvine/shadowvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [8, 2, 7]
+  }
+]

--- a/plants/trees/forestceiling/stems/slimevine/slimevine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/slimevine/slimevine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [38, 54, 12]
+  }
+]

--- a/plants/trees/forestceiling/stems/snowyvine/snowyvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/snowyvine/snowyvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [95, 65, 37]
+  }
+]

--- a/plants/trees/forestceiling/stems/sulphurvine/sulphurvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/sulphurvine/sulphurvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [70, 40, 24]
+  }
+]

--- a/plants/trees/forestceiling/stems/swampvine/swampvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/swampvine/swampvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [70, 47, 24]
+  }
+]

--- a/plants/trees/forestceiling/stems/tarvine/tarvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/tarvine/tarvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [8, 2, 7]
+  }
+]

--- a/plants/trees/forestceiling/stems/tentacle/tentacle.modularstem.patch
+++ b/plants/trees/forestceiling/stems/tentacle/tentacle.modularstem.patch
@@ -1,0 +1,25 @@
+[
+  {
+    "op": "add",
+    "path": "/dropConfig/sounds",
+    "value": {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [33, 6, 16]
+  }
+]

--- a/plants/trees/forestceiling/stems/vein/vein.modularstem.patch
+++ b/plants/trees/forestceiling/stems/vein/vein.modularstem.patch
@@ -1,0 +1,25 @@
+[
+  {
+    "op": "add",
+    "path": "/dropConfig/sounds",
+    "value": {
+      "breakTree" : [
+        { "file" : "/sfx/environmental/vine_cut1.ogg" }, { "file" : "/sfx/environmental/vine_cut2.ogg" }, { "file" : "/sfx/environmental/vine_cut3.ogg" }
+      ]
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [54, 10, 14]
+  }
+]

--- a/plants/trees/forestceiling/stems/vine/vine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/vine/vine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [37, 116, 16]
+  }
+]

--- a/plants/trees/forestceiling/stems/vine2/vine2.modularstem.patch
+++ b/plants/trees/forestceiling/stems/vine2/vine2.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [37, 116, 16]
+  }
+]

--- a/plants/trees/forestceiling/stems/vine3/vine3.modularstem.patch
+++ b/plants/trees/forestceiling/stems/vine3/vine3.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [37, 116, 16]
+  }
+]

--- a/plants/trees/forestceiling/stems/vine4/vine4.modularstem.patch
+++ b/plants/trees/forestceiling/stems/vine4/vine4.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [37, 116, 16]
+  }
+]

--- a/plants/trees/forestceiling/stems/wildernessvine/wildernessvine.modularstem.patch
+++ b/plants/trees/forestceiling/stems/wildernessvine/wildernessvine.modularstem.patch
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/dropConfig/particles/damageTree/options/0/type",
+    "value": "ember"
+  },
+  {
+    "op": "remove",
+    "path": "/dropConfig/particles/damageTree/options/0/image"
+  },
+  {
+    "op": "add",
+    "path": "/dropConfig/particles/damageTree/options/0/color",
+    "value": [70, 40, 24]
+  }
+]


### PR DESCRIPTION
- Fixed/adjusted break particles and added missing break sounds for vines.
- Adjusted medicine consume sounds so you no longer eat syringes.
- Removed unintentional glow from recently added particles and fixed color in one of them.