### PR TITLE
Make liquid irradium usable in fission reactor

### DIFF
--- a/objects/power/isn_fissionreactornew/isn_fissionreactornew.object
+++ b/objects/power/isn_fissionreactornew/isn_fissionreactornew.object
@@ -51,6 +51,7 @@
 
   "bonusWasteChance" : 50,
   "fuels" : {
+      "liquidirradium" :      { "power" : 12,  "decayRate" : 30  },
       "tritium" :             { "power" : 10,  "decayRate" : 60  },
       "deuterium" :           { "power" : 15,  "decayRate" : 50  },
       "uraniumrod" :          { "power" : 20,  "decayRate" : 90  },


### PR DESCRIPTION
Irradium in its raw farm is a radioactive material that makes sense for a fission reactor to utilize. Fission reactors lost an important fuel in Hydrogen and is somewhat hard to use due to fuel scarcity so I believe an addition of a generally renewable (with steps involved) fuel would be good for its balance. 

Its specific numbers are up in the air. I have it at 12 between Tritium and Deuterium, while it is more common than Tritium or Deuterium and easier to produce, Tritium and Deuterium also aren't actually fissile fuels and there's a decent argument to just remove them entirely and replace them with Irradium. Thoughts on this are appreciated.