### PR TITLE
Armour and other fixes

### DIFF
--- a/a_modders/research/research_template.config
+++ b/a_modders/research/research_template.config
@@ -1,218 +1,223 @@
 {
-	// NOTE: There is an empty template at the end of the document for easy copy-pasting
-	
-	// This is a template file created to serve as documentation on how to define your own research trees.
-	// To add research to the game, you must first create a research tree.
-	// Trees are mainly used to split between multiple mods, so players don't end up with a cluttered mess on their screen
-	// But they can also be used to split research to categories. (Though I'd suggest putting all your research into one tree for less clutter and more "WOW THIS TREE IS AMAZING" factor)
-	// Make sure to give your trees unique names such as "zb_main" so you don't end up accidentally overriding someone elses tree, or your stuff getting overriden.
-	// This is where you define your research trees:
-	"researchTree" : {},
-	
-	// By following this example:
-//	"researchTree" : {
-//		"myTree" : {	// replace with the desired tree identifier, this is NOT the displayed name
-//			"example1" : {
-//				"icon" : "image.png",
-//				"position" : [x, y],
-//				"price" : [["currency", 322], ["item", 1337]],
-//				"unlocks" : ["myResearchedItem", "myOtherItem"],	>> OPTIONAL
-//				"hideUnlocks" : true/false,							>> OPTIONAL
-//				"children" : ["example2"],							>> OPTIONAL
-//				"func" : "myFunctionName"							>> OPTIONAL
-//				"params" : "whatever the heck you need."			>> OPTIONAL
-//			},
-//			"example2" : {
-//				"icon" : "/assetmissing.png",
-//				"position" : [20, 30],
-//				"price" : [["money", 300], ["corefragmentore", 20]],
-//				"unlocks" : ["banana"]
-//			}
-//		}
-//	}
-	//	icon		- The image used to represent the research. Use "/assetmissing.png" if you want it blank. 16x16 sized images suggested, otherwise might look bad.
-	//	position	- The position of the research on the drag screen.
-	//	price		- An array of prices structured similar to how quest rewards are. Can use both currencies and items.
-	//	unlocks		- An array of blueprints the player would learn upon completing the research.
-	//	hideUnlocks	- By default, the info panel will display unlocked blue prints. Set this to true if you want to hide unlocks.
-	//	children	- An array of research names that this research leads to. This research is a requirement before you can unlock any of its children.
-	//	func		- A function you would like to call when the research is complete. We will cover this later
-	//	params		- Parameters for the above function
-	
-	
-	
-	// Every research used in the tree MUST have an acronym.
-	// While research can't exist without an acronym, acronyms can exist without research, but they will be erased when the research trees version is updated to prevent reusing them by accident
-	// Make sure there are no duplicates of the same acronym on the same tree
-	// Don't worry about other mods/trees using the same acronyms, each tree has its acronyms stored and read separatly 
-	// Note that updating the mod after changing already present acronyms, players who already have the pre-update acronyms will keep them, and the system will see the new acronyms as not researched.
-	// And this is where acronyms for research are defined:
-	"acronyms" : {},
-	
-	// By following this example:
-//	"acronyms" : {
-//		"myTree" : {
-//			"EXA1" : "example1",
-//			"EXA2" : "example2"
-//		}
-//	},
-	
-	
-	
-	// To add strings to elements, you follow this table:
-	// (AVOID using colors for currencies and research titles, because currencies have their own color defined elsewhere, and research titles are color coded to display their status)
-	"strings" : {
-		"currencies" : {
-		//	"currencyName" : "Displayed Name",
-		//	"money" : "Pixels"
-		},
-		"trees" : {
-		//	"treeName" : "Displayed Tree Name",
-		//	"myTree" : "[^orange;ZB^reset;] My Research Tree"
-		},
-		
-		"research" : {
-		//	"researchName" : [ "Research Title", "The text that is written below the title on the side view." ],
-		//	"example1" : [ "Example Research", "This research is an example." ]
-		}
-	},
-	
-	
-	
-	// Every tree needs an origin point, and this is where we define them. Add the acronyms for researches you want to be initially researched.
-	// Note that a single tree can have multiple origins.
-	"initiallyResearched" : {},
-	
-	// By following this example:
-//	"initiallyResearched" : {
-//		"myTree" : [ "EXA1" ]
-//	},
-	
-	
-	
-	
-	// If you want some research and its children to be hidden from the player until it becomes available, you do the same thing you did the previous step, but for this object:
-	"hiddenResearch" : {},
-	
-	// By following this example:
-//	"hiddenResearch" : {
-//		"myTree" : [ "EXA2" ]
-//	},
-	
-	
-	
-	
-	// If your mod adds custom currencies you'd like to be visually available (So you don't have to open another pane to view them) you add them here:
-	"currencies" : [],
-	
-	// By following this example:
-//	"currencies" : [
-//		[ "currencyName", "#currencyColor", "representingItem", "miniIconPath", isHiddenWhenEmpty?	],
-//		[ "essence", "#FF22FF", "essence", "/zb/researchTree/currencyMiniIcons.png:essence", false	]
-//	]
-	// isHiddenWhenEmpty	- If the player has less than 1, the currency will not be displayed
-	
-	
-	
-	// Going back the the tree definitions, I've mentioned custom functions.
-	// To utilize this option, you must create a .lua script file(s), and add its(their) path(s) to the following array:
-	// (again, make sure the functions have unique names to your mod so they don't override/get overriden)
-	// IMPORTANT: Make sure to properly test the functions and any potential edge cases before making your addition public if you want to avoid gigantic pains in the ass
-	"externalScripts" : [],
-	
-	// By following this example:
-//		"externalScripts" : ["/folder/myscriptfile.lua", "/zb/zb_util.lua"]
-	
-	
-	// Your tree can be easier to recognize with an icon, and you can give it one through this field:
-	"treeIcons" : {},
+  // NOTE: There is an empty template at the end of the document for easy copy-pasting
 
-	// Example:
-//	"treeIcons" : {
-//		"myTree" : "/path/to/icon.png"
-//	}
-	
-	// If you want your tree to have a custom background, you can easily add the path to the desired background into the following table:
-	// Note that the image is automatically tiled, and is used instead of the default grid tile image
-	"cutsomGridTileImages" : {}
-	
-	// By following this example:
-//	"cutsomGridTileImages":{
-//		"treeName" : "path/to/image.png",
-//		"myTree" : "/assetmissing.png"
-//	}
+  // This is a template file created to serve as documentation on how to define your own research trees.
+  // To add research to the game, you must first create a research tree.
+  // Trees are mainly used to split between multiple mods, so players don't end up with a cluttered mess on their screen
+  // But they can also be used to split research to categories. (Though I'd suggest putting all your research into one tree for less clutter and more "WOW THIS TREE IS AMAZING" factor)
+  // Make sure to give your trees unique names such as "zb_main" so you don't end up accidentally overriding someone elses tree, or your stuff getting overriden.
+  // This is where you define your research trees:
+  "researchTree" : {},
 
-	
-	// Sometimes you'd like to add blueprints to already existing researches, which may already be researched by players
-	// So instead of making them hack their way around to get the new blueprint, you simply add your tree and its version here:
-	// By doing so, the research system would readd all the blueprints for already finished researches when the version changes.
-	// No point in modifying it when you just add new research nodes. Modify it only when adding blueprints to already existing nodes instead.
-	// IMPORTANT: This will NOT call FUNCTIONS assigned to research because of potential exploitation
-	"versions" : {}
-	
-	// By following this example:
-//	"versions" : {
-//		"myTree" : "0.1",
-//	}
+  // By following this example:
+//  "researchTree" : {
+//    "myTree" : {  // replace with the desired tree identifier, this is NOT the displayed name
+//      "example1" : {
+//        "icon" : "image.png",
+//        "position" : [x, y],
+//        "price" : [["currency", 322], ["item", 1337]],
+//        "unlocks" : ["myResearchedItem", "myOtherItem"],  >> OPTIONAL
+//        "hideUnlocks" : true/false,              >> OPTIONAL
+//        "children" : ["example2"],              >> OPTIONAL
+//        "func" : "myFunctionName"              >> OPTIONAL
+//        "params" : "whatever the heck you need."      >> OPTIONAL
+//      },
+//      "example2" : {
+//        "icon" : "/assetmissing.png",
+//        "position" : [20, 30],
+//        "price" : [["money", 300], ["corefragmentore", 20]],
+//        "unlocks" : ["banana"]
+//      }
+//    }
+//  }
+  //  icon    - The image used to represent the research. Use "/assetmissing.png" if you want it blank. 16x16 sized images suggested, otherwise might look bad.
+  //  position  - The position of the research on the drag screen.
+  //  price    - An array of prices structured similar to how quest rewards are. Can use both currencies and items.
+  //  unlocks    - An array of blueprints the player would learn upon completing the research.
+  //  hideUnlocks  - By default, the info panel will display unlocked blue prints. Set this to true if you want to hide unlocks.
+  //  children  - An array of research names that this research leads to. This research is a requirement before you can unlock any of its children.
+  //  func    - A function you would like to call when the research is complete. We will cover this later
+  //  params    - Parameters for the above function
 
 
-	
-	// If you'd like, you could hide a research tree until the player has completed certain quests, or unlocked certain research in certain trees, or both!
-	"treeUnlocks" : {},
 
-	// Example:
-//	"treeUnlocks" : {
-//		"myTree" : {
-//			"quests" : [ "questId1", "questId2" ],
-//			"research" : {
-//				"myOtherTree" : [ "ACR1", "ACR2", "ACR5" ],
-//				"myOtherOTHERTree" : [ "STF11", "ZZ20", "TERA1" ]
-//			}
-//		},
-//		"yetAnotherTree" : {
-//			"research" : {
-//				"myTree" : [ "DD5" ],
-//			}
-//		},
-//	}
+  // Every research used in the tree MUST have an acronym.
+  // While research can't exist without an acronym, acronyms can exist without research, but they will be erased when the research trees version is updated to prevent reusing them by accident
+  // Make sure there are no duplicates of the same acronym on the same tree
+  // Don't worry about other mods/trees using the same acronyms, each tree has its acronyms stored and read separatly
+  // Note that updating the mod after changing already present acronyms, players who already have the pre-update acronyms will keep them, and the system will see the new acronyms as not researched.
+  // And this is where acronyms for research are defined:
+  "acronyms" : {},
 
-	// By default, researching consumes the curencies and items it costs. You can modify this behavior per tree via this table:
-	"customConsumptionRules" : { }
+  // By following this example:
+//  "acronyms" : {
+//    "myTree" : {
+//      "EXA1" : "example1",
+//      "EXA2" : "example2"
+//    }
+//  },
 
-	// Example:
-//	"customConsumptionRules" : {
-//		"myTree" : {"currency" : true, "items" : true }, // will consume both items and currencies
-//		"myOtherTree" : {"currency" : false, "items" : false }, // will consume neither items nor currencies
-//		"myOtherOTHERTree" : { }, // will consume both items and currencies
-// 	}
+
+
+  // To add strings to elements, you follow this table:
+  // (AVOID using colors for currencies and research titles, because currencies have their own color defined elsewhere, and research titles are color coded to display their status)
+  "strings" : {
+    "currencies" : {
+    //  "currencyName" : "Displayed Name",
+    //  "money" : "Pixels"
+    },
+    "trees" : {
+    //  "treeName" : "Displayed Tree Name",
+    //  "myTree" : "[^orange;ZB^reset;] My Research Tree"
+    },
+
+    "research" : {
+    //  "researchName" : [ "Research Title", "The text that is written below the title on the side view." ],
+    //  "example1" : [ "Example Research", "This research is an example." ]
+    }
+  },
+
+
+
+  // Every tree needs an origin point, and this is where we define them. Add the acronyms for researches you want to be initially researched.
+  // Note that a single tree can have multiple origins.
+  "initiallyResearched" : {},
+
+  // By following this example:
+//  "initiallyResearched" : {
+//    "myTree" : [ "EXA1" ]
+//  },
+
+
+
+
+  // If you want some research and its children to be hidden from the player until it becomes available, you do the same thing you did the previous step, but for this object:
+  "hiddenResearch" : {},
+
+  // By following this example:
+//  "hiddenResearch" : {
+//    "myTree" : [ "EXA2" ]
+//  },
+
+
+
+
+  // If your mod adds custom currencies you'd like to be visually available (So you don't have to open another pane to view them) you add them here:
+  "currencies" : [],
+
+  // By following this example:
+//  "currencies" : [
+//    [ "currencyName", "#currencyColor", "representingItem", "miniIconPath", isHiddenWhenEmpty?  ],
+//    [ "essence", "#FF22FF", "essence", "/zb/researchTree/currencyMiniIcons.png:essence", false  ]
+//  ]
+  // isHiddenWhenEmpty  - If the player has less than 1, the currency will not be displayed
+
+
+
+  // Going back the the tree definitions, I've mentioned custom functions.
+  // To utilize this option, you must create a .lua script file(s), and add its(their) path(s) to the following array:
+  // (again, make sure the functions have unique names to your mod so they don't override/get overriden)
+  // IMPORTANT: Make sure to properly test the functions and any potential edge cases before making your addition public if you want to avoid gigantic pains in the ass
+  "externalScripts" : [],
+
+  // By following this example:
+//    "externalScripts" : ["/folder/myscriptfile.lua", "/zb/zb_util.lua"]
+
+
+  // Your tree can be easier to recognize with an icon, and you can give it one through this field:
+  "treeIcons" : {},
+
+  // Example:
+//  "treeIcons" : {
+//    "myTree" : "/path/to/icon.png"
+//  }
+
+  // If you want your tree to have a custom background, you can easily add the path to the desired background into the following table:
+  // Note that the image is automatically tiled, and is used instead of the default grid tile image
+  "cutsomGridTileImages" : {}
+
+  // By following this example:
+//  "cutsomGridTileImages":{
+//    "treeName" : "path/to/image.png",
+//    "myTree" : "/assetmissing.png"
+//  }
+
+
+  // Sometimes you'd like to add blueprints to already existing researches, which may already be researched by players
+  // So instead of making them hack their way around to get the new blueprint, you simply add your tree and its version here:
+  // By doing so, the research system would read all the blueprints for already finished researches when the version changes.
+  // No point in modifying it when you just add new research nodes. Modify it only when adding blueprints to already existing nodes instead.
+  // IMPORTANT: This will NOT call FUNCTIONS assigned to research because of potential exploitation
+  "versions" : {}
+
+  // By following this example:
+//  "versions" : {
+//    "myTree" : "0.1",
+//  }
+
+
+
+  // If you'd like, you could hide a research tree until the player has completed certain quests, or unlocked certain research in certain trees, or both!
+  "treeUnlocks" : {},
+
+  // Example:
+//  "treeUnlocks" : {
+//    "myTree" : {
+//      "quests" : [ "questId1", "questId2" ],
+//      "research" : {
+//        "myOtherTree" : [ "ACR1", "ACR2", "ACR5" ],
+//        "myOtherOTHERTree" : [ "STF11", "ZZ20", "TERA1" ]
+//      }
+//    },
+//    "yetAnotherTree" : {
+//      "research" : {
+//        "myTree" : [ "DD5" ],
+//      }
+//    },
+//  }
+
+  // By default, researching consumes the curencies and items it costs. You can modify this behavior per tree via this table:
+  "customConsumptionRules" : { }
+
+  // Example:
+//  "customConsumptionRules" : {
+//    "myTree" : {"currency" : true, "items" : true }, // will consume both items and currencies
+//    "myOtherTree" : {"currency" : false, "items" : false }, // will consume neither items nor currencies
+//    "myOtherOTHERTree" : { }, // will consume both items and currencies
+//   }
 
 }
-	
-	// To ease testing your tree, I've implemented some debug commands.
-	// To access the cheat console, you must click the gray smiley face that appears in the bottom left of the screen that appears only when you're in admin mode.
-	// These are the commands you can use:
-	//
-	// nocosttoogreat					- Toggle free researches
-	// iamabeaconofknowledge			- Research everything
-	// forgottenmemories				- Reset researches
-	// revealourselves					- Unhides all researches
-	// nostringsonme					- Disables "read only" mode
-	// kotlgiffmana	[acronym string]	- Research the specified acronyms in the current research tree
-	// bankrupt							- Resets all currencies displayed on the side to 0
-	
-	
-	// Empty table for easy-copy pasting:
+
+
+  // To ease testing your tree, I've implemented some debug commands.
+  // To access the cheat console, you must click the gray smiley face that appears in the bottom left of the screen that appears only when you're in admin mode.
+
+  // NOTE: To see the cheat console you must uncomment line 148 in /zb/researchTree/researchTree.lua
+
+  // These are the commands you can use:
+  //
+  // nocosttoogreat				- Toggle free researches
+  // iamabeaconofknowledge			- Research everything
+  // forgottenmemories			- Reset researches
+  // revealourselves				- Unhides all researches
+  // nostringsonme				- Disables "read only" mode
+  // kotlgiffmana [acronym string]		- Research the specified acronyms in the current research tree
+  // bankrupt				- Resets all currencies displayed on the side to 0
+
+
+
+  // Empty table for easy-copy pasting:
 {
-	"researchTree" : {},
-	"acronyms" : {},
-	"strings" : {},
-	"initiallyResearched" : {},
-	"hiddenResearch" : {},
-	"currencies" : [],
-	"externalScripts" : [],
-	"cutsomGridTileImages" : {},
-	"versions" : {},
-	"treeUnlocks" : {},
-	"customConsumptionRules" : {},
-	"treeIcons" : {}
+  "researchTree" : {},
+  "acronyms" : {},
+  "strings" : {},
+  "initiallyResearched" : {},
+  "hiddenResearch" : {},
+  "currencies" : [],
+  "externalScripts" : [],
+  "cutsomGridTileImages" : {},
+  "versions" : {},
+  "treeUnlocks" : {},
+  "customConsumptionRules" : {},
+  "treeIcons" : {}
 }

--- a/codex/thelusian/thelusian6.codex
+++ b/codex/thelusian/thelusian6.codex
@@ -1,7 +1,7 @@
 {
   "id" : "thelusian6",
   "species" : "thelusian",
-  "title" : "The Xi'an Link",
+  "title" : "The X'ian Link",
   "description" : "Thelusian Life Vol 6",
   "icon" : "ffbook4.png",
   "contentPages" : [

--- a/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_dungeon_apexmining.json
+++ b/dungeons/microdungeons/fuasteroidbelt/fuasteroidbelt_dungeon_apexmining.json
@@ -239,7 +239,7 @@
                  "name":"",
                  "properties":
                     {
-                     "parameters":"{ \"detectArea\" : [ [-11, -7], [24, 10] ], \"detectDamageTeams\" : [ \"enemy\" ]}"
+                     "parameters":"{ \"detectArea\" : [ [-10, -6], [21, 10] ], \"detectDamageTeam\" : { \"type\" : \"enemy\" } }"
                     },
                  "propertytypes":
                     {
@@ -319,7 +319,7 @@
                  "name":"",
                  "properties":
                     {
-                     "parameters":"{ \"detectArea\" : [ [-15, -9], [15, 4] ], \"detectDamageTeams\" : [ \"enemy\" ]}"
+                     "parameters":"{ \"detectArea\" : [ [-12, -8], [13, 4] ], \"detectDamageTeam\" : { \"type\" : \"enemy\" } }"
                     },
                  "propertytypes":
                     {
@@ -359,7 +359,7 @@
                  "name":"",
                  "properties":
                     {
-                     "parameters":"{ \"detectArea\" : [ [-22, -12], [17, 10] ], \"detectDamageTeams\" : [ \"enemy\" ]}"
+                     "parameters":"{ \"detectArea\" : [ [-22, -14], [19, 14] ], \"detectDamageTeam\" : { \"type\" : \"enemy\" } }"
                     },
                  "propertytypes":
                     {

--- a/items/active/grapplinghooks/grapplinghook.lua
+++ b/items/active/grapplinghooks/grapplinghook.lua
@@ -194,7 +194,7 @@ function firePosition()
 end
 
 function updateRope(newRope)
-  local position = mcontroller.position()
+--  local position = mcontroller.position()
   local previousRopeCount = #self.rope
   self.rope = newRope
   self.ropeLength = 0

--- a/items/active/grapplinghooks/grapplinghook.lua
+++ b/items/active/grapplinghooks/grapplinghook.lua
@@ -1,0 +1,210 @@
+require "/scripts/util.lua"
+require "/scripts/vec2.lua"
+require "/scripts/rope.lua"
+
+function init()
+  self.fireOffset = config.getParameter("fireOffset")
+  self.ropeOffset = config.getParameter("ropeOffset")
+  self.ropeVisualOffset = config.getParameter("ropeVisualOffset")
+  self.consumeOnUse = config.getParameter("consumeOnUse")
+  self.projectileType = config.getParameter("projectileType")
+  self.projectileParameters = config.getParameter("projectileParameters")
+  self.reelInDistance = config.getParameter("reelInDistance")
+  self.reelOutLength = config.getParameter("reelOutLength")
+  self.breakLength = config.getParameter("breakLength")
+  self.minSwingDistance = config.getParameter("minSwingDistance")
+  self.reelSpeed = config.getParameter("reelSpeed")
+  self.controlForce = config.getParameter("controlForce")
+  self.groundLagTime = config.getParameter("groundLagTime")
+
+  self.rope = {}
+  self.ropeLength = 0
+  self.aimAngle = 0
+  self.onGround = false
+  self.onGroundTimer = 0
+  self.facingDirection = 0
+  self.projectileId = nil
+  self.projectilePosition = nil
+  self.anchored = false
+  self.previousMoves = {}
+  self.previousFireMode = nil
+end
+
+function uninit()
+  cancel()
+end
+
+function update(dt, fireMode, shiftHeld, moves)
+  if fireMode == "primary" and self.previousFireMode ~= "primary" then
+    if self.projectileId then
+      cancel()
+    elseif status.stat("activeMovementAbilities") < 1 then
+      fire()
+    end
+  end
+  self.previousFireMode = fireMode
+
+  self.aimAngle, self.facingDirection = activeItem.aimAngleAndDirection(self.fireOffset[2], activeItem.ownerAimPosition())
+  activeItem.setFacingDirection(self.facingDirection)
+
+  trackGround(dt)
+  trackProjectile()
+
+  if self.projectileId then
+    if world.entityExists(self.projectileId) then
+      local position = mcontroller.position()
+      local handPosition = vec2.add(position, activeItem.handPosition(self.ropeOffset))
+
+      local newRope
+      if #self.rope == 0 then
+        newRope = {handPosition, self.projectilePosition}
+      else
+        newRope = copy(self.rope)
+        table.insert(newRope, 1, world.nearestTo(newRope[1], handPosition))
+        table.insert(newRope, world.nearestTo(newRope[#newRope], self.projectilePosition))
+      end
+
+      windRope(newRope)
+      updateRope(newRope)
+
+      if not self.anchored and self.ropeLength > self.reelOutLength then
+        cancel()
+      end
+    else
+      cancel()
+    end
+  end
+
+  if self.ropeLength > self.breakLength then
+    cancel()
+  end
+
+  if self.anchored then
+    swing(moves)
+  else
+    activeItem.setArmAngle(self.aimAngle)
+  end
+end
+
+function trackProjectile()
+  if self.projectileId then
+    if world.entityExists(self.projectileId) then
+      local position = mcontroller.position()
+      self.projectilePosition = vec2.add(world.distance(world.entityPosition(self.projectileId), position), position)
+      if not self.anchored then
+        self.anchored = world.callScriptedEntity(self.projectileId, "anchored")
+      end
+    else
+      cancel()
+    end
+  end
+end
+
+function trackGround(dt)
+  if mcontroller.onGround() then
+    self.onGround = true
+    self.onGroundTimer = self.groundLagTime
+  else
+    self.onGroundTimer = self.onGroundTimer - dt
+    if self.onGroundTimer < 0 then
+      self.onGround = false
+    end
+  end
+end
+
+function fire()
+  cancel()
+
+  local aimVector = vec2.rotate({1, 0}, self.aimAngle)
+  aimVector[1] = aimVector[1] * self.facingDirection
+
+  self.projectileId = world.spawnProjectile(
+      self.projectileType,
+      firePosition(),
+      activeItem.ownerEntityId(),
+      aimVector,
+      false,
+      self.projectileParameters
+    )
+
+  if self.projectileId then
+    animator.playSound("fire")
+    status.setPersistentEffects("grapplingHook"..activeItem.hand(), {{stat = "activeMovementAbilities", amount = 0.5}})
+  end
+end
+
+function cancel()
+  if self.projectileId and world.entityExists(self.projectileId) then
+    world.callScriptedEntity(self.projectileId, "kill")
+  end
+  if self.projectileId and self.anchored and self.consumeOnUse then
+    item.consume(1)
+  end
+  self.projectileId = nil
+  self.projectilePosition = nil
+  self.anchored = false
+  updateRope({})
+  status.clearPersistentEffects("grapplingHook"..activeItem.hand())
+end
+
+function swing(moves)
+  local canReel = self.ropeLength > self.reelInDistance or world.magnitude(self.rope[2], mcontroller.position()) > self.reelInDistance
+
+  local armAngle = activeItem.aimAngle(self.fireOffset[2], self.rope[2])
+  local pullDirection = vec2.withAngle(armAngle)
+  activeItem.setArmAngle(self.facingDirection == 1 and armAngle or math.pi - armAngle)
+
+  if world.magnitude(self.projectilePosition, mcontroller.position()) < self.minSwingDistance then
+    --do nothing
+  elseif self.onGround then
+    if (moves.up and canReel) or self.ropeLength > self.reelOutLength then
+      mcontroller.controlApproachVelocityAlongAngle(vec2.angle(pullDirection), self.reelSpeed, self.controlForce, true)
+    end
+  else
+    if moves.down and self.ropeLength < self.reelOutLength then
+      mcontroller.controlApproachVelocityAlongAngle(vec2.angle(pullDirection), -self.reelSpeed, self.controlForce, true)
+    elseif moves.up and canReel then
+      mcontroller.controlApproachVelocityAlongAngle(vec2.angle(pullDirection), self.reelSpeed, self.controlForce, true)
+    elseif pullDirection[2] > 0 or self.ropeLength > self.reelOutLength or world.gravity(mcontroller.position()) <= 0 or status.statusProperty("fu_byosnogravity", false) then
+      --grappling hooks in zero-gravity swing in circles rather than arcs
+      mcontroller.controlApproachVelocityAlongAngle(vec2.angle(pullDirection), 0, self.controlForce, true)
+    end
+
+    if moves.jump and not self.previousMoves.jump then
+      if not mcontroller.canJump() then
+        mcontroller.controlJump(true)
+      end
+      cancel()
+    end
+  end
+
+  self.previousMoves = moves
+end
+
+function firePosition()
+  local entityPos = mcontroller.position()
+  local barrelOffset = activeItem.handPosition(self.fireOffset)
+  local barrelPosition = vec2.add(entityPos, barrelOffset)
+  local collidePoint = world.lineCollision(entityPos, barrelPosition)
+  if collidePoint then
+    return vec2.add(entityPos, vec2.mul(barrelOffset, vec2.mag(barrelOffset) - 0.5))
+  else
+    return barrelPosition
+  end
+end
+
+function updateRope(newRope)
+  local position = mcontroller.position()
+  local previousRopeCount = #self.rope
+  self.rope = newRope
+  self.ropeLength = 0
+
+  activeItem.setScriptedAnimationParameter("ropeOffset", self.ropeVisualOffset)
+  for i = 2, #self.rope do
+    self.ropeLength = self.ropeLength + world.magnitude(self.rope[i], self.rope[i - 1])
+    activeItem.setScriptedAnimationParameter("p" .. i, self.rope[i])
+  end
+  for i = #self.rope + 1, previousRopeCount do
+    activeItem.setScriptedAnimationParameter("p" .. i, nil)
+  end
+end

--- a/items/active/weapons/ranged/unique/peglaci/splittergun/splittergun.activeitem
+++ b/items/active/weapons/ranged/unique/peglaci/splittergun/splittergun.activeitem
@@ -38,7 +38,7 @@
 
   "scripts" : ["/items/active/weapons/ranged/gun.lua"],
 
-  "elementalType" : "poison",
+  "elementalType" : "electric",
 
   "primaryAbility" : {
     "scripts" : ["/items/active/weapons/ranged/gunfire.lua"],

--- a/items/armors/bees/fugoldenknight/fugoldenchest.chest
+++ b/items/armors/bees/fugoldenknight/fugoldenchest.chest
@@ -26,7 +26,7 @@
   },
 
   "level" : 5,
-  //"collectablesOnPickup" : { "fu_armortank" : "fugoldenchest" },
+//  "collectablesOnPickup" : { "fu_armortank" : "fugoldenchest" },
   "leveledStatusEffects" : [
     {
       "levelFunction" : "standardArmorLevelPowerMultiplierMultiplier",

--- a/items/armors/bees/fuqueen/fuqueenschest.chest
+++ b/items/armors/bees/fuqueen/fuqueenschest.chest
@@ -7,7 +7,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;25^reset;% Speed, +^green;15^reset;% Jump
 ^yellow;^reset; Bee Weapons: +^green;8^reset;% Crit Chance, +^green;50^reset;% Crit Damage, Damage x^green;1.2^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Beestings, Extreme Radiation",
+^yellow;^reset; ^cyan;Immune^reset;: Beestings, Honey, Extreme Radiation",
   "shortdescription" : "Queen's Dress",
   "category" : "chestarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/bees/fuqueen/fuqueenshead.head
+++ b/items/armors/bees/fuqueen/fuqueenshead.head
@@ -7,7 +7,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;25^reset;% Speed, +^green;15^reset;% Jump
 ^yellow;^reset; Bee Weapons: +^green;8^reset;% Crit Chance, +^green;50^reset;% Crit Damage, Damage x^green;1.2^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Beestings, Extreme Radiation",
+^yellow;^reset; ^cyan;Immune^reset;: Beestings, Honey, Extreme Radiation",
   "shortdescription" : "Queen's Head",
   "category" : "headarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/bees/fuqueen/fuqueenslegs.legs
+++ b/items/armors/bees/fuqueen/fuqueenslegs.legs
@@ -7,7 +7,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;25^reset;% Speed, +^green;15^reset;% Jump
 ^yellow;^reset; Bee Weapons: +^green;8^reset;% Crit Chance, +^green;50^reset;% Crit Damage, Damage x^green;1.2^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Beestings, Extreme Radiation",
+^yellow;^reset; ^cyan;Immune^reset;: Beestings, Honey, Extreme Radiation",
   "shortdescription" : "Queen's Skirt",
   "category" : "legarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier1/fubonearmor/fubone.chest
+++ b/items/armors/tier1/fubonearmor/fubone.chest
@@ -14,9 +14,9 @@
 	"tooltipKind": "armornew2",
 //	"learnBlueprintsOnPickup": [
 //		"fubonearmor2head",
- //	 "fubonearmor2chest",
+// 	 "fubonearmor2chest",
 //		"fubonearmor2legs"
- // ],
+//  ],
 	"maleFrames": {
 		"body": "chestm.png",
 		"backSleeve": "bsleeve.png",

--- a/items/armors/tier2/battletotem/beararmor.chest
+++ b/items/armors/tier2/battletotem/beararmor.chest
@@ -11,11 +11,11 @@
 ^yellow;^reset; ^cyan;Immune^reset;: Slush, Chill",
 
 	"shortdescription": "Battle Totem Jerkin",
- // "learnBlueprintsOnPickup": [
- //	 "fubearchest2",
- //	 "fubearhead2",
- //	 "fubearlegs2"
- // ],
+//  "learnBlueprintsOnPickup": [
+// 	 "fubearchest2",
+// 	 "fubearhead2",
+// 	 "fubearlegs2"
+//  ],
 	"category": "chestarmour",
 	"tooltipKind": "armornew2",
 

--- a/items/armors/tier2/fangshaman/wolf.chest
+++ b/items/armors/tier2/fangshaman/wolf.chest
@@ -5,6 +5,7 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Dagger Mastery: +^green;15^reset;%
 ^yellow;^reset; Dagger/Shortsword: +^green;10^reset;/^green;20^reset;% Crit Damage
 ^yellow;^reset; ^cyan;Immune^reset;: Snow, Chill^reset;",
 

--- a/items/armors/tier2/fangshaman/wolf.head
+++ b/items/armors/tier2/fangshaman/wolf.head
@@ -5,6 +5,7 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Dagger Mastery: +^green;15^reset;%
 ^yellow;^reset; Dagger/Shortsword: +^green;10^reset;/^green;20^reset;% Crit Damage
 ^yellow;^reset; ^cyan;Immune^reset;: Snow, Chill^reset;",
 

--- a/items/armors/tier2/fangshaman/wolf.legs
+++ b/items/armors/tier2/fangshaman/wolf.legs
@@ -5,6 +5,7 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Dagger Mastery: +^green;15^reset;%
 ^yellow;^reset; Dagger/Shortsword: +^green;10^reset;/^green;20^reset;% Crit Damage
 ^yellow;^reset; ^cyan;Immune^reset;: Snow, Chill^reset;",
 

--- a/items/armors/tier2/ff_slimearmor/ff_slimearmor.head
+++ b/items/armors/tier2/ff_slimearmor/ff_slimearmor.head
@@ -12,11 +12,7 @@
 
   "shortdescription" : "Slime Helm",
   "category" : "headarmour",
-  "learnBlueprintsOnPickup" : [
-    "ff_slimechest2",
-    "ff_slimehead2",
-    "ff_slimelegs2"
-  ],
+  //"learnBlueprintsOnPickup" : ["ff_slimechest2","ff_slimehead2","ff_slimelegs2"],
   "tooltipKind" : "armornew2",
   "maleFrames" : "head.png",
   "femaleFrames" : "head.png",

--- a/items/armors/tier2/ff_slimearmor/ff_slimearmor.legs
+++ b/items/armors/tier2/ff_slimearmor/ff_slimearmor.legs
@@ -12,11 +12,7 @@
 
   "shortdescription" : "Slime Greaves",
   "category" : "legarmour",
-  "learnBlueprintsOnPickup" : [
-    "ff_slimechest2",
-    "ff_slimehead2",
-    "ff_slimelegs2"
-  ],
+  //"learnBlueprintsOnPickup" : ["ff_slimechest2","ff_slimehead2","ff_slimelegs2"],
   "tooltipKind" : "armornew2",
   "maleFrames" : "pants.png",
   "femaleFrames" : "pants.png",

--- a/items/armors/tier2/lunariarmor/lunari.chest
+++ b/items/armors/tier2/lunariarmor/lunari.chest
@@ -5,7 +5,8 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
-^yellow;^reset; +^green;12^reset;% Energy Regen, -^green;10^reset;% Fuel Cost^reset;
+^yellow;^reset; -^green;10^reset;% Ship Fuel Cost^reset;
+^yellow;^reset; +^green;12^reset;% Energy Regen
 ^yellow;^reset; Lunari weapons: Damage x^green;1.15^reset;, +^green;4^reset;% Crit Chance",
 
 	"shortdescription": "Lunari Armor",

--- a/items/armors/tier2/lunariarmor/lunari.head
+++ b/items/armors/tier2/lunariarmor/lunari.head
@@ -5,7 +5,8 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
-^yellow;^reset; +^green;12^reset;% Energy Regen, -^green;10^reset;% Fuel Cost^reset;
+^yellow;^reset; -^green;10^reset;% Ship Fuel Cost^reset;
+^yellow;^reset; +^green;12^reset;% Energy Regen
 ^yellow;^reset; Lunari weapons: Damage x^green;1.15^reset;, +^green;4^reset;% Crit Chance",
 
 	"shortdescription": "Lunari Helm",

--- a/items/armors/tier2/lunariarmor/lunari.legs
+++ b/items/armors/tier2/lunariarmor/lunari.legs
@@ -5,7 +5,8 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
-^yellow;^reset; +^green;12^reset;% Energy Regen, -^green;10^reset;% Fuel Cost^reset;
+^yellow;^reset; -^green;10^reset;% Ship Fuel Cost^reset;
+^yellow;^reset; +^green;12^reset;% Energy Regen
 ^yellow;^reset; Lunari weapons: Damage x^green;1.15^reset;, +^green;4^reset;% Crit Chance",
 
 	"shortdescription": "Lunari Greaves",

--- a/items/armors/tier2/mantiziroyalguard/royalguard.chest
+++ b/items/armors/tier2/mantiziroyalguard/royalguard.chest
@@ -5,6 +5,7 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Shortspear Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;15^reset;% Knockback Resist
 ^yellow;^reset; Defense x^green;1.15^reset;
 ^yellow;^reset; All Spears: Damage x^green;1.15^reset;",

--- a/items/armors/tier2/mantiziroyalguard/royalguard.head
+++ b/items/armors/tier2/mantiziroyalguard/royalguard.head
@@ -3,8 +3,9 @@
 	"price": 450,
 	"inventoryIcon": "icons.png:head",
 	"maxStack": 1,
-	"rarity": "common",
+	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Shortspear Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;15^reset;% Knockback Resist
 ^yellow;^reset; Defense x^green;1.15^reset;
 ^yellow;^reset; All Spears: Damage x^green;1.15^reset;",

--- a/items/armors/tier2/mantiziroyalguard/royalguard.legs
+++ b/items/armors/tier2/mantiziroyalguard/royalguard.legs
@@ -5,6 +5,7 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Shortspear Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;15^reset;% Knockback Resist
 ^yellow;^reset; Defense x^green;1.15^reset;
 ^yellow;^reset; All Spears: Damage x^green;1.15^reset;",

--- a/items/armors/tier2/mantiziroyalguardornate/royalguardornate.chest
+++ b/items/armors/tier2/mantiziroyalguardornate/royalguardornate.chest
@@ -5,6 +5,7 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Shortsword/Longsword/Mace Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;17^reset;% Shield Health and Regen
 ^yellow;^reset; Sword/Mace and Shield: +^green;2^reset;% Crit Chance, +^green;15^reset;% Crit Damage, +^green;15^reset;% Knockback Resist",
 

--- a/items/armors/tier2/mantiziroyalguardornate/royalguardornate.head
+++ b/items/armors/tier2/mantiziroyalguardornate/royalguardornate.head
@@ -5,6 +5,7 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Shortsword/Longsword/Mace Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;17^reset;% Shield Health and Regen
 ^yellow;^reset; Sword/Mace and Shield: +^green;2^reset;% Crit Chance, +^green;15^reset;% Crit Damage, +^green;15^reset;% Knockback Resist",
 

--- a/items/armors/tier2/mantiziroyalguardornate/royalguardornate.legs
+++ b/items/armors/tier2/mantiziroyalguardornate/royalguardornate.legs
@@ -5,6 +5,7 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Shortsword/Longsword/Mace Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;17^reset;% Shield Health and Regen
 ^yellow;^reset; Sword/Mace and Shield: +^green;2^reset;% Crit Chance, +^green;15^reset;% Crit Damage, +^green;15^reset;% Knockback Resist",
 

--- a/items/armors/tier2/nomad/fudesertwalker.chest
+++ b/items/armors/tier2/nomad/fudesertwalker.chest
@@ -8,7 +8,7 @@
 ^yellow;^reset; +^green;20^reset;% Shield Regen^reset;
 ^yellow;^reset; Dagger/Shortspear: Damage x^green;1.15^reset;
 ^yellow;^reset; Assault/Sniper Rifle: Damage x^green;1.08^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Burning, Deserts",
+^yellow;^reset; ^cyan;Immune^reset;: Burning, Sandstorms, Quicksand",
 
 	"shortdescription": "Nomad Robes",
 	"category": "chestarmour",

--- a/items/armors/tier2/nomad/fudesertwalker.head
+++ b/items/armors/tier2/nomad/fudesertwalker.head
@@ -8,7 +8,7 @@
 ^yellow;^reset; +^green;20^reset;% Shield Regen^reset;
 ^yellow;^reset; Dagger/Shortspear: Damage x^green;1.15^reset;
 ^yellow;^reset; Assault/Sniper Rifle: Damage x^green;1.08^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Burning, Deserts",
+^yellow;^reset; ^cyan;Immune^reset;: Burning, Sandstorms, Quicksand",
 
 	"shortdescription": "Nomad Hood",
 	"category": "headarmour",

--- a/items/armors/tier2/nomad/fudesertwalker.legs
+++ b/items/armors/tier2/nomad/fudesertwalker.legs
@@ -8,7 +8,7 @@
 ^yellow;^reset; +^green;20^reset;% Shield Regen^reset;
 ^yellow;^reset; Dagger/Shortspear: Damage x^green;1.15^reset;
 ^yellow;^reset; Assault/Sniper Rifle: Damage x^green;1.08^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Burning, Deserts",
+^yellow;^reset; ^cyan;Immune^reset;: Burning, Sandstorms, Quicksand",
 
 	"shortdescription": "Nomad Pants",
 	"category": "legarmour",

--- a/items/armors/tier2/swashbuckler/cannoneer.chest
+++ b/items/armors/tier2/swashbuckler/cannoneer.chest
@@ -5,8 +5,9 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Rapier Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;8^reset;% Jump, -^green;20^reset;% Hunger Drain
-^yellow;^reset; Rapier/Pistol: Damage x^green;1.075^reset;/^green;1.15^reset;.",
+^yellow;^reset; Rapier/Pistol: Damage x^green;1.075^reset;/^green;1.15^reset;",
 
 "shortdescription": "Swashbuckler Coat",
 	"category": "chestarmour",

--- a/items/armors/tier2/swashbuckler/cannoneer.head
+++ b/items/armors/tier2/swashbuckler/cannoneer.head
@@ -5,8 +5,9 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Rapier Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;8^reset;% Jump, -^green;20^reset;% Hunger Drain
-^yellow;^reset; Rapier/Pistol: Damage x^green;1.075^reset;/^green;1.15^reset;.",
+^yellow;^reset; Rapier/Pistol: Damage x^green;1.075^reset;/^green;1.15^reset;",
 
 "shortdescription": "Swashbuckler Hat",
 	"category": "headarmour",

--- a/items/armors/tier2/swashbuckler/cannoneer.legs
+++ b/items/armors/tier2/swashbuckler/cannoneer.legs
@@ -5,8 +5,9 @@
 	"maxStack": 1,
 	"rarity": "Common",
 	"description": "^orange;Set Bonuses^reset;:
+^yellow;^reset; Rapier Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;8^reset;% Jump, -^green;20^reset;% Hunger Drain
-^yellow;^reset; Rapier/Pistol: Damage x^green;1.075^reset;/^green;1.15^reset;.",
+^yellow;^reset; Rapier/Pistol: Damage x^green;1.075^reset;/^green;1.15^reset;",
 
 	"shortdescription": "Swashbuckler Pants",
 	"category": "legarmour",

--- a/items/armors/tier3/battleborn/test1.chest
+++ b/items/armors/tier3/battleborn/test1.chest
@@ -5,8 +5,9 @@
   "maxStack" : 1,
   "rarity" : "Uncommon",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Cyber/Wasteland: Health x^green;1.24^reset;, Damage x^green;1.12^reset;, 10% Phys./Poison Resist
-^yellow;^reset; ^cyan;Immune^reset;: Acid.",
+^yellow;^reset; Broadsword Mastery: +^green;15^reset;%
+^yellow;^reset; Cyber/Wasteland/Scorched: Health x^green;1.24^reset;, Damage x^green;1.12^reset;, ^cyan;10^reset;% Phys./Poison Resist
+^yellow;^reset; ^cyan;Immune^reset;: Acid",
   "shortdescription" : "Battleborn Plate",
   "category" : "chestarmour",
   "tooltipKind" : "armornew2",
@@ -97,6 +98,6 @@
     /* BROWN */
     { "ffca8a" : "ccae7c", "e0975c" : "a47844", "a85636" : "754c23", "6f2919" : "472b13" }
 ],
-  //"upgrades" : 1 ,
+//  "upgrades" : 1 ,
   "builder" : "/items/buildscripts/fubuildarmor.lua"
 }

--- a/items/armors/tier3/battleborn/test1.head
+++ b/items/armors/tier3/battleborn/test1.head
@@ -5,8 +5,9 @@
   "maxStack" : 1,
   "rarity" : "Uncommon",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Cyber/Wasteland: Health x^green;1.24^reset;, Damage x^green;1.12^reset;, 10% Phys./Poison Resist
-^yellow;^reset; ^cyan;Immune^reset;: Acid.",
+^yellow;^reset; Broadsword Mastery: +^green;15^reset;%
+^yellow;^reset; Cyber/Wasteland/Scorched: Health x^green;1.24^reset;, Damage x^green;1.12^reset;, ^cyan;10^reset;% Phys./Poison Resist
+^yellow;^reset; ^cyan;Immune^reset;: Acid",
   "shortdescription" : "Battleborn Helm",
   "category" : "headarmour",
   "tooltipKind" : "armornew2",
@@ -17,8 +18,8 @@
 
 //  "learnBlueprintsOnPickup" : [
 //    "fukingslayerhead",
- //   "fukingslayerchest",
- //   "fukingslayerpants"
+//    "fukingslayerchest",
+//    "fukingslayerpants"
 //  ],
   "itemTags" : [ "upgradeableWeapon", "defensive", "melee" ],
   "level" : 3,
@@ -88,6 +89,6 @@
     /* BROWN */
     { "ffca8a" : "ccae7c", "e0975c" : "a47844", "a85636" : "754c23", "6f2919" : "472b13" }
 ],
-  //"upgrades" : 1 ,
+//  "upgrades" : 1 ,
   "builder" : "/items/buildscripts/fubuildarmor.lua"
 }

--- a/items/armors/tier3/battleborn/test1.legs
+++ b/items/armors/tier3/battleborn/test1.legs
@@ -5,8 +5,9 @@
   "maxStack" : 1,
   "rarity" : "Uncommon",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Cyber/Wasteland: Health x^green;1.24^reset;, Damage x^green;1.12^reset;, 10% Phys./Poison Resist
-^yellow;^reset; ^cyan;Immune^reset;: Acid.",
+^yellow;^reset; Broadsword Mastery: +^green;15^reset;%
+^yellow;^reset; Cyber/Wasteland/Scorched: Health x^green;1.24^reset;, Damage x^green;1.12^reset;, ^cyan;10^reset;% Phys./Poison Resist
+^yellow;^reset; ^cyan;Immune^reset;: Acid",
   "shortdescription" : "Battleborn Greaves",
   "category" : "legarmour",
   "tooltipKind" : "armornew2",
@@ -14,11 +15,11 @@
   "maleFrames" : "pants.png",
   "femaleFrames" : "pants.png",
 
- // "learnBlueprintsOnPickup" : [
+//  "learnBlueprintsOnPickup" : [
 //    "fukingslayerhead",
- //   "fukingslayerchest",
- //   "fukingslayerpants"
- // ],
+//    "fukingslayerchest",
+//    "fukingslayerpants"
+//  ],
   "itemTags" : [ "upgradeableWeapon", "defensive", "melee" ],
   "level" : 3,
   "leveledStatusEffects" : [
@@ -87,6 +88,6 @@
     /* BROWN */
     { "ffca8a" : "ccae7c", "e0975c" : "a47844", "a85636" : "754c23", "6f2919" : "472b13" }
 ],
-  //"upgrades" : 1 ,
+//  "upgrades" : 1 ,
   "builder" : "/items/buildscripts/fubuildarmor.lua"
 }

--- a/items/armors/tier3/chaos/test1.chest
+++ b/items/armors/tier3/chaos/test1.chest
@@ -5,13 +5,14 @@
   "maxStack" : 1,
   "rarity" : "Uncommon",
   "description" : "^orange;Set Bonuses^reset;:
+^yellow;^reset; Dagger Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;0.5^reset;% Health Regen
 ^yellow;^reset; +^green;10^reset;% Speed
 ^yellow;^reset; Daggers, Whips, Boomerangs, Chakrams: +^green;3^reset;% Crit Chance",
-  "itemTags" : [ "upgradeableWeapon", "offensive" ],
   "shortdescription" : "Chaos Robe",
   "category" : "chestarmour",
   "tooltipKind" : "armornew2",
+  "itemTags" : [ "upgradeableWeapon", "offensive" ],
 
   "maleFrames" : {
     "body" : "chestm.png",

--- a/items/armors/tier3/chaos/test1.head
+++ b/items/armors/tier3/chaos/test1.head
@@ -5,6 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Uncommon",
   "description" : "^orange;Set Bonuses^reset;:
+^yellow;^reset; Dagger Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;0.5^reset;% Health Regen
 ^yellow;^reset; +^green;10^reset;% Speed
 ^yellow;^reset; Daggers, Whips, Boomerangs, Chakrams: +^green;3^reset;% Crit Chance",

--- a/items/armors/tier3/chaos/test1.legs
+++ b/items/armors/tier3/chaos/test1.legs
@@ -5,6 +5,7 @@
   "maxStack" : 1,
   "rarity" : "Uncommon",
   "description" : "^orange;Set Bonuses^reset;:
+^yellow;^reset; Dagger Mastery: +^green;15^reset;%
 ^yellow;^reset; +^green;0.5^reset;% Health Regen
 ^yellow;^reset; +^green;10^reset;% Speed
 ^yellow;^reset; Daggers, Whips, Boomerangs, Chakrams: +^green;3^reset;% Crit Chance",

--- a/items/armors/tier3/fujunker/fujunker.chest
+++ b/items/armors/tier3/fujunker/fujunker.chest
@@ -8,7 +8,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;200^reset;s Oxygen, +^green;15^reset;% E. Regen, -^green;10^reset;% E. Regen Block
 ^yellow;^reset; +^green;450^reset;% Bomb Tech Damage
-^yellow;^reset; +^green;35^reset;% Dash Tech Speed
+^yellow;^reset; +^green;35^reset;% Dash/Dodge Tech Speed
 ^yellow;^reset; +^green;15^reset;% Jump Tech Height
 ^yellow;^reset; ^cyan;Immune^reset;: Acid, Gas",
   "shortdescription" : "Junker Chestpiece",

--- a/items/armors/tier3/fujunker/fujunker.head
+++ b/items/armors/tier3/fujunker/fujunker.head
@@ -9,7 +9,7 @@
 ^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;200^reset;s Oxygen, +^green;15^reset;% E. Regen, -^green;10^reset;% E. Regen Block
 ^yellow;^reset; +^green;450^reset;% Bomb Tech Damage
-^yellow;^reset; +^green;35^reset;% Dash Tech Speed
+^yellow;^reset; +^green;35^reset;% Dash/Dodge Tech Speed
 ^yellow;^reset; +^green;15^reset;% Jump Tech Height
 ^yellow;^reset; ^cyan;Immune^reset;: Acid, Gas",
   "shortdescription" : "Junker Helm",

--- a/items/armors/tier3/fujunker/fujunker.legs
+++ b/items/armors/tier3/fujunker/fujunker.legs
@@ -8,7 +8,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;200^reset;s Oxygen, +^green;15^reset;% E. Regen, -^green;10^reset;% E. Regen Block
 ^yellow;^reset; +^green;450^reset;% Bomb Tech Damage
-^yellow;^reset; +^green;35^reset;% Dash Tech Speed
+^yellow;^reset; +^green;35^reset;% Dash/Dodge Tech Speed
 ^yellow;^reset; +^green;15^reset;% Jump Tech Height
 ^yellow;^reset; ^cyan;Immune^reset;: Acid, Gas",
   "shortdescription" : "Junker Greaves",

--- a/items/armors/tier3/samurai2/samurai2.chest
+++ b/items/armors/tier3/samurai2/samurai2.chest
@@ -6,8 +6,8 @@
   "rarity" : "uncommon",
   "category" : "chestarmour",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Katana: Damage x^green;1.15^reset;, +^green;3^reset;% Crit, +^green;10^reset;% Crit Damage^reset;
-^yellow;^reset; Katana + Dagger: +^green;1^reset;% Crit Chance, Defense x^green;1.14^reset;^reset;",
+^yellow;^reset; Katana: Damage x^green;1.15^reset;, +^green;3^reset;% Crit Chance, +^green;10^reset;% Crit Damage^reset;
+^yellow;^reset; Katana + Dagger: Additional +^green;1^reset;% Crit Chance, Defense x^green;1.14^reset;^reset;",
   "shortdescription" : "Neishin Breastplate",
   "tooltipKind" : "armornew2",
   "itemTags": ["upgradeableWeapon", "balanced", "melee"],

--- a/items/armors/tier3/samurai2/samurai2.head
+++ b/items/armors/tier3/samurai2/samurai2.head
@@ -6,8 +6,8 @@
   "rarity" : "uncommon",
   "category" : "headarmour",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Katana: Damage x^green;1.15^reset;, +^green;3^reset;% Crit, +^green;10^reset;% Crit Damage^reset;
-^yellow;^reset; Katana + Dagger: +^green;1^reset;% Crit Chance, Defense x^green;1.14^reset;^reset;",
+^yellow;^reset; Katana: Damage x^green;1.15^reset;, +^green;3^reset;% Crit Chance, +^green;10^reset;% Crit Damage^reset;
+^yellow;^reset; Katana + Dagger: Additional +^green;1^reset;% Crit Chance, Defense x^green;1.14^reset;^reset;",
   "shortdescription" : "Neishin Helm",
   "tooltipKind" : "armornew2",
   "itemTags": ["upgradeableWeapon", "balanced", "melee"],

--- a/items/armors/tier3/samurai2/samurai2.legs
+++ b/items/armors/tier3/samurai2/samurai2.legs
@@ -6,8 +6,8 @@
   "rarity" : "uncommon",
   "category" : "legarmour",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Katana: Damage x^green;1.15^reset;, +^green;3^reset;% Crit, +^green;10^reset;% Crit Damage^reset;
-^yellow;^reset; Katana + Dagger: +^green;1^reset;% Crit Chance, Defense x^green;1.14^reset;^reset;",
+^yellow;^reset; Katana: Damage x^green;1.15^reset;, +^green;3^reset;% Crit Chance, +^green;10^reset;% Crit Damage^reset;
+^yellow;^reset; Katana + Dagger: Additional +^green;1^reset;% Crit Chance, Defense x^green;1.14^reset;^reset;",
   "shortdescription" : "Neishin Greaves",
   "tooltipKind" : "armornew2",
   "itemTags": ["upgradeableWeapon", "balanced", "melee"],

--- a/items/armors/tier4/agilitysuit/agilitysuit.chest
+++ b/items/armors/tier4/agilitysuit/agilitysuit.chest
@@ -7,7 +7,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;12^reset;% Speed, ^green;8^reset;% Jump
 ^yellow;^reset; +^green;25^reset;% Jump Tech Efficiency
-^yellow;^reset; +^green;25^reset;% Dash Tech Efficiency
+^yellow;^reset; +^green;25^reset;% Dash/Dodge Tech Efficiency
 ^yellow;^reset; +^green;25^reset;% Phase Tech Efficiency
 ^yellow;^reset; Dagger/Pistol: +^green;4^reset;% Crit Chance",
 
@@ -86,6 +86,6 @@
     { "ffca8a" : "e6e9ea", "e0975c" : "c6d2d4", "a85636" : "97abac", "6f2919" : "627677" }
 */
 ],
-  //"upgrades" : 1 ,
+//  "upgrades" : 1 ,
   "builder" : "/items/buildscripts/fubuildarmor.lua"
 }

--- a/items/armors/tier4/agilitysuit/agilitysuit.head
+++ b/items/armors/tier4/agilitysuit/agilitysuit.head
@@ -7,7 +7,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;12^reset;% Speed, ^green;8^reset;% Jump
 ^yellow;^reset; +^green;25^reset;% Jump Tech Efficiency
-^yellow;^reset; +^green;25^reset;% Dash Tech Efficiency
+^yellow;^reset; +^green;25^reset;% Dash/Dodge Tech Efficiency
 ^yellow;^reset; +^green;25^reset;% Phase Tech Efficiency
 ^yellow;^reset; Dagger/Pistol: +^green;4^reset;% Crit Chance",
 
@@ -78,6 +78,6 @@
     { "ffca8a" : "e6e9ea", "e0975c" : "c6d2d4", "a85636" : "97abac", "6f2919" : "627677" }
 */
 ],
-  //"upgrades" : 1 ,
+//  "upgrades" : 1 ,
   "builder" : "/items/buildscripts/fubuildarmor.lua"
 }

--- a/items/armors/tier4/agilitysuit/agilitysuit.legs
+++ b/items/armors/tier4/agilitysuit/agilitysuit.legs
@@ -7,7 +7,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;12^reset;% Speed, ^green;8^reset;% Jump
 ^yellow;^reset; +^green;25^reset;% Jump Tech Efficiency
-^yellow;^reset; +^green;25^reset;% Dash Tech Efficiency
+^yellow;^reset; +^green;25^reset;% Dash/Dodge Tech Efficiency
 ^yellow;^reset; +^green;25^reset;% Phase Tech Efficiency
 ^yellow;^reset; Dagger/Pistol: +^green;4^reset;% Crit Chance",
 
@@ -77,6 +77,6 @@
     { "ffca8a" : "e6e9ea", "e0975c" : "c6d2d4", "a85636" : "97abac", "6f2919" : "627677" }
 */
 ],
-  //"upgrades" : 1 ,
+//  "upgrades" : 1 ,
   "builder" : "/items/buildscripts/fubuildarmor.lua"
 }

--- a/items/armors/tier4/bearenhanced/beararmor2.chest
+++ b/items/armors/tier4/bearenhanced/beararmor2.chest
@@ -5,9 +5,9 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; +^green;30^reset;% Knockback Resistance
-^yellow;^reset; Axes or 2-Handed Melee: +^green;4.5^reset;% Crit Chance, Damage x^green;1.25^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Ice status effects.",
+^yellow;^reset; +^green;30^reset;% Knockback Resist
+^yellow;^reset; Axes, Two-handed Melee: +^green;4.5^reset;% Crit Chance, Damage x^green;1.25^reset;
+^yellow;^reset; ^cyan;Immune^reset;: Ice status effects",
   "shortdescription" : "Savage Bear Coat",
   "category" : "chestarmour",
   "tooltipKind" : "armornew2",
@@ -25,7 +25,7 @@
   },
 
   "level" : 4,
-  //"collectablesOnPickup" : { "fu_armortank" : "fubearchest2" },
+//  "collectablesOnPickup" : { "fu_armortank" : "fubearchest2" },
   "leveledStatusEffects" : [
     {
       "levelFunction" : "standardArmorLevelPowerMultiplierMultiplier",
@@ -103,6 +103,6 @@
     { "ffca8a" : "e6e9ea", "e0975c" : "c6d2d4", "a85636" : "97abac", "6f2919" : "627677" }
 */
 ],
-  //"upgrades" : 1 ,
+//  "upgrades" : 1 ,
   "builder" : "/items/buildscripts/fubuildarmor.lua"
 }

--- a/items/armors/tier4/bearenhanced/beararmor2.head
+++ b/items/armors/tier4/bearenhanced/beararmor2.head
@@ -5,9 +5,9 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; +^green;30^reset;% Knockback Resistance
-^yellow;^reset; Axes or 2-Handed Melee: +^green;4.5^reset;% Crit Chance, Damage x^green;1.25^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Ice status effects.",
+^yellow;^reset; +^green;30^reset;% Knockback Resist
+^yellow;^reset; Axes, Two-handed Melee: +^green;4.5^reset;% Crit Chance, Damage x^green;1.25^reset;
+^yellow;^reset; ^cyan;Immune^reset;: Ice status effects",
   "shortdescription" : "Savage Bear Hood",
   "category": "headarmour",
   "tooltipKind" : "armornew2",
@@ -17,7 +17,7 @@
   "mask" : "mask.png",
 
   "level" : 4,
-  //"collectablesOnPickup" : { "fu_armortank" : "fubearhead2" },
+//  "collectablesOnPickup" : { "fu_armortank" : "fubearhead2" },
   "leveledStatusEffects" : [
     {
       "levelFunction" : "standardArmorLevelPowerMultiplierMultiplier",
@@ -95,6 +95,6 @@
     { "ffca8a" : "e6e9ea", "e0975c" : "c6d2d4", "a85636" : "97abac", "6f2919" : "627677" }
 */
 ],
-  //"upgrades" : 1 ,
+//  "upgrades" : 1 ,
   "builder" : "/items/buildscripts/fubuildarmor.lua"
 }

--- a/items/armors/tier4/bearenhanced/beararmor2.legs
+++ b/items/armors/tier4/bearenhanced/beararmor2.legs
@@ -5,9 +5,9 @@
   "maxStack" : 1,
   "rarity" : "uncommon",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; +^green;30^reset;% Knockback Resistance
-^yellow;^reset; Axes or 2-Handed Melee: +^green;4.5^reset;% Crit Chance, Damage x^green;1.25^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Ice status effects.",
+^yellow;^reset; +^green;30^reset;% Knockback Resist
+^yellow;^reset; Axes, Two-handed Melee: +^green;4.5^reset;% Crit Chance, Damage x^green;1.25^reset;
+^yellow;^reset; ^cyan;Immune^reset;: Ice status effects",
   "shortdescription" : "Savage Bear Greaves",
   "category": "legarmour",
   "tooltipKind" : "armornew2",
@@ -16,7 +16,7 @@
   "femaleFrames" : "pants.png",
 
   "level" : 4,
-  //"collectablesOnPickup" : { "fu_armortank" : "fubearlegs2" },
+//  "collectablesOnPickup" : { "fu_armortank" : "fubearlegs2" },
   "leveledStatusEffects" : [
     {
       "levelFunction" : "standardArmorLevelPowerMultiplierMultiplier",
@@ -94,6 +94,6 @@
     { "ffca8a" : "e6e9ea", "e0975c" : "c6d2d4", "a85636" : "97abac", "6f2919" : "627677" }
 */
 ],
-  //"upgrades" : 1 ,
+//  "upgrades" : 1 ,
   "builder" : "/items/buildscripts/fubuildarmor.lua"
 }

--- a/items/armors/tier4/enforcerarmor/enforcerarmor.chest
+++ b/items/armors/tier4/enforcerarmor/enforcerarmor.chest
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Assault Rifle/ Shotgun: Damage x^green;1.2^reset;
+^yellow;^reset; Assault Rifle/Shotgun: Damage x^green;1.2^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Liq.Nitrogen, Darkness",
   "shortdescription" : "Enforcer Chestplate",
   "category" : "chestarmour",

--- a/items/armors/tier4/enforcerarmor/enforcerarmor.head
+++ b/items/armors/tier4/enforcerarmor/enforcerarmor.head
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Assault Rifle/ Shotgun: Damage x^green;1.2^reset;
+^yellow;^reset; Assault Rifle/Shotgun: Damage x^green;1.2^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Liq.Nitrogen, Darkness",
   "shortdescription" : "Enforcer Helmet",
   "category" : "headarmour",

--- a/items/armors/tier4/enforcerarmor/enforcerarmor.legs
+++ b/items/armors/tier4/enforcerarmor/enforcerarmor.legs
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Assault Rifle/ Shotgun: Damage x^green;1.2^reset;
+^yellow;^reset; Assault Rifle/Shotgun: Damage x^green;1.2^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Liq.Nitrogen, Darkness",
   "shortdescription" : "Enforcer Greaves",
   "category" : "legarmour",

--- a/items/armors/tier4/fuarmoredcultist/fuarmoredcultist.chest
+++ b/items/armors/tier4/fuarmoredcultist/fuarmoredcultist.chest
@@ -7,7 +7,7 @@
   "rarity" : "rare",
    "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^cyan;Flings Eyeballs^reset;
-^yellow;^reset; Aether/Lightless Worlds: Damage x^green;1.15^reset;, Health x^green;1.25^reset;
+^yellow;^reset; Aether/Lightless/Midnight/Shadow Worlds: Damage x^green;1.15^reset;, Health x^green;1.25^reset;
 ^yellow;^reset; ^cyan;Immune^reset;: Poison, Acid",
   "shortdescription" : "Corrupted Armor",
   "category" : "chestarmour",

--- a/items/armors/tier4/fuinferno/fuinferno.chest
+++ b/items/armors/tier4/fuinferno/fuinferno.chest
@@ -8,7 +8,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^cyan;Fire Nova when hit^reset;
 ^yellow;^reset; Flamethrower: Damage x^green;1.3^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Mild Heat, Burning",
+^yellow;^reset; ^cyan;Immune^reset;: Moderate Heat, Burning",
   "shortdescription" : "Inferno Chest",
   "category" : "chestarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier4/fuinferno/fuinferno.head
+++ b/items/armors/tier4/fuinferno/fuinferno.head
@@ -8,7 +8,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^cyan;Fire Nova when hit^reset;
 ^yellow;^reset; Flamethrower: Damage x^green;1.3^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Mild Heat, Burning",
+^yellow;^reset; ^cyan;Immune^reset;: Moderate Heat, Burning",
   "shortdescription" : "Inferno Helm",
   "category" : "headarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier4/fuinferno/fuinferno.legs
+++ b/items/armors/tier4/fuinferno/fuinferno.legs
@@ -8,7 +8,7 @@
   "description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^cyan;Fire Nova when hit^reset;
 ^yellow;^reset; Flamethrower: Damage x^green;1.3^reset;
-^yellow;^reset; ^cyan;Immune^reset;: Mild Heat, Burning",
+^yellow;^reset; ^cyan;Immune^reset;: Moderate Heat, Burning",
   "shortdescription" : "Inferno Pants",
   "category" : "legarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier4/intersec/kirhostier4.chest
+++ b/items/armors/tier4/intersec/kirhostier4.chest
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; -^green;15^reset;%Ship Mass^reset;^reset;
+^yellow;^reset; -^green;15^reset;% Ship Mass^reset;^reset;
 ^yellow;^reset; Assault Rifle, Pistol: +^green;2^reset;% Crit Chance, +^green;25^reset;% Crit Damage",
   "shortdescription" : "Intersec Breastplate",
   "category" : "chestarmour",

--- a/items/armors/tier4/intersec/kirhostier4.head
+++ b/items/armors/tier4/intersec/kirhostier4.head
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; -^green;15^reset;%Ship Mass^reset;^reset;
+^yellow;^reset; -^green;15^reset;% Ship Mass^reset;^reset;
 ^yellow;^reset; Assault Rifle, Pistol: +^green;2^reset;% Crit Chance, +^green;25^reset;% Crit Damage",
   "shortdescription" : "Intersec Helmet",
   "category" : "headarmour",

--- a/items/armors/tier4/intersec/kirhostier4.legs
+++ b/items/armors/tier4/intersec/kirhostier4.legs
@@ -5,7 +5,7 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; -^green;15^reset;%Ship Mass^reset;^reset;
+^yellow;^reset; -^green;15^reset;% Ship Mass^reset;^reset;
 ^yellow;^reset; Assault Rifle, Pistol: +^green;2^reset;% Crit Chance, +^green;25^reset;% Crit Damage",
   "shortdescription" : "Intersec Greaves",
   "category" : "legarmour",

--- a/items/armors/tier4/kingslayer/test1.legs
+++ b/items/armors/tier4/kingslayer/test1.legs
@@ -11,7 +11,7 @@
   "shortdescription" : "Kingslayer Greaves",
   "category" : "legarmour",
   "tooltipKind" : "armornew2",
-
+  "itemTags" : [ "upgradeableWeapon", "balanced", "melee" ],
   "maleFrames" : "pants.png",
   "femaleFrames" : "pants.png",
 
@@ -54,7 +54,7 @@
       "amount" : 0.028
     }
   ],
-  "itemTags" : [ "upgradeableWeapon", "balanced", "melee" ],
+
   "statusEffects" : [
     "kingslayersetbonus",
     {

--- a/items/armors/tier4/mutachitin/test1.chest
+++ b/items/armors/tier4/mutachitin/test1.chest
@@ -7,11 +7,11 @@
   "description" : "^yellow;+20^reset;% X'i Bulb Regen Rate (60%)
 ^orange;Set Bonuses^reset;:
 ^yellow;^reset; Health x^green;1.25^reset;, Energy x^green;1.2^reset;, Damage x^green;1.07^reset;
-^yellow;^reset; Xi Weapons: Defense x^green;1.1^reset;
+^yellow;^reset; X'i Weapons: Defense x^green;1.1^reset;
 ^yellow;^reset; Sulphuric biomes: Energy x^green;1.05^reset;, +^green;5^reset;% Knockback Resistance
 ^yellow;^reset; ^cyan;Immune^reset;: Acid",
-  "itemTags" : [ "upgradeableWeapon", "balanced", "ranged" ],
   "shortdescription" : "Muta-Chitin Chest",
+  "itemTags" : [ "upgradeableWeapon", "balanced", "ranged" ],
   "category" : "chestarmour",
   "tooltipKind" : "armornew2",
   "learnBlueprintsOnPickup" : [ "biomorphhead","biomorphpants","biomorphchest"],

--- a/items/armors/tier4/mutachitin/test1.head
+++ b/items/armors/tier4/mutachitin/test1.head
@@ -7,11 +7,11 @@
   "description" : "^yellow;+20^reset;% X'i Bulb Regen Rate (60%)
 ^orange;Set Bonuses^reset;:
 ^yellow;^reset; Health x^green;1.25^reset;, Energy x^green;1.2^reset;, Damage x^green;1.07^reset;
-^yellow;^reset; Xi Weapons: Defense x^green;1.1^reset;
+^yellow;^reset; X'i Weapons: Defense x^green;1.1^reset;
 ^yellow;^reset; Sulphuric biomes: Energy x^green;1.05^reset;, +^green;5^reset;% Knockback Resistance
 ^yellow;^reset; ^cyan;Immune^reset;: Acid",
   "shortdescription" : "Muta-Chitin Helm",
-    "itemTags" : [ "upgradeableWeapon", "balanced", "ranged" ],
+  "itemTags" : [ "upgradeableWeapon", "balanced", "ranged" ],
   "category" : "headarmour",
   "tooltipKind" : "armornew2",
   "learnBlueprintsOnPickup" : [ "biomorphhead","biomorphpants","biomorphchest"],

--- a/items/armors/tier4/mutachitin/test1.legs
+++ b/items/armors/tier4/mutachitin/test1.legs
@@ -7,11 +7,11 @@
   "description" : "^yellow;+20^reset;% X'i Bulb Regen Rate (60%)
 ^orange;Set Bonuses^reset;:
 ^yellow;^reset; Health x^green;1.25^reset;, Energy x^green;1.2^reset;, Damage x^green;1.07^reset;
-^yellow;^reset; Xi Weapons: Defense x^green;1.1^reset;
+^yellow;^reset; X'i Weapons: Defense x^green;1.1^reset;
 ^yellow;^reset; Sulphuric biomes: Energy x^green;1.05^reset;, +^green;5^reset;% Knockback Resistance
 ^yellow;^reset; ^cyan;Immune^reset;: Acid",
   "shortdescription" : "Muta-Chitin Greaves",
-   "itemTags" : [ "upgradeableWeapon", "balanced", "ranged" ],
+  "itemTags" : [ "upgradeableWeapon", "balanced", "ranged" ],
   "category" : "legarmour",
   "tooltipKind" : "armornew2",
   "learnBlueprintsOnPickup" : [ "biomorphhead","biomorphpants","biomorphchest"],

--- a/items/armors/tier6/biomorph/test1.chest
+++ b/items/armors/tier6/biomorph/test1.chest
@@ -8,7 +8,7 @@
   "description" : "+^green;40^reset;% X'i Bulb Regen Rate (120%)
 ^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^green;5^reset;% Speed, Damage x^green;1.07^reset;, Health x^green;1.25^reset;, Energy x^green;1.2^reset;
-^yellow;^reset; Xi Weapons: Defense x^green;1.1^reset;
+^yellow;^reset; X'i Weapons: Defense x^green;1.1^reset;
 ^yellow;^reset; Sulphuric Biome: Energy x^green;1.05^reset;, +^green;5^reset;% Knockback Resist
 ^yellow;^reset; ^cyan;Immune^reset;: Acid, Burning, All Radiation, Snow, Slush, Ice, Oxygen",
   "itemTags" : [ "upgradeableWeapon", "balanced", "explorer" ],

--- a/items/armors/tier6/biomorph/test1.head
+++ b/items/armors/tier6/biomorph/test1.head
@@ -8,7 +8,7 @@
   "description" : "+^green;40^reset;% X'i Bulb Regen Rate (120%)
 ^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^green;5^reset;% Speed, Damage x^green;1.07^reset;, Health x^green;1.25^reset;, Energy x^green;1.2^reset;
-^yellow;^reset; Xi Weapons: Defense x^green;1.1^reset;
+^yellow;^reset; X'i Weapons: Defense x^green;1.1^reset;
 ^yellow;^reset; Sulphuric Biome: Energy x^green;1.05^reset;, +^green;5^reset;% Knockback Resist
 ^yellow;^reset; ^cyan;Immune^reset;: Acid, Burning, All Radiation, Snow, Slush, Ice, Oxygen",
   "shortdescription" : "Biomorphic Helm",

--- a/items/armors/tier6/biomorph/test1.legs
+++ b/items/armors/tier6/biomorph/test1.legs
@@ -8,7 +8,7 @@
   "description" : "+^green;40^reset;% X'i Bulb Regen Rate (120%)
 ^orange;Set Bonuses^reset;:
 ^yellow;^reset; ^green;5^reset;% Speed, Damage x^green;1.07^reset;, Health x^green;1.25^reset;, Energy x^green;1.2^reset;
-^yellow;^reset; Xi Weapons: Defense x^green;1.1^reset;
+^yellow;^reset; X'i Weapons: Defense x^green;1.1^reset;
 ^yellow;^reset; Sulphuric Biome: Energy x^green;1.05^reset;, +^green;5^reset;% Knockback Resist
 ^yellow;^reset; ^cyan;Immune^reset;: Acid, Burning, All Radiation, Snow, Slush, Ice, Oxygen",
   "itemTags" : [ "upgradeableWeapon", "balanced", "explorer" ],

--- a/items/armors/tier6/champion/mantizitier6separator.chest
+++ b/items/armors/tier6/champion/mantizitier6separator.chest
@@ -5,8 +5,8 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Hammer,Axe,Mace: Damage x^green;1.3^reset;, +^green;3^reset;% Crit Chance
-^yellow;^reset; ^cyan;Immune^reset;: Tar, Mud, Clay, Moderate Cold",
+^yellow;^reset; Hammer, Axe, Mace: Damage x^green;1.3^reset;, +^green;3^reset;% Crit Chance
+^yellow;^reset; ^cyan;Immune^reset;:  Moderate Cold, Tar, Mud, Clay",
   "shortdescription" : "Champion's Carapace",
   "category" : "chestarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier6/champion/mantizitier6separator.head
+++ b/items/armors/tier6/champion/mantizitier6separator.head
@@ -5,8 +5,8 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Hammer,Axe,Mace: Damage x^green;1.3^reset;, +^green;3^reset;% Crit Chance
-^yellow;^reset; ^cyan;Immune^reset;: Tar, Mud, Clay, Moderate Cold",
+^yellow;^reset; Hammer, Axe, Mace: Damage x^green;1.3^reset;, +^green;3^reset;% Crit Chance
+^yellow;^reset; ^cyan;Immune^reset;:  Moderate Cold, Tar, Mud, Clay",
   "shortdescription" : "Champion's Maw",
   "category" : "headarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier6/champion/mantizitier6separator.legs
+++ b/items/armors/tier6/champion/mantizitier6separator.legs
@@ -5,8 +5,8 @@
   "maxStack" : 1,
   "rarity" : "rare",
   "description" : "^orange;Set Bonuses^reset;:
-^yellow;^reset; Hammer,Axe,Mace: Damage x^green;1.3^reset;, +^green;3^reset;% Crit Chance
-^yellow;^reset; ^cyan;Immune^reset;: Tar, Mud, Clay, Moderate Cold",
+^yellow;^reset; Hammer, Axe, Mace: Damage x^green;1.3^reset;, +^green;3^reset;% Crit Chance
+^yellow;^reset; ^cyan;Immune^reset;:  Moderate Cold, Tar, Mud, Clay",
   "shortdescription" : "Champion's Tights",
   "category" : "legarmour",
   "tooltipKind" : "armornew2",

--- a/items/armors/tier6/furecon3/furecon3.chest
+++ b/items/armors/tier6/furecon3/furecon3.chest
@@ -7,7 +7,7 @@
 	"rarity" : "Legendary",
 	"description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;15^reset;% Speed
-^yellow;^reset; Assault/Sniper Rifle: +^green;3^reset;% Crit Chance, Damage x^green;1.22^reset;
+^yellow;^reset; Assault/Sniper Rifle: Damage x^green;1.22^reset;, +^green;3^reset;% Crit Chance
 ^yellow;^reset; ^cyan;Immune^reset;: All Radiation",
 	"shortdescription" : "Type-3 Recon Vest",
 	"category" : "chestarmour",

--- a/items/armors/tier6/furecon3/furecon3.head
+++ b/items/armors/tier6/furecon3/furecon3.head
@@ -7,7 +7,7 @@
 	"rarity" : "Legendary",
 	"description" : "^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;15^reset;% Speed
-^yellow;^reset; Assault/Sniper Rifle: +^green;3^reset;% Crit Chance, Damage x^green;1.22^reset;
+^yellow;^reset; Assault/Sniper Rifle: Damage x^green;1.22^reset;, +^green;3^reset;% Crit Chance
 ^yellow;^reset; ^cyan;Immune^reset;: All Radiation",
 	"shortdescription" : "Type-3 Recon Helm",
 	"category" : "headarmour",

--- a/items/armors/tier6/furecon3/furecon3.legs
+++ b/items/armors/tier6/furecon3/furecon3.legs
@@ -8,7 +8,7 @@
 	"description" : "^cyan;Immune^reset; to most tile effects.
 ^orange;Set Bonuses^reset;:
 ^yellow;^reset; +^green;15^reset;% Speed
-^yellow;^reset; Assault/Sniper Rifle: +^green;3^reset;% Crit Chance, Damage x^green;1.22^reset;
+^yellow;^reset; Assault/Sniper Rifle: Damage x^green;1.22^reset;, +^green;3^reset;% Crit Chance
 ^yellow;^reset; ^cyan;Immune^reset;: All Radiation",
 	"shortdescription" : "Type-3 Recon Legs",
 	"category" : "legarmour",

--- a/objects/ship/fu_byosgravgen/fu_byosgravgen.lua
+++ b/objects/ship/fu_byosgravgen/fu_byosgravgen.lua
@@ -1,23 +1,24 @@
 require "/scripts/effectUtil.lua"
 
 function init()
-	power()
+  self.range = config.getParameter("range", 80)
+  power()
 end
 
 function update(dt)
-	if storage.state then
-		effectUtil.effectAllInRange("fu_byosgravgenfield",config.getParameter("range"), 10)
-	end
+  if storage.state then
+    effectUtil.effectAllInRange("fu_byosgravgenfield", self.range, 10)
+  end
 end
 
 function onInputNodeChange()
-	power()
+  power()
 end
 
 function onNodeConnectionChange()
-	power()
+  power()
 end
 
 function power()
-	storage.state=not object.isInputNodeConnected(0) or object.isInputNodeConnected(0) and object.getInputNodeLevel(0)
+  storage.state=not object.isInputNodeConnected(0) or object.isInputNodeConnected(0) and object.getInputNodeLevel(0)
 end

--- a/objects/ship/fu_byosgravgen/fu_byosgravgenfield.lua
+++ b/objects/ship/fu_byosgravgen/fu_byosgravgenfield.lua
@@ -1,11 +1,7 @@
 function init()
-	status.setStatusProperty("fu_byosgravgenfield", status.statusProperty("fu_byosgravgenfield", 0) + 1)
-end
-
-function update(dt)
-
+  status.setStatusProperty("fu_byosgravgenfield", status.statusProperty("fu_byosgravgenfield", 0) + 1)
 end
 
 function uninit()
-	status.setStatusProperty("fu_byosgravgenfield", status.statusProperty("fu_byosgravgenfield", 0) - 1)
+  status.setStatusProperty("fu_byosgravgenfield", status.statusProperty("fu_byosgravgenfield", 0) - 1)
 end

--- a/stats/effects/fu_armoreffects/set_bonuses/bees/ambersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/bees/ambersetbonuseffect.lua
@@ -31,7 +31,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"shortsword","broadsword","axe","hammer","spear","shortspear","dagger","katana","daikatana"})
+	local weapons=weaponCheck({"dagger","knife","sword","shortsword","longsword","broadsword","rapier","katana","axe","scythe","spear","shortspear"})
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else

--- a/stats/effects/fu_armoreffects/set_bonuses/nightar/daywalkersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/nightar/daywalkersetbonuseffect.lua
@@ -17,7 +17,7 @@ armorBonus={
 	{stat = "iceslipImmunity", amount = 1},
 	{stat = "snowslowImmunity", amount = 1},
 	{stat = "slushslowImmunity", amount = 1},
-	{stat = "maxEnergy", effectiveMultiplier = 1.1}
+	{stat = "maxEnergy", effectiveMultiplier = 1.05}
 }
 
 function init()
@@ -55,7 +55,7 @@ end
 
 
 function checkWeapons()
-	local weapons=weaponCheck({"longsword","rapier","katana","shortsword","dagger"})
+	local weapons=weaponCheck({"sword","shortsword","longsword","broadsword","rapier","katana"})
 	if weapons["either"] and not weapons["twoHanded"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else

--- a/stats/effects/fu_armoreffects/set_bonuses/tier1/leathersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier1/leathersetbonuseffect.lua
@@ -10,7 +10,7 @@ weaponBonus={
 	{stat="powerMultiplier",effectiveMultiplier=1.15 },
 	{stat="bowEnergyBonus",amount=4 },
 	{stat="bowAirBonus",amount=0.05 },
-	{stat="bowDrawTimeBonus",amount=0.01 }
+	{stat="bowDrawTimeBonus",amount=0.10 }
 }
 
 biomeBonus={

--- a/stats/effects/fu_armoreffects/set_bonuses/tier1/missionarysetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier1/missionarysetbonuseffect.lua
@@ -29,7 +29,7 @@ end
 
 function checkWeapons()
 	local weapons=weaponCheck({ "quarterstaff","fist" })
-	if (weapons["either"] and weapons["twoHanded"]) or weapons["both"] then
+	if (weapons["either"] and (weapons["twoHanded"] or weapons["both"])) then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonus1Handle,weaponBonus1)
 	else
 		effect.setStatModifierGroup(effectHandlerList.weaponBonus1Handle,{})

--- a/stats/effects/fu_armoreffects/set_bonuses/tier1/plebiansetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier1/plebiansetbonuseffect.lua
@@ -30,7 +30,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({ "shortsword", "longsword", "mace" })
+	local weapons=weaponCheck({ "sword","shortsword","longsword","broadsword","rapier","katana", "mace" })
 	local weapons2=weaponCheck({ "shield" })
 	if weapons["either"] and weapons2["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonus1Handle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier2/bonesteelsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier2/bonesteelsetbonuseffect.lua
@@ -27,7 +27,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({ "broadsword", "shortsword", "longsword","katana","daikatana"})
+	local weapons=weaponCheck({ "sword","shortsword","longsword","broadsword","rapier","katana" })
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonus1Handle,weaponBonus)
 	else

--- a/stats/effects/fu_armoreffects/set_bonuses/tier2/swashbucklersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier2/swashbucklersetbonuseffect.lua
@@ -23,7 +23,7 @@ function update(dt)
 	if not checkSetWorn(self.setBonusCheck) then
 		effect.expire()
 	else
-		mcontroller.controlModifiers({jump=1.8})
+		mcontroller.controlModifiers({jump=1.08})
 		checkWeapons()
 	end
 end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier3/evadersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier3/evadersetbonuseffect.lua
@@ -30,7 +30,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"shortsword", "longsword"})
+	local weapons=weaponCheck({"sword","shortsword","longsword","broadsword","rapier","katana"})
 	local shield=weaponCheck({"shield"})
 	if weapons["either"] and shield["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonus1Handle,weaponBonus1)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier3/junkersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier3/junkersetbonuseffect.lua
@@ -22,7 +22,5 @@ end
 function update(dt)
 	if not checkSetWorn(self.setBonusCheck) then
 		effect.expire()
-	else
-		--fart
 	end
 end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier3/mutavisksetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier3/mutavisksetbonuseffect.lua
@@ -16,7 +16,5 @@ end
 function update(dt)
 	if not checkSetWorn(self.setBonusCheck) then
 		effect.expire()
-	else
-		--fart
 	end
 end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier3/samuraisetbonus2effect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier3/samuraisetbonus2effect.lua
@@ -30,7 +30,7 @@ end
 
 function checkWeapons()
 	local daggercheck=weaponCheck({"dagger"})
-	local katanacheck=weaponCheck({"daikatana","katana"})
+	local katanacheck=weaponCheck({"katana"})
 	if katanacheck["either"] then
 		if daggercheck["either"] then
 			effect.setStatModifierGroup(effectHandlerList.weaponBonus1Handle,weaponBonus2)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier3/stalkersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier3/stalkersetbonuseffect.lua
@@ -2,7 +2,7 @@ require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
 setName="fu_stalkerset"
 
 armorBonus={
-	{stat = "fallDamageMultiplier", effectiveMultiplier = 0.875},
+	{stat = "fallDamageMultiplier", effectiveMultiplier = 0.75},
 	{stat = "biooozeImmunity", amount = 1},
 	{stat = "poisonStatusImmunity", amount = 1}
 }
@@ -23,7 +23,7 @@ function update(dt)
 	if not checkSetWorn(self.setBonusCheck) then
 		effect.expire()
 	else
-		mcontroller.controlModifiers({airJumpModifier = 1.08})
+		mcontroller.controlModifiers({speed = 1.08})
 		checkWeapons()
 	end
 end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier3/wanderersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier3/wanderersetbonuseffect.lua
@@ -5,7 +5,7 @@ armorBonus={
 	{stat = "critChance", amount = 2}
 }
 weaponBonus={
-	{stat = "critDamage", amount = 0.1},
+	{stat = "critDamage", amount = 0.15},
 	{stat = "powerMultiplier", effectiveMultiplier = 1.15}
 }
 

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/bearsetbonuseffect2.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/bearsetbonuseffect2.lua
@@ -27,12 +27,11 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weaponSword=weaponCheck({ "axe", "hammer", "broadsword", "spear","quarterstaff","daikatana" })
-
-	if weaponSword["either"] then
+	local melee=weaponCheck({ "melee","dagger","knife","sword","shortsword","longsword","broadsword","rapier","katana","axe","greataxe","scythe","mace","hammer","spear","shortspear","quarterstaff","flail" })
+	local axes=weaponCheck({ "axe","greataxe" })
+	if (melee["either"] and melee["twoHanded"]) or axes["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,{})
 	end
-
 end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/corruptsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/corruptsetbonuseffect.lua
@@ -2,8 +2,8 @@ require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
 setName="fu_corruptset"
 
 armorBonus={
-	{stat = "maxHealth", effectiveMultiplier = 1.25},
-	{stat = "powerMultiplier", effectiveMultiplier = 1.15}
+	{stat = "powerMultiplier", effectiveMultiplier = 1.15},
+	{stat = "maxHealth", effectiveMultiplier = 1.25}
 }
 
 armorEffect={
@@ -30,8 +30,8 @@ function update(dt)
 end
 
 function checkArmor()
-	if checkBiome({"lightless","penumbra","aethersea","moon_shadow","shadow","midnight"}) then
-
+	if checkBiome({"astral","aethersea","lightless","moon_shadow","shadow","midnight"}) then
+		effect.setStatModifierGroup(effectHandlerList.armorBonusHandle,armorBonus)
 	else
 		effect.setStatModifierGroup(effectHandlerList.armorBonusHandle,{})
 	end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/graphenesetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/graphenesetbonuseffect.lua
@@ -33,7 +33,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"energy","plasma"})
+	local weapons=weaponCheck({"energy"})
 
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/huntersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/huntersetbonuseffect.lua
@@ -27,7 +27,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"rocketlauncher", "grenadelauncher", "bow", "crossbow"})
+	local weapons=weaponCheck({"rocketlauncher", "grenadelauncher"})
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/intersecsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/intersecsetbonuseffect.lua
@@ -1,4 +1,5 @@
 require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
+setName="fu_intersecset"
 
 weaponBonus={
 	{stat = "critChance", amount = 2},
@@ -9,12 +10,13 @@ armorBonus={
 	{stat = "shipMass", baseMultiplier = 0.85}
 }
 
-setName="fu_intersecset"
 
 function init()
 	setSEBonusInit(setName)
 	effectHandlerList.weaponBonusHandle=effect.addStatModifierGroup({})
+
 	checkWeapons()
+
 	effectHandlerList.armorBonusHandle=effect.addStatModifierGroup(armorBonus)
 end
 

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/kingslayersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/kingslayersetbonuseffect.lua
@@ -29,9 +29,9 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"dagger","broadsword","axe","hammer","shortsword","greataxe","spear","shortspear","quarterstaff"})
+	local weapons=weaponCheck({"melee","dagger","knife","sword","shortsword","longsword","broadsword","rapier","katana","axe","greataxe","scythe","mace","hammer","spear","shortspear","quarterstaff","flail"})
 
-	if (weapons["twoHanded"] and weapons["either"]) or (weapons["primary"] and weapons["alt"]) then
+	if (weapons["either"] and (weapons["twoHanded"] or weapons["both"])) then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,setBonusMultiply(weaponBonus,2))
 	elseif weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/primussetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/primussetbonuseffect.lua
@@ -2,7 +2,7 @@ require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
 setName="fu_primusset"
 
 weaponBonus={
-	{stat = "powerMultiplier", effectiveMultiplier = 1.25},
+	{stat = "powerMultiplier", effectiveMultiplier = 1.15},
 	{stat = "critChance", amount = 3}
 }
 

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/protectorsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/protectorsetbonuseffect.lua
@@ -25,7 +25,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({ "shortsword","broadsword", "longsword", "katana", "dagger", "knife", "axe", "greataxe", "chakram", "rapier", "scythe","daikatana" })
+	local weapons=weaponCheck({ "dagger","knife","sword","shortsword","longsword","broadsword","rapier","katana","axe","greataxe","scythe" })
 
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/reptilesetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/reptilesetbonuseffect.lua
@@ -1,11 +1,11 @@
 require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
 setName="fu_reptileset"
 
-weaponBonus={
+weaponBonusSword={
 	{stat = "physicalResistance", amount = 0.1}
 }
 
-weaponBonus2={
+weaponBonusAxe={
 	{stat = "powerMultiplier", effectiveMultiplier = 1.25}
 }
 
@@ -34,14 +34,14 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weaponSword=weaponCheck({"shortsword","longsword","katana","rapier","dagger"})
+	local weaponSword=weaponCheck({"sword","shortsword","longsword","broadsword","rapier","katana"})
+	local weaponAxe=weaponCheck({"axe","shortspear"})
 	local weaponShield=weaponCheck({"shield"})
-	local weaponSword2=weaponCheck({"axe","shortspear"})
 
 	if weaponSword["either"] and weaponShield["either"] then
-		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
-	elseif weaponSword2["either"] and weaponShield["either"] then
-		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus2)
+		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonusSword)
+	elseif weaponAxe["either"] and weaponShield["either"] then
+		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonusAxe)
 	else
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,{})
 	end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/shadowbonesetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/shadowbonesetbonuseffect.lua
@@ -29,7 +29,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"axe","hammer","scythe"})
+	local weapons=weaponCheck({"axe","greataxe","hammer","scythe"})
 
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/starkillersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/starkillersetbonuseffect.lua
@@ -39,7 +39,7 @@ function checkArmor()
 	daytime = daytimeCheck()
 	underground = undergroundCheck()
 	if daytime and not underground then
-
+		effect.setStatModifierGroup(effectHandlerList.armorBonusHandle,armorBonus)
 	else
 		effect.setStatModifierGroup(effectHandlerList.armorBonusHandle,{})
 	end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/warriorsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/warriorsetbonuseffect.lua
@@ -31,7 +31,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"melee","shortsword","broadsword","whip","axe","hammer","spear","shortspear","dagger","longsword","rapier","mace","scythe","quarterstaff","katana","daikatana"})
+	local weapons=weaponCheck({"melee","dagger","knife","sword","shortsword","longsword","broadsword","rapier","katana","axe","greataxe","scythe","mace","hammer","spear","shortspear","quarterstaff","flail"})
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/x10setbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/x10setbonuseffect.lua
@@ -39,9 +39,12 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"assaultrifle","energy"})
+	local weaponsAssault=weaponCheck({"assaultrifle"})
 
-	if weapons["either"] then
+	local weaponsEnergy=weaponCheck({"energy"})
+	local weaponsRifle=weaponCheck({"rifle","assaultrifle","sniperrifle"})
+
+	if weaponsAssault["either"] or (weaponsEnergy["either"] and weaponsRifle["either"]) then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,{})

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/xenosetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/xenosetbonuseffect.lua
@@ -2,16 +2,14 @@ require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
 setName="fu_xenoset"
 
 weaponBonus={
-	{stat = "powerMultiplier", effectiveMultiplier = 1.20},
-	{stat = "critChance", amount = 2}
+	{stat = "powerMultiplier", effectiveMultiplier = 1.20}
 }
 
 armorEffect={
 	{stat = "breathProtection", amount = 1.0},
 	{stat = "gasImmunity", amount = 1.0},
 	{stat = "liquidnitrogenImmunity", amount = 1.0},
-	{stat = "biomecoldImmunity", amount = 1.0},
-	{stat = "fallDamageMultiplier", effectiveMultiplier = 0.70}
+	{stat = "biomecoldImmunity", amount = 1.0}
 }
 
 function init()

--- a/stats/effects/fu_armoreffects/set_bonuses/tier5/cutesetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier5/cutesetbonuseffect.lua
@@ -27,7 +27,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"energy"})
+	local weapons=weaponCheck({"cute"})
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else

--- a/stats/effects/fu_armoreffects/set_bonuses/tier5/diamondsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier5/diamondsetbonuseffect.lua
@@ -29,7 +29,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weaponSingle=weaponCheck({"katana","daikatana"})
+	local weaponSingle=weaponCheck({"katana"})
 
 	if weaponSingle["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier5/millenionsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier5/millenionsetbonuseffect.lua
@@ -3,7 +3,7 @@ setName="fu_millenionset"
 
 weaponBonus={
 	{stat = "maxHealth", effectiveMultiplier = 1.20},
-	{stat="grit", amount=0.25}
+	{stat = "grit", amount=0.25}
 }
 
 armorBonus={
@@ -32,7 +32,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weaponSword=weaponCheck({"shortsword","longsword","rapier","katana"})
+	local weaponSword=weaponCheck({"sword","shortsword","longsword","broadsword","rapier","katana"})
 	local weaponShield=weaponCheck({"shield"})
 
 	if weaponSword["either"] and weaponShield["either"] then

--- a/stats/effects/fu_armoreffects/set_bonuses/tier5/precursorsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier5/precursorsetbonuseffect.lua
@@ -33,10 +33,9 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weaponSword=weaponCheck({"energy","precursor"})
-	local weaponShield=weaponCheck({"energy","precursor"})
+	local weapons=weaponCheck({"energy","precursor"})
 
-	if weaponSword["either"] or weaponShield["either"] then
+	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,{})

--- a/stats/effects/fu_armoreffects/set_bonuses/tier5/riftersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier5/riftersetbonuseffect.lua
@@ -3,7 +3,7 @@ setName="fu_rifterset"
 
 weaponBonus={
 	{stat = "critChance", amount = 3},
-				{stat = "powerMultiplier", effectiveMultiplier = 1.25}
+	{stat = "powerMultiplier", effectiveMultiplier = 1.25}
 }
 
 armorEffect={

--- a/stats/effects/fu_armoreffects/set_bonuses/tier5/sentrysetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier5/sentrysetbonuseffect.lua
@@ -30,7 +30,7 @@ end
 function checkWeapons()
 	local weaponsEnergy=weaponCheck({"energy"})
 	local weaponsRifle=weaponCheck({"rifle","assaultrifle","sniperrifle"})
-	if weaponsEnergy["either"] and weaponsRifle["either"] then
+	if (weaponsEnergy["either"] and weaponsRifle["either"]) then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,{})

--- a/stats/effects/fu_armoreffects/set_bonuses/tier5/sentrysetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier5/sentrysetbonuseffect.lua
@@ -28,10 +28,9 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"energy"})
-	if weapons["both"] then
-		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,setBonusMultiply(weaponBonus,2))
-	elseif weapons["either"] then
+	local weaponsEnergy=weaponCheck({"energy"})
+	local weaponsRifle=weaponCheck({"rifle","assaultrifle","sniperrifle"})
+	if weaponsEnergy["either"] and weaponsRifle["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
 	else
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,{})

--- a/stats/effects/fu_armoreffects/set_bonuses/tier6/densiniumsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier6/densiniumsetbonuseffect.lua
@@ -2,15 +2,15 @@ require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
 setName="fu_densiniumset"
 
 weaponBonus={
-	{stat = "critChance", amount = 3},
+	{stat = "critChance", amount = 2},
 	{stat = "powerMultiplier", effectiveMultiplier = 1.25}
 }
 
 armorBonus={
 	{stat = "breathProtection", amount = 1},
 	{stat = "poisonStatusImmunity", amount = 1},
-	{stat = "extremepressureProtection", amount = 1},
 	{stat = "pressureProtection", amount = 1},
+	{stat = "extremepressureProtection", amount = 1},
 	{stat = "gasImmunity", amount = 1}
 }
 

--- a/stats/effects/fu_armoreffects/set_bonuses/tier6/geistsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier6/geistsetbonuseffect.lua
@@ -29,9 +29,9 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"dagger","broadsword","axe","hammer","shortsword","greataxe","spear","shortspear","quarterstaff","katana","flail","scythe","mace","longsword","daikatana"})
+	local weapons=weaponCheck({"melee","dagger","knife","sword","shortsword","longsword","broadsword","rapier","katana","axe","greataxe","scythe","mace","hammer","spear","shortspear","quarterstaff","flail"})
 
-	if (weapons["either"] and weapons["twoHanded"]) or (weapons["primary"] and weapons["alt"]) then
+	if (weapons["either"] and (weapons["twoHanded"] or weapons["both"])) then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,setBonusMultiply(weaponBonus,2))
 	elseif weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier6/neuromancersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier6/neuromancersetbonuseffect.lua
@@ -1,7 +1,11 @@
 require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
 setName="fu_neuromancerset"
 
-weaponBonus={
+weaponBonusDual={
+	{stat = "critDamage", amount = 0.30}
+}
+
+weaponBonusSingle={
 	{stat = "powerMultiplier", effectiveMultiplier = 1.25}
 }
 
@@ -35,9 +39,9 @@ function checkWeapons()
 	local weapons=weaponCheck({"energy"})
 
 	if weapons["both"] then
-		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,setBonusMultiply(weaponBonus,2))
+		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonusDual)
 	elseif weapons["either"] then
-		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)
+		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonusSingle)
 	else
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,{})
 	end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier6/replicantsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier6/replicantsetbonuseffect.lua
@@ -33,7 +33,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weaponSword=weaponCheck({"shortsword","broadsword","rapier","longsword","katana","daikatana"})
+	local weaponSword=weaponCheck({"shortsword","broadsword","rapier","longsword","katana"})
 
 	if weaponSword["primary"] and weaponSword["alt"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus2)

--- a/stats/effects/fu_armoreffects/set_bonuses/tier6/sunwalkersetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier6/sunwalkersetbonuseffect.lua
@@ -6,13 +6,14 @@ weaponBonus={
 }
 
 armorBonus={
-	{stat = "biomecoldImmunity", amount = 1},
 	{stat = "biomeheatImmunity", amount = 1},
+	{stat = "biomecoldImmunity", amount = 1},
 	{stat = "biomeradiationImmunity", amount = 1},
-	{stat = "ffextremeradiationImmunity", amount = 1},
-	{stat = "extremepressureProtection", amount = 1},
 	{stat = "ffextremeheatImmunity", amount = 1},
 	{stat = "ffextremecoldImmunity", amount = 1},
+	{stat = "ffextremeradiationImmunity", amount = 1},
+	{stat = "pressureProtection", amount = 1},
+	{stat = "extremepressureProtection", amount = 1},
 	{stat = "breathProtection", amount = 1}
 }
 

--- a/stats/effects/fu_armoreffects/set_bonuses/tier6/ultrameshsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier6/ultrameshsetbonuseffect.lua
@@ -35,7 +35,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weaponSword=weaponCheck({"shortsword","rapier","katana","longsword"})
+	local weaponSword=weaponCheck({"sword","shortsword","longsword","broadsword","rapier","katana"})
 	local weaponShield=weaponCheck({"shield"})
 
 	if weaponSword["either"] and weaponShield["either"] then

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/biome/copperarmorsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/biome/copperarmorsetbonuseffect.lua
@@ -2,7 +2,7 @@ require "/stats/effects/fu_armoreffects/setbonuses_common.lua"
 setName="fu_copperarmorsetnew"
 
 weaponBonus1={
-	{stat = "powerMultiplier", effectiveMultiplier = 1.4}
+	{stat = "powerMultiplier", effectiveMultiplier = 1.5}
 }
 
 weaponBonus2={

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier1/hylotltier1setbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier1/hylotltier1setbonuseffect.lua
@@ -28,7 +28,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"katana","daikatana","quarterstaff"})
+	local weapons=weaponCheck({"katana","quarterstaff"})
 
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier2/hylotltier2setbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier2/hylotltier2setbonuseffect.lua
@@ -28,7 +28,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"katana","daikatana","quarterstaff"})
+	local weapons=weaponCheck({"katana","quarterstaff"})
 
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier3/hylotltier3setbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier3/hylotltier3setbonuseffect.lua
@@ -28,7 +28,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"katana","daikatana","quarterstaff"})
+	local weapons=weaponCheck({"katana","quarterstaff"})
 
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier4/hylotltier4setbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier4/hylotltier4setbonuseffect.lua
@@ -28,7 +28,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"katana","daikatana","quarterstaff"})
+	local weapons=weaponCheck({"katana","quarterstaff"})
 
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier5/hylotltier5setbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier5/hylotltier5setbonuseffect.lua
@@ -28,7 +28,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"katana","daikatana","quarterstaff"})
+	local weapons=weaponCheck({"katana","quarterstaff"})
 
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier6/hylotltier6setbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/vanilla/tier6/hylotltier6setbonuseffect.lua
@@ -28,7 +28,7 @@ function update(dt)
 end
 
 function checkWeapons()
-	local weapons=weaponCheck({"katana","daikatana","quarterstaff"})
+	local weapons=weaponCheck({"katana","quarterstaff"})
 
 	if weapons["either"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle,weaponBonus)

--- a/zb/researchTree/fu_warcraft.config
+++ b/zb/researchTree/fu_warcraft.config
@@ -398,7 +398,7 @@
 
       "irongear"  : [ "Weapons and Armor Forging", "^orange;Tier 1^reset;\n\nYou've learned the basics of making weapons and armor. You can now create an ^orange;Armorworks^reset; at your ^orange;Machining Table^reset; where you can create a huge variety of EPPs, armor, and weapons out of many materials. There, you can now make a variety of basic armor and equipment out of simple metals like iron.\n\n^yellow;Note^reset;: While the old Anvil is still available, it has essentially been superseded by the Armorworks in function. You no longer really have a reason to make one." ],
 
-      "bonegear"  : [ "Bonecraft", "^orange;Tier 1^reset;\n\nFashioning weapons and armor out of bone is pretty simple, at least compared to metalworking. You can now carve a variety of useful bone-based equipment by hand. They might not be as good as metal, but they sure beat sticks and stones." ],
+      "bonegear"  : [ "Bonecraft", "^orange;Tier 1^reset;\n\nFashioning weapons and armor out of bone is pretty simple, at least compared to metalworking. You can now carve a variety of useful bone-based equipment ^green;by hand [C]^reset;. They might be primitive compared to metal, but they sure beat sticks and stones." ],
 
       "telebriumgear"  : [ "Telebrium Equipment", "^orange;Tier 2^reset;\n\nYou've learned how best to utilize Telebrium in the creation of lightweight, poison-themed weapons and armor." ],
 
@@ -441,6 +441,7 @@
       "elduugear"  : [ "Elduu Weapons", "^orange;Tier 2^reset;\n\nThe Elduu race use crystals for most everything. Gleaming and beautiful. You've learned to mimic that style and can make such weapons on your own." ],
 
       "veluuishgear"  : [ "Vel'uuish Weapons", "^orange;Tier 2^reset;\n\nThe Vel'uuish race alloys gold with Duskiline crystals, creating heavy but surprisingly durable weaponry. You've learned to mimic that style and can make such weapons on your own." ],
+
       "skathgear"  : [ "Skath Weapons", "^orange;Tier 2^reset;\n\nThe Skath were almost rendered extinct thanks to a long-forgotten enemy, and it has shaped their culture ever since. Skath are quite adept with weaponry, especially plasma." ],
 
       "quietusgear"  : [ "Quietus Equipment", "^orange;Tier 4^reset;\n\nQuietus metal is a strange, highly poisonous substance that almost seems to be alive, somehow. Few metals hold a sharp edge like Quietus, making it great in melee weapons. It's also quite potent in armors and ballistic weapons." ],
@@ -480,10 +481,10 @@
       "epps4"  : [ "Peerless EPPs", "^orange;Tier 6^reset;\n\nYou've mastered the art of EPP creation and can make the best EPPs around." ],
 
       "ambergear"  : [ "Bee Equipment", "^orange;Tier 4^reset;\n\nYou've gotten very good at shaping organic materials, and can now forge hard amber into a variety of bee and honey-themed armors and weapons. (Not by hand, of course!)" ],
+
       "slimegear1"  : [ "Slime Equipment", "^orange;Tier 2^reset;\n\nIt might seem pretty gross, but with some clever engineering you could form solid slime capable of being used as weapons or armor. Don't argue. Just accept.\n\nSome recipes require the ^cyan;Biochemist Table^reset;. Research it in the ^green;Geology tree^reset;." ],
       "slimegear2"  : [ "Slime Equipment II", "^orange;Tier 4^reset;\n\nIt might seem pretty gross, but with some clever engineering you could form solid slime capable of being used as weapons or armor. Don't argue. Just accept." ],
       "slimegear3"  : [ "Slime Equipment III", "^orange;Tier 5^reset;\n\nIt might seem pretty gross, but with some clever engineering you could form solid slime capable of being used as weapons or armor. Don't argue. Just accept." ]
-
     }
   },
 


### PR DESCRIPTION
- Corrected the descriptions and set effects of many armour sets to document unlisted bonuses, correct inconsistent numbers, and improve weapon filters so that armour sets more consistently buff relevant weapons.
- Updated the description of the Bonecraft research node.
- The Apex asteroid microdungeon now properly unlocks the field generator room when all enemies are dead.
- Grappling hooks in zero-gravity now swing in circles rather than arcs.
- Corrected missing punctuation for X'i and X'ian.
- The Splitter Rifle now correctly displays its damage type as electric.