### PR TITLE
GalaxyFoxes EX: Eeveelution Set Bonuses

### DIFF
--- a/stats/effects/gfex_eeveesetbonus/espeon/espeonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/espeon/espeonsetbonus.lua
@@ -1,0 +1,14 @@
+function init()
+  effect.addStatModifierGroup({
+    {stat = "physicalResistance", "amount": 0.1},
+    {stat = "fallDamageMultiplier", effectiveMultiplier = 0.5}
+  })
+  
+  script.setUpdateDelta(0)
+end
+
+function update(dt)
+end
+
+function uninit()
+end

--- a/stats/effects/gfex_eeveesetbonus/espeon/espeonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/espeon/espeonsetbonus.lua
@@ -3,7 +3,6 @@ function init()
     {stat = "physicalResistance", amount = 0.15},
     {stat = "fallDamageMultiplier", effectiveMultiplier = 0.7}
   })
-  
   script.setUpdateDelta(0)
 end
 

--- a/stats/effects/gfex_eeveesetbonus/espeon/espeonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/espeon/espeonsetbonus.lua
@@ -1,6 +1,6 @@
 function init()
   effect.addStatModifierGroup({
-    {stat = "physicalResistance", "amount": 0.15},
+    {stat = "physicalResistance", amount = 0.15},
     {stat = "fallDamageMultiplier", effectiveMultiplier = 0.7}
   })
   

--- a/stats/effects/gfex_eeveesetbonus/espeon/espeonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/espeon/espeonsetbonus.lua
@@ -1,7 +1,7 @@
 function init()
   effect.addStatModifierGroup({
-    {stat = "physicalResistance", "amount": 0.1},
-    {stat = "fallDamageMultiplier", effectiveMultiplier = 0.5}
+    {stat = "physicalResistance", "amount": 0.15},
+    {stat = "fallDamageMultiplier", effectiveMultiplier = 0.7}
   })
   
   script.setUpdateDelta(0)

--- a/stats/effects/gfex_eeveesetbonus/flareon/flareonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/flareon/flareonsetbonus.lua
@@ -1,0 +1,11 @@
+function init()
+   effect.addStatModifierGroup({{stat = "iceResistance", amount = 0.25}, {stat = "biomecoldImmunity", amount = 1}})
+
+   script.setUpdateDelta(0)
+end
+
+function update(dt)
+end
+
+function uninit()
+end

--- a/stats/effects/gfex_eeveesetbonus/flareon/flareonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/flareon/flareonsetbonus.lua
@@ -1,6 +1,5 @@
 function init()
-   effect.addStatModifierGroup({{stat = "iceResistance", amount = 0.25}, {stat = "biomecoldImmunity", amount = 1}})
-
+   effect.addStatModifierGroup({{stat = "iceResistance", amount = 0.15}, {stat = "biomecoldImmunity", amount = 1}})
    script.setUpdateDelta(0)
 end
 

--- a/stats/effects/gfex_eeveesetbonus/glaceon/glaceonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/glaceon/glaceonsetbonus.lua
@@ -1,0 +1,10 @@
+function init()
+   effect.addStatModifierGroup({{stat = "poisonResistance", amount = 0.15}, {stat = "biomeheatImmunity", amount = 1}})
+   script.setUpdateDelta(0)
+end
+
+function update(dt)
+end
+
+function uninit()
+end

--- a/stats/effects/gfex_eeveesetbonus/jolteon/jolteonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/jolteon/jolteonsetbonus.lua
@@ -1,0 +1,11 @@
+function init()
+  effect.addStatModifierGroup({{stat = "electricResistance", amount = 0.25}, {stat = "electricStatusImmunity", amount = 1}})
+
+  script.setUpdateDelta(0)
+end
+
+function update(dt)
+end
+
+function uninit()
+end

--- a/stats/effects/gfex_eeveesetbonus/jolteon/jolteonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/jolteon/jolteonsetbonus.lua
@@ -1,5 +1,5 @@
 function init()
-  effect.addStatModifierGroup({{stat = "electricResistance", amount = 0.25}, {stat = "electricStatusImmunity", amount = 1}})
+  effect.addStatModifierGroup({{stat = "electricResistance", amount = 0.15}, {stat = "electricStatusImmunity", amount = 1}})
 
   script.setUpdateDelta(0)
 end

--- a/stats/effects/gfex_eeveesetbonus/leafeon/leafeonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/leafeon/leafeonsetbonus.lua
@@ -1,9 +1,5 @@
 function init()
-   effect.addStatModifierGroup({
-     {stat = "tarStatusImmunity", amount = 1},
-	   {stat = "electricResistance", amount = 0.15}
-   })
-  
+   effect.addStatModifierGroup({{stat = "tarStatusImmunity", amount = 1},{stat = "electricResistance", amount = 0.15}})
   script.setUpdateDelta(0)
 end
 

--- a/stats/effects/gfex_eeveesetbonus/leafeon/leafeonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/leafeon/leafeonsetbonus.lua
@@ -1,0 +1,14 @@
+function init()
+   effect.addStatModifierGroup({
+     {stat = "tarStatusImmunity", amount = 1},
+	   {stat = "electricResistance", amount = 0.15}
+   })
+  
+  script.setUpdateDelta(0)
+end
+
+function update(dt)
+end
+
+function uninit()
+end

--- a/stats/effects/gfex_eeveesetbonus/nucleon/nucleonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/nucleon/nucleonsetbonus.lua
@@ -1,10 +1,9 @@
 function init()
    effect.addStatModifierGroup({
      {stat = "biomeradiationImmunity", amount = 1},
-	   {stat = "radioactiveResistance", amount = 0.15},
+     {stat = "radioactiveResistance", amount = 0.15},
      {stat = "sulphuricImmunity", amount = 1}
    })
-  
   script.setUpdateDelta(0)
 end
 

--- a/stats/effects/gfex_eeveesetbonus/nucleon/nucleonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/nucleon/nucleonsetbonus.lua
@@ -1,0 +1,15 @@
+function init()
+   effect.addStatModifierGroup({
+     {stat = "biomeradiationImmunity", amount = 1},
+	   {stat = "radioactiveResistance", amount = 0.15},
+     {stat = "sulphuricImmunity", amount = 1}
+   })
+  
+  script.setUpdateDelta(0)
+end
+
+function update(dt)
+end
+
+function uninit()
+end

--- a/stats/effects/gfex_eeveesetbonus/sylveon/sylveonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/sylveon/sylveonsetbonus.lua
@@ -1,0 +1,17 @@
+function init()
+  effect.addStatModifierGroup({{stat = "shadowResistance", amount = 0.15}})
+  script.setUpdateDelta(5)
+  self.healingRate = 1.0 / 150
+  
+  effect.addStatModifierGroup({
+    {stat = "energyRegenPercentageRate", amount = 10},
+    {stat = "energyRegenBlockTime", effectiveMultiplier = 0}
+  })
+end
+
+function update(dt)
+  status.modifyResourcePercentage("health", self.healingRate * dt)
+end
+
+function uninit()
+end

--- a/stats/effects/gfex_eeveesetbonus/sylveon/sylveonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/sylveon/sylveonsetbonus.lua
@@ -2,7 +2,6 @@ function init()
   effect.addStatModifierGroup({{stat = "shadowResistance", amount = 0.15}})
   script.setUpdateDelta(5)
   self.healingRate = 1.0 / 150
-  
   effect.addStatModifierGroup({
     {stat = "energyRegenPercentageRate", amount = 10},
     {stat = "energyRegenBlockTime", effectiveMultiplier = 0}

--- a/stats/effects/gfex_eeveesetbonus/umbreon/umbreonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/umbreon/umbreonsetbonus.lua
@@ -1,8 +1,9 @@
 function init()
-  effect.addStatModifierGroup({{stat = "cosmicResistance", amount = 0.1},{stat = "gfex_umbrethorns", amount = 1}})
+  effect.addStatModifierGroup({{stat = "cosmicResistance", amount = 0.1}})
 end
 
 function update(dt)
+  status.addEphemeralEffect("gfex_umbrethorns", 5)
 end
 
 function uninit()

--- a/stats/effects/gfex_eeveesetbonus/umbreon/umbreonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/umbreon/umbreonsetbonus.lua
@@ -1,0 +1,9 @@
+function init()
+  effect.addStatModifierGroup({{stat = "cosmicResistance", amount = 0.1},{stat = "gfex_umbrethorns", amount = 1}})
+end
+
+function update(dt)
+end
+
+function uninit()
+end

--- a/stats/effects/gfex_eeveesetbonus/vaporeon/vaporeonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/vaporeon/vaporeonsetbonus.lua
@@ -1,8 +1,8 @@
 function init()
   effect.addStatModifierGroup({
-    {stat = "fireResistance", amount = 0.25},
+    {stat = "fireResistance", amount = 0.15},
     {stat = "wetImmunity", amount = 1},
-    {stat = "maxBreath", amount = 1500}
+    {stat = "maxBreath", amount = 1000}
   })
   self.movementParameters = config.getParameter("movementParameters", {})
 end

--- a/stats/effects/gfex_eeveesetbonus/vaporeon/vaporeonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/vaporeon/vaporeonsetbonus.lua
@@ -7,7 +7,7 @@ function init()
   self.movementParameters = config.getParameter("movementParameters", {})
 end
 
-function update()
+function update(dt)
 end
 
 function uninit()

--- a/stats/effects/gfex_eeveesetbonus/vaporeon/vaporeonsetbonus.lua
+++ b/stats/effects/gfex_eeveesetbonus/vaporeon/vaporeonsetbonus.lua
@@ -1,0 +1,14 @@
+function init()
+  effect.addStatModifierGroup({
+    {stat = "fireResistance", amount = 0.25},
+    {stat = "wetImmunity", amount = 1},
+    {stat = "maxBreath", amount = 1500}
+  })
+  self.movementParameters = config.getParameter("movementParameters", {})
+end
+
+function update()
+end
+
+function uninit()
+end


### PR DESCRIPTION
Figure it'd be a good idea to have the set bonuses switch over to Frackin Universe stats so they're slightly relevant.

Feel free to change and optimize these effects <sub>~~because lord knows I have very little idea what I'm doing~~</sub>.

---
### Armor Set Bonuses
**Jolteon:** Electric resistance and electrified status immunity
**Flareon:** Ice resistance and tier 1 cold planet protection
**Vaporeon:** Fire resistance, faster swim speed, and more air
**Espeon:** Physical resistance and reduced fall damage
**Umbreon:** Cosmic resistance and poison thorns effect
**Glaceon:** Poison resistance and tier 1 hot planet protection
**Leafeon:** Electric resistance and tar immunity
**Sylveon:** Shadow resistance, glow, light regeneration
**Nucleon:** Radiation resistance, glow, sulfuric acid protection