### PR TITLE
Parachute and Gold Armour fixes

### DIFF
--- a/items/armors/backitems/parachutepack/parachutepack.back.patch
+++ b/items/armors/backitems/parachutepack/parachutepack.back.patch
@@ -7,7 +7,7 @@
   {
     "op": "add",
     "path": "/statusEffects",
-    "value": [ "lowgravavian" ]
+    "value": [ "lowgravavian", "nofallinvis" ]
   },
   {
     "op": "add",
@@ -29,6 +29,7 @@
   {
     "op": "replace",
     "path": "/description",
-    "value": "A parachute. No more freefalling!"
+    "value": "A parachute. No more freefalling!
+^cyan;Immune^reset;: Fall Damage, Grav-Rain"
   }
 ]

--- a/items/armors/other/goldarmor/goldarmor.chest.patch
+++ b/items/armors/other/goldarmor/goldarmor.chest.patch
@@ -45,7 +45,7 @@
 			"value": [
 				    "goldarmorsetbonusnew",
 				{
-					"stat" : "fu_goldsetnew_chest",
+					"stat" : "fu_goldarmorsetnew_chest",
 					"amount" : 1
 				}
 			]

--- a/items/armors/other/goldarmor/goldarmor.head.patch
+++ b/items/armors/other/goldarmor/goldarmor.head.patch
@@ -45,7 +45,7 @@
 			"value": [
 				    "goldarmorsetbonusnew",
 				{
-					"stat" : "fu_goldsetnew_head",
+					"stat" : "fu_goldarmorsetnew_head",
 					"amount" : 1
 				}
 			]

--- a/items/armors/other/goldarmor/goldarmor.legs.patch
+++ b/items/armors/other/goldarmor/goldarmor.legs.patch
@@ -45,7 +45,7 @@
 			"value": [
 				    "goldarmorsetbonusnew",
 				{
-					"stat" : "fu_goldsetnew_legs",
+					"stat" : "fu_goldarmorsetnew_legs",
 					"amount" : 1
 				}
 			]

--- a/stats/effects/lowgrav/lowgravavian.lua
+++ b/stats/effects/lowgrav/lowgravavian.lua
@@ -1,20 +1,11 @@
 require "/scripts/unifiedGravMod.lua"
-local handle=nil
 
 function init()
 	unifiedGravMod.init()
+	unifiedGravMod.initSoft()
 	effect.addStatModifierGroup({ {stat = "gravrainImmunity", amount = 1} })
-	self.powerModifier = config.getParameter("powerModifier", 0)
-	effect.addStatModifierGroup({{stat = "powerMultiplier", baseMultiplier = self.powerModifier}})
-	self.gravParam=config.getParameter("gravityMod",0)
 end
 
 function update(dt)
-	self.newGravityMultiplier = status.resource("customGravity")*(self.gravParam or 0)
-	if handle==nil then
-		handle=effect.addStatModifierGroup({ {stat = "gravityMod", amount=self.newGravityMultiplier} })
-	else
-		effect.setStatModifierGroup(handle,{ {stat = "gravityMod", amount=self.newGravityMultiplier} })
-	end
 	unifiedGravMod.refreshGrav(dt)
 end

--- a/stats/effects/lowgrav/lowgravavian.statuseffect
+++ b/stats/effects/lowgrav/lowgravavian.statuseffect
@@ -1,7 +1,7 @@
 {
   "name" : "lowgravavian",
   "effectConfig" : {
-    "gravityMod" : -0.6
+    "gravityMod" : -0.8
   },
   "defaultDuration" : 15,
 


### PR DESCRIPTION
- The Parachute now correctly reduces fall speed and damage, and doesn't reduce player damage.
- Gold Armour now correctly applies its set effect.