### PR TITLE
colony core fallback measure

### DIFF
--- a/scripts/colonycorefu.lua
+++ b/scripts/colonycorefu.lua
@@ -50,6 +50,7 @@ function update(dt)
 		world.containerPutItemsAt(entity.id(),{name=wellSlots[1].name,count=(10 * (wellsDrawing) * (bonusHappiness/10))*(1+offlineTicks)},0)
 		offlineTicks=0
 		rentTimer = 0
+		object.setConfigParameter("leftTime", os.time() )
 	end
 end
 


### PR DESCRIPTION
tentative fallback measure for colony core: records 'last alive' time in update block in case uninit isn't called for some reason. (still have no reproducible case for it giving max output on instance entry)