### PR TITLE
liquid irradium fission nerf

### DIFF
--- a/objects/power/isn_fissionreactornew/isn_fissionreactor.lua
+++ b/objects/power/isn_fissionreactornew/isn_fissionreactor.lua
@@ -3,7 +3,7 @@ require "/scripts/fupower.lua"
 require "/scripts/effectUtil.lua"
 
 function init()
-    power.init()
+	power.init()
 	wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
 	tritiumstack = world.containerSwapItems(entity.id(),{name = "tritium", count = 1, data={}},5)
 	object.setInteractive(true)
@@ -25,8 +25,8 @@ function init()
 		{amount = 1, state = 'slow'},
 		{amount = 0, state = 'off'}
 	}
-    storage.bonusWasteChance = config.getParameter("bonusWasteChance", 50)
-    self.fuels = config.getParameter("fuels")
+	storage.bonusWasteChance = config.getParameter("bonusWasteChance", 50)
+	self.fuels = config.getParameter("fuels")
 	storage.radiation = storage.radiation or 0
 	storage.active = true
 	storage.active2 = (not object.isInputNodeConnected(0)) or object.getInputNodeLevel(0)
@@ -49,10 +49,10 @@ function update(dt)
 		transferUtilDeltaTime=transferUtilDeltaTime+dt
 	end
 	for _,dink in pairs(radiationStates) do
-        if storage.radiation >= dink.amount then
-            animator.setAnimationState("hazard", dink.state)
-            break
-        end
+	if storage.radiation >= dink.amount then
+		animator.setAnimationState("hazard", dink.state)
+		break
+	end
 	end
 	if (not storage.active) or (not storage.active2) then
 		storage.radiation = math.max(storage.radiation - dt*5,0)
@@ -70,10 +70,10 @@ function update(dt)
 	local powerout = isn_getCurrentPowerOutput()
 	power.setPower(powerout)
 	for _,dink in pairs(powerStates) do
-        if powerout >= dink.amount then
-            animator.setAnimationState("screen", dink.state)
-            break
-        end
+	if powerout >= dink.amount then
+		animator.setAnimationState("screen", dink.state)
+		break
+	end
 	end
 	local rads = -4 + powerout
 	rads = (rads > 0) and (rads * 2) or rads
@@ -88,26 +88,26 @@ function update(dt)
 	-- could match this with the current radiation resistance
 	--khe was here
 	for _,dink in ipairs(radiationRanges) do
-        if storage.radiation >= dink.power then
-			effectUtil.projectileAllInRange("isn_fissionrads",dink.range)
-            break
-        end
+	if storage.radiation >= dink.power then
+		effectUtil.projectileAllInRange("isn_fissionrads",dink.range)
+		break
+	end
 	end
 	object.setAllOutputNodes(powerout>0)
 	power.update(dt)
 end
 
 function isn_powerSlotCheck(slotnum)
-    local item = world.containerItemAt(entity.id(), slotnum)
-    if not item then return 0 end
+	local item = world.containerItemAt(entity.id(), slotnum)
+	if not item then return 0 end
 	return self and self.fuels and self.fuels[item.name] and self.fuels[item.name].power or 0
 end
 
 function isn_slotDecayCheck(slot)
 	local item = world.containerItemAt(entity.id(),slot)
-    if item and self and self.fuels and self.fuels[item.name] and math.random(1, self.fuels[item.name].decayRate) == 1 then
-        return true
-    end
+	if item and self and self.fuels and self.fuels[item.name] and math.random(1, self.fuels[item.name].decayRate) == 1 then
+	return true
+	end
 	return false
 end
 
@@ -120,14 +120,14 @@ function isn_doSlotDecay(slot)
 	if waste then
 		-- sb.logInfo("Waste found in slot. Name is " .. waste.name)
 		if (waste.name == "toxicwaste") then
-		  -- sb.logInfo("increasing storage.radiation")
-		  storage.radiation = storage.radiation + 5
-		  wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
+			-- sb.logInfo("increasing storage.radiation")
+			storage.radiation = storage.radiation + 5
+			wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
 		else
-		  -- sb.logInfo("not toxic waste, ejecting")
-		  local wastecount = waste.count -- variable to ensure no change of quantities in between calculations.
-		  world.containerConsumeAt(entity.id(),4,wastecount) --delete waste
-		  world.spawnItem(waste.name,entity.position(),wastecount) --drop it on the ground
+			-- sb.logInfo("not toxic waste, ejecting")
+			local wastecount = waste.count -- variable to ensure no change of quantities in between calculations.
+			world.containerConsumeAt(entity.id(),4,wastecount) --delete waste
+			world.spawnItem(waste.name,entity.position(),wastecount) --drop it on the ground
 		end
 	else -- (waste == nil)
 		wastestack = world.containerSwapItems(entity.id(),{name = "toxicwaste", count = 1, data={}},4)
@@ -159,10 +159,10 @@ end
 
 function isn_getCurrentPowerOutput()
 	if not storage.active then return 0 end
-    local powercount = 0
-    for i=0,3 do
-        powercount = powercount + isn_powerSlotCheck(i)
-    end
+	local powercount = 0
+	for i=0,3 do
+		powercount = powercount + isn_powerSlotCheck(i)
+	end
 	--object.say(powercount)
 	return powercount
 end

--- a/objects/power/isn_fissionreactornew/isn_fissionreactornew.object
+++ b/objects/power/isn_fissionreactornew/isn_fissionreactornew.object
@@ -51,7 +51,7 @@
 
   "bonusWasteChance" : 50,
   "fuels" : {
-      "liquidirradium" :      { "power" : 12,  "decayRate" : 30  },
+      "liquidirradium" :      { "power" : 12,  "decayRate" : 30, "bonusChance": 10 },
       "tritium" :             { "power" : 10,  "decayRate" : 60  },
       "deuterium" :           { "power" : 15,  "decayRate" : 50  },
       "uraniumrod" :          { "power" : 20,  "decayRate" : 90  },

--- a/objects/power/isn_fissionreactornew/isn_fissionreactornew.object
+++ b/objects/power/isn_fissionreactornew/isn_fissionreactornew.object
@@ -57,11 +57,11 @@
       "uraniumrod" :          { "power" : 20,  "decayRate" : 90  },
       "plutoniumrod" :        { "power" : 30,  "decayRate" : 90  },
       "neptuniumrod" :        { "power" : 40,  "decayRate" : 90  },
-	    "thoriumrod" :          { "power" : 50,  "decayRate" : 90  },
-	    "enricheduranium" :     { "power" : 60, "decayRate" : 120 },
-	    "enrichedplutonium" :   { "power" : 70, "decayRate" : 180 },
-	    "solariumstar" :        { "power" : 80, "decayRate" : 240  },
-	    "ultronium" :           { "power" : 90, "decayRate" : 300 },
-	    "schrodingerscat" :     { "power" : 120, "decayRate" : 500 }
+      "thoriumrod" :          { "power" : 50,  "decayRate" : 90  },
+      "enricheduranium" :     { "power" : 60,  "decayRate" : 120 },
+      "enrichedplutonium" :   { "power" : 70,  "decayRate" : 180 },
+      "solariumstar" :        { "power" : 80,  "decayRate" : 240 },
+      "ultronium" :           { "power" : 90,  "decayRate" : 300 },
+      "schrodingerscat" :     { "power" : 120, "decayRate" : 500 }
   }
 }


### PR DESCRIPTION
liquid irradium drops tritium 5x less often
tritium overflow also creates extra radiation
fix buggy behavior when other items are placed in waste slots (item parameters stripped, waste doesn't drop)