### PR TITLE
Update old radiomessages, etc.

### DIFF
--- a/radiomessages/fu_exploration.radiomessages
+++ b/radiomessages/fu_exploration.radiomessages
@@ -30,7 +30,7 @@
   },
   "needMicrosphere" : {
     "unique" : false,
-    "text" : "To fit through this gap, you're going to require a ^orange;Microsphere Tech^reset;. You can craft it via your ^orange;Tech Tablet^reset;. "
+    "text" : "To fit through this gap, you're going to require a ^orange;Microsphere Tech^reset;. You can craft it via your ^orange;Tricorder^reset;. "
   },
   "justkiddingyoureamoron" : {
     "unique" : false,

--- a/radiomessages/fu_resources.radiomessages
+++ b/radiomessages/fu_resources.radiomessages
@@ -94,7 +94,7 @@
 
   "pickupIodine" : {
     "type" : "tutorial",
-    "text" : "With ^orange;Iodine^reset; available, graphene and methyl iodide become relatively simple to produce. I'd collect as much as you can."
+    "text" : "With ^orange;Iodine^reset; available, advanced medicine and methyl iodide become relatively simple to produce. I'd collect as much as you can."
   },
 
   "pickupMagnesiumpowder" : {

--- a/species/fukirhos.species
+++ b/species/fukirhos.species
@@ -11,7 +11,7 @@
 ^orange;Perks^reset;:
   +^green;10^reset;% Speed
   ^green;Resist^reset;: +^cyan;15^reset;% Electric, +^cyan;10^reset;% Radioactive & Ice, +^cyan;7^reset;% Mental
-  Great Traders: +^green;21^reset;% Charisma, +1000 Start Cash
+  Great Traders: +^green;25^reset;% Charisma, +1000 Start Cash
   +^green;72^reset; Max Food
 
 ^orange;Weapons^reset;:

--- a/stats/effects/fu_tileeffects/poison_effects/darkwaterpoison/darkwaterpoison.statuseffect
+++ b/stats/effects/fu_tileeffects/poison_effects/darkwaterpoison/darkwaterpoison.statuseffect
@@ -13,6 +13,6 @@
 
   "animationConfig" : "darkwaterpoison.animation",
 
-  "label" : "Darkwater Poison: ^red;%50%^reset; Shadow, Fire, Ice Resistance. ^red;20%^reset; move penalty. Resist with Poison Resistance",
+  "label" : "Darkwater Poison: ^red;-25%^reset; Shadow, Fire, Ice Resistance. ^red;20%^reset; move penalty. Resist with Poison Resistance",
   "icon" : "/interface/statuses/darkwaterpoison.png"
 }


### PR DESCRIPTION
- Updated radiomessage about Iodine to not imply that it is needed to produce Graphene
- Updated radiomessage that was mentioning Tech Tablet (old item that was replaced by Tricorder)
- Updated tooltip of Darkwater Poison status effect
- Updated description of Kirhos to say that they have +25% to Charisma (was: 21%)