### PR TITLE
tiny

### DIFF
--- a/items/active/weapons/melee/mace/uraniummace.activeitem
+++ b/items/active/weapons/melee/mace/uraniummace.activeitem
@@ -31,7 +31,7 @@
     "baseDps":7.12,
     "damageConfig" : {
       "damageSourceKind" : "radioactivehammer",
-      "statusEffects" : [ "defensebradiationburn" ]
+      "statusEffects" : [ "radiationburn" ]
     }
   },
   "critChance" : 1,


### PR DESCRIPTION
uranium mace: now uses radiationburn, instead of a nonexistent status effect. fixes it making enemies invulnerable.