### PR TITLE
Update beeData.config

### DIFF
--- a/bees/beeData.config
+++ b/bees/beeData.config
@@ -1010,7 +1010,7 @@
 					"godlycomb" : 670,
 				//drops
 					"mutaviskthread" : 900,
-					"goldensand" : 290,
+					"goldensand" : 90,
 					"goldenleaves" : 45,
 					"beesilk" : 500,
 					"goldenwood" : 200

--- a/bees/beeData.config
+++ b/bees/beeData.config
@@ -638,10 +638,10 @@
 				        "goldcomb": 300,
 				//drops
 					"volatilepowder" : 500,
-					"fu_oxygen" : 350,
+					"fu_oxygen" : 200,
 					"fu_carbondioxide" : 200,
-					"fu_hydrogen" : 250,
-					"fu_nitrogen" : 320
+					"fu_hydrogen" : 200,
+					"fu_nitrogen" : 200
 				}
 			},
 			{
@@ -1005,15 +1005,15 @@
 
 				"production" : {
 				// honey
-					"fu_liquidhoney" : 110,
+					"fu_liquidhoney" : 70,
 				//comb
-					"godlycomb" : 770,
+					"godlycomb" : 670,
 				//drops
 					"mutaviskthread" : 900,
 					"goldensand" : 290,
-					"goldenleaves" : 245,
+					"goldenleaves" : 45,
 					"beesilk" : 500,
-					"goldenwood" : 400
+					"goldenwood" : 200
 				}
 			}
 		],
@@ -1237,9 +1237,9 @@
 
 				"production" : {
 				// honey
-					"liquidoil" : 50,
+					"liquidoil" : 30,
 				//comb
-					"minercomb" : 300,
+					"minercomb" : 200,
 				//drops
 					"cobblestonematerial" : 40,
 					"copperore" : 700,
@@ -1791,7 +1791,7 @@
 				//comb
 					"redcomb" : 300,
 				//drops
-					"aliencompound" : 400,
+					"aliencompound" : 140,
 					"fuflesh" : 700,
 					"blooddiamond" : 1300
 				}
@@ -1881,13 +1881,13 @@
 
 				"production" : {
 				// honey
-					"fu_liquidhoneyred" : 350,
+					"fu_liquidhoneyred" : 50,
 				//comb
-					"feroziumcomb" : 700,
+					"feroziumcomb" : 400,
 				//drops
-					"redwaxchunk" : 1200,
-					"bugshell" : 140,
-					"bone" : 340
+					"redwaxchunk" : 300,
+					"bugshell" : 40,
+					"bone" : 240
 				}
 			}
 		]


### PR DESCRIPTION
Fixed some bee subtypes to not be strictly inferior to their comparable subtype. Made them equal in output to the superior subtype instead.
Goldensaint, oremason, inventor, reaper and red-banded all had strictly inferior subtypes.