### PR TITLE
removal of breath depletion and regeneration double ticking

### DIFF
--- a/interface/scripted/statWindow/extraStatsWindow.lua
+++ b/interface/scripted/statWindow/extraStatsWindow.lua
@@ -82,8 +82,10 @@ function update()
 			if breathMax > 0 then
 				-- Why divided by 2 you ask? Fuck if I know, it returns double the right value otherwise. <-zimber's note
 				--khe: that's because breath timer is decremented twice per update; once in vanilla code, once in FR code.
-				widget.setText("breathMaxTime", breathMax / breathRate / 2)
-				widget.setText("breathRegenTime", breathMax / breatRegen / 2)
+				--widget.setText("breathMaxTime", breathMax / breathRate / 2)
+				widget.setText("breathMaxTime", breathMax / breathRate)
+				--widget.setText("breathRegenTime", breathMax / breatRegen / 2)
+				widget.setText("breathRegenTime", breathMax / breatRegen)
 			end
 		end
 	end

--- a/interface/scripted/statWindow/extraStatsWindow.lua
+++ b/interface/scripted/statWindow/extraStatsWindow.lua
@@ -10,16 +10,9 @@ function init()
 end
 
 function update()
-	-- Breath calculated separately
-	local breatRegen = status.stat("breathRegenerationRate")
-	local breathMax = status.stat("maxBreath")
-
 	-- for stat, type in pairs(self.stats) do
 	for stat, type in pairs(self.data.stats) do
 		local value = status.stat(stat)
-		--[[if stat=="healthRegen" then
-			sb.logInfo("%s",{stat=stat,value=value})
-		end]]
 
 		-- Getting rid of the redundant .0's
 		local fraction = math.abs(math.floor(value) - value)
@@ -55,7 +48,6 @@ function update()
 		elseif type == "food" then
 			local foodVal=status.isResource("food") and status.resourceMax("food") or 0
 			if foodVal~=0 then
-				--value = math.abs(shorten(1 / (value / status.resourceMax("food")) * 0.01))--blatantly wrong
 				value=math.abs(shorten(foodVal/(value*60.0)))
 				if value % 1 == 0 then
 					widget.setText(stat, tostring(math.floor(value)))
@@ -78,14 +70,12 @@ function update()
 			widget.setText(stat, v2)
 
 		elseif type == "breath" then
-			local breathRate = value
+			-- Breath calculated separately. this only is fired off breathDepletionRate and should NOT fire off breathRegenerationRate or maxBreath
+			local breathRegen = status.stat("breathRegenerationRate")
+			local breathMax = status.stat("maxBreath")
 			if breathMax > 0 then
-				-- Why divided by 2 you ask? Fuck if I know, it returns double the right value otherwise. <-zimber's note
-				--khe: that's because breath timer is decremented twice per update; once in vanilla code, once in FR code.
-				--widget.setText("breathMaxTime", breathMax / breathRate / 2)
-				widget.setText("breathMaxTime", breathMax / breathRate)
-				--widget.setText("breathRegenTime", breathMax / breatRegen / 2)
-				widget.setText("breathRegenTime", breathMax / breatRegen)
+				widget.setText("breathMaxTime", breathMax / value)
+				widget.setText("breathRegenTime", breathMax / breathRegen)
 			end
 		end
 	end

--- a/scripts/fr_raceEffects.lua
+++ b/scripts/fr_raceEffects.lua
@@ -108,7 +108,7 @@ function update(dt)
 		self.helper:applyControlModifiers(self.helper.controlModifiers,self.helper.controlParameters)
 	end
 	self.helper:runScripts("racialscript", self, dt)
-
+--[[--disabling
 	-- Breath handling
 	-- which, as it happens, is already handled by the vanilla script. so this applies TWICE.
 	if entity.entityType() ~= "npc" then
@@ -120,7 +120,7 @@ function update(dt)
 		else
 			status.modifyResource("breath", -status.stat("breathDepletionRate") * dt)
 		end
-	end
+	end]]
 	tagCaching.update()
 	masteries.update(dt)
 end


### PR DESCRIPTION
removed double-ticking of breath regeneration and depletion. this will functionally double time to fully regenerate breath and time to deplete, except  (apparently) on shipworlds.

further revisions to breath related items will need to be made. handing that off to zarra.