### PR TITLE
Chef tenant fixes

### DIFF
--- a/npcs/dungeon/hylotloceancity/chefmerchant.npctype.patch
+++ b/npcs/dungeon/hylotloceancity/chefmerchant.npctype.patch
@@ -1,0 +1,62 @@
+[
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/elduukhar",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/fenerox",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/fukirhos",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/fumantizi",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/fupeglaci",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/nightar",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/radien",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/shadow",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/skath",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/slimeperson",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/thelusian",
+		"value": [ "chefmerchant" ]
+	},
+	{
+		"op": "add",
+		"path": "/scriptConfig/merchant/categories/veluu",
+		"value": [ "chefmerchant" ]
+	}
+]

--- a/quests/fu_questlines/deprecated/fuquest_nano.questtemplate
+++ b/quests/fu_questlines/deprecated/fuquest_nano.questtemplate
@@ -1,8 +1,8 @@
 {
 	"id" : "fuquest_nano",
 	"title" : "The Amazing Tinker",
-	"text" : "The ^orange;Tinker Table^reset; is an extremely useful device. It can be used to fashion ^green;upgrades, augments, techs^reset; and more. Try making a ^orange;Mining Laser^reset; in yours.",
-	"completionText" : "Both the ^orange;Tinker Table^reset; and the ^orange;Mining Laser^reset; can be upgraded. You won't want to be without both. The mining laser will really start to shine after a few additions!",
+	"text" : "The ^orange;Tinkering Table^reset; is an extremely useful device. It can be used to fashion ^green;upgrades, augments, techs^reset; and more. Try making a ^orange;Mining Laser^reset; in yours.",
+	"completionText" : "Both the ^orange;Tinkering Table^reset; and the ^orange;Mining Laser^reset; can be upgraded. You won't want to be without both. The mining laser will really start to shine after a few additions!",
 	"rewards" : [
 		[ [ "serumstim", 1] ]
 	],

--- a/quests/fu_questlines/tutorial/start_basics5.questtemplate
+++ b/quests/fu_questlines/tutorial/start_basics5.questtemplate
@@ -2,7 +2,7 @@
 	"id" : "start_basics5",
 	"prerequisites" : [ "start_basics4" ],
 	"title" : "Homestead V",
-	"text" : "I've heard of some fancy stuff in my day, but I'd most like ta see me a ^orange;Mining Laser^reset; 'afore I die. I heard you kin make one in a ^orange;Tinker Table^reset;. That's ^orange;Researched^reset; in the ^orange;Engineering^reset; sciences.",
+	"text" : "I've heard of some fancy stuff in my day, but I'd most like ta see me a ^orange;Mining Laser^reset; 'afore I die. I heard you kin make one in a ^orange;Tinkering Table^reset;. That's ^orange;Researched^reset; in the ^orange;Engineering^reset; sciences.",
 	"completionText" : "You've made an ol' Novakid happy today. Thanks so much, friend. Take this unusual stone I found as a thanks. It looks valuable.",
 	"moneyRange" : [22, 33],
 	"rewards" : [ [ [ "protheonshard",1 ] ] ],
@@ -16,7 +16,7 @@
 			"questComplete" : "questGiver"
 		},
 		"requireTurnIn" : true,
-		"turnInDescription" : "Craft a ^green;Mining Laser^reset; at a ^orange;Tinker Table^reset; and return.",
+		"turnInDescription" : "Craft a ^green;Mining Laser^reset; at a ^orange;Tinkering Table^reset; and return.",
 		"conditions" : [
 			{
 				"type" : "gatherItem",

--- a/quests/fu_questlines/tutorial/vinj/create_tinkertable.questtemplate
+++ b/quests/fu_questlines/tutorial/vinj/create_tinkertable.questtemplate
@@ -2,7 +2,7 @@
   "id" : "create_tinkertable",
   "prerequisites" : [ "create_matterassembler" ],
   "title" : "Tinkering",
-  "text" : "Without a ^orange;Tinker Table^reset; you'll be hard-pressed to create ^green;augments, upgrades and specialist tools^reset;. When you get a chance, ^orange;Research^reset; into ^orange;Engineering^reset; and build one for me.",
+  "text" : "Without a ^orange;Tinkering Table^reset; you'll be hard-pressed to create ^green;augments, upgrades and specialist tools^reset;. When you get a chance, ^orange;Research^reset; into ^orange;Engineering^reset; and build one for me.",
   "completionText" : "Might I recommend starting with a ^orange;Mining Laser?^reset; They are truly effective tools to use for rapidly digging through dirt!",
   "moneyRange" : [0, 0],
   "rewards" : [ [ [ "fuscienceresource", 100 ] ] ],

--- a/radiomessages/fu_quests.radiomessages
+++ b/radiomessages/fu_quests.radiomessages
@@ -146,7 +146,7 @@
   "fu_start_Complete3b" : {
     "type" : "tutorial",
     "unique": true,
-    "text" : "The ^orange;Personal Tricorder^reset; is ^red;EXTREMELY^reset; important. Do not throw it out. Ever! Should you lose it, you can always create a new ^orange;Personal Tricorder^reset; in your ^green;Tinker Table^reset;.",
+    "text" : "The ^orange;Personal Tricorder^reset; is ^red;EXTREMELY^reset; important. Do not throw it out. Ever! Should you lose it, you can always create a new ^orange;Personal Tricorder^reset; in your ^green;Tinkering Table^reset;.",
     "persistTime" : 20.0
   },
 

--- a/radiomessages/mech.radiomessages.patch
+++ b/radiomessages/mech.radiomessages.patch
@@ -44,7 +44,7 @@
     "path": "/testdrive04",
     "value": {
       "unique": false,
-      "text": "Remember, you can create a ^orange;Mech Repair tool^reset; at your ^orange;Tinker Table^reset; and upgrade it to be more effective using your ^orange;Tricorder's upgrade menu^reset;.",
+      "text": "Remember, you can create a ^orange;Mech Repair tool^reset; at your ^orange;Tinkering Table^reset; and upgrade it to be more effective using your ^orange;Tricorder's upgrade menu^reset;.",
       "portraitImage": "yell.<frame>",
       "textSpeed": 70
     }

--- a/tenants/elduu/pub_elduukhar.tenant
+++ b/tenants/elduu/pub_elduukhar.tenant
@@ -1,6 +1,6 @@
 {
   "name" : "pub_elduukhar",
-  "priority" : 2,
+  "priority" : 3,
 
   "colonyTagCriteria": {
     "light" : 1,

--- a/tenants/tenebrhae/chef_shadow.tenant
+++ b/tenants/tenebrhae/chef_shadow.tenant
@@ -12,7 +12,7 @@
   "tenants": [
     {
       "spawn": "npc",
-      "species": "apex",
+      "species": "shadow",
       "type": "chefmerchanttenant",
       "overrides": {
        }


### PR DESCRIPTION
* Tenants like Fenerox Chef now sell foods (was: generic merchant items)
* Shadow furniture now spawns Shadow Chef tenant (was: Apex Chef)
* Pub Elduukhar tenant is more likely to spawn if the requirements are met.
* Tutorial quests now correctly name the Tinkering Table station (was: Tinker Table)