### PR TITLE
liquid mixer tweak

### DIFF
--- a/objects/power/fu_liquidmixer/fu_liquidmixer.lua
+++ b/objects/power/fu_liquidmixer/fu_liquidmixer.lua
@@ -112,7 +112,7 @@ function update(dt)
 				storage.crafting = false
 				object.setOutputNodeLevel(0,storage.crafting)
 				storage.output = {}
-				storage.timer = self.speed
+				--storage.timer = self.speed
 			else
 				animator.setAnimationState("centrifuge", "idle")
 			end


### PR DESCRIPTION
removed an excessive wait after each craft on the liquid mixer, which was causing it to craft half as fast as intended.