### PR TITLE
Chewable magnet lasts 10x duration; recipe produces 1/10th the magnets

### DIFF
--- a/items/generic/food/chewablemagnet.consumable
+++ b/items/generic/food/chewablemagnet.consumable
@@ -1,7 +1,7 @@
 {
   "itemName" : "chewablemagnet",
   "rarity" : "uncommon",
-  "price" : 35,
+  "price" : 150,
   "category" : "drink",
   "inventoryIcon" : "chewablemagnet.png",
   "description" : "Not healthy, but useful. \n^yellow;Item Magnet II^reset;",
@@ -12,7 +12,7 @@
   "effects" : [ [
     {
         "effect" : "fu_pickuprange2",
-        "duration" : 40
+        "duration" : 400
     }
   ] ]
 }

--- a/recipes/cooking/snacks/chewablemagnet.recipe
+++ b/recipes/cooking/snacks/chewablemagnet.recipe
@@ -4,6 +4,6 @@
       { "item" : "copperbar", "count" : 2 },
       { "item" : "sugar", "count" : 1 }
     ],
-    "output" : { "item" : "chewablemagnet", "count" : 10 },
+    "output" : { "item" : "chewablemagnet", "count" : 1 },
     "groups" : [ "craftingfood", "snacks" ]
   }


### PR DESCRIPTION
The recipe used to make 10 magnets, but each magnet lasted a fairly short time. I wanted to reduce the total micro involved in using the magnets (having to constantly refresh the buff is annoying) and this accomplishes that without changing the balance of chewable magnets' ingredients.