### PR TITLE
small stuff

### DIFF
--- a/items/active/weapons/bow/abilities/rngbows/warppointarrow/neb-warppointarrow.lua
+++ b/items/active/weapons/bow/abilities/rngbows/warppointarrow/neb-warppointarrow.lua
@@ -174,7 +174,7 @@ function NebRNGWarpPoint:fire()
 
 	self.cannotUseAlt = true
 
-	while world.entityExists(self.teleportProjectile) do
+	while (self.teleportProjectile) and world.entityExists(self.teleportProjectile) do
 		world.debugText("Active projectiles detected!", mcontroller.position(), "green")
 
 		self.targetPosition = world.entityPosition(self.teleportProjectile)

--- a/items/active/weapons/masteries.lua
+++ b/items/active/weapons/masteries.lua
@@ -383,7 +383,7 @@ function masteries.apply(args)
 			end
 
 			-- hammers: increased damage. crit, stun chance. crit damage.
-			--special bonuses while doing charged attacks, like greataxes.
+			--special bonuses while doing charged attacks, like greataxes. note that greataxes are exclusively handled in /items/active/weapons/melee/abilities/greataxe/greataxesmash.lua
 			if tagCaching[currentHand.."TagCache"]["hammer"] then
 				masteryBuffer[#masteryBuffer + 1]={stat="powerMultiplier", effectiveMultiplier=1+(masteries.stats.hammerMastery*handMultiplier/2) }
 				masteryBuffer[#masteryBuffer + 1]={stat="critChance", amount=2*masteries.stats.hammerMastery*handMultiplier}

--- a/items/active/weapons/melee/abilities/greataxe/greataxesmash.lua
+++ b/items/active/weapons/melee/abilities/greataxe/greataxesmash.lua
@@ -62,10 +62,10 @@ function GreataxeSmash:windup(windupProgress)
 				self.timerGreataxe = 0
 				status.setPersistentEffects("greataxeMasteryBonus", {})
 			else
-				if self.timerGreataxe < 100 then --otherwise, add bonus
+				if self.timerGreataxe < 100 then --otherwise, add bonus. crit chance scales from 0 to 100%, reaching it quicker with higher mastery. crit damage reaches 1% at max, multiplied by mastery value (30% makes it 1.3% CD)
 					self.timerGreataxe = self.timerGreataxe + 0.5
 					local greataxeMastery=1+status.stat("greataxeMastery")
-					status.setPersistentEffects("greataxeMasteryBonus", {{stat = "critChance", amount = ((self.timerGreataxe * 1.05) + (greataxeMastery/2)) },{stat = "critDamage", amount = (self.timerGreataxe/100) + (greataxeMastery/100)}})
+					status.setPersistentEffects("greataxeMasteryBonus", {{stat = "critChance", amount = self.timerGreataxe * 1.05 * greataxeMastery },{stat = "critDamage", amount = greataxeMastery*self.timerGreataxe/100}})
 					world.sendEntityMessage(activeItem.ownerEntityId(),"recordFUPersistentEffect","greataxeMasteryBonus")
 				end
 				if self.timerGreataxe == 100 then	--at 101, play a sound


### PR DESCRIPTION
added some sanity proofing on warp point arrow code in case the projectile spawn function returns nil for some reason

added line in mastery lua file about where greataxes handle theirs. 

revised greataxe mastery so that you now get 0.3% crit damage for 30% mastery, instead of 0.03%.