### PR TITLE
Merge duplicate immunity stats

### DIFF
--- a/species/apex.raceeffect
+++ b/species/apex.raceeffect
@@ -13,7 +13,6 @@
 		{ "stat" : "radioactiveResistance", "amount" : -0.05 },
 
 		{ "stat" : "fujungleslowImmunity", "amount" : 1 },
-		{ "stat" : "jungleslowImmunity", "amount" : 1 },
 		{ "stat" : "fumudslowImmunity", "amount" : 1 },
 
 		//tech bonuses

--- a/species/bunnykin.raceeffect
+++ b/species/bunnykin.raceeffect
@@ -8,7 +8,7 @@
 		{ "stat" : "iceResistance", "amount" : 0.3 },
 		{ "stat" : "cosmicResistance", "amount" : 0.2 },
 		{ "stat" : "slimestickImmunity", "amount" : 1 },
-		{ "stat" : "jungleslowImmunity", "amount" : 1 },
+		{ "stat" : "fujungleslowImmunity", "amount" : 1 },
 		{ "stat" : "fumudslowImmunity", "amount" : 1 }
 	],
 	"diet" : "herbivore",

--- a/species/callistan.raceeffect
+++ b/species/callistan.raceeffect
@@ -11,7 +11,7 @@
 		{ "stat" : "cosmicResistance", "amount" : -0.2 },
 		{ "stat" : "radioactiveResistance", "amount" : 0.2 },
 		{ "stat" : "fumudslowImmunity", "amount" : 1 },
-		{ "stat" : "jungleslowImmunity", "amount" : 1 },
+		{ "stat" : "fujungleslowImmunity", "amount" : 1 },
 		{ "stat" : "webstickImmunity", "amount" : 1 },
 		{ "stat" : "sandstormImmunity", "amount" : 1 },
 		{ "stat" : "snowslowImmunity", "amount" : 1 },

--- a/species/cat.raceeffect
+++ b/species/cat.raceeffect
@@ -6,7 +6,6 @@
 		{ "stat" : "fumudslowImmunity", "amount" : 1 },
 		{ "stat" : "fallDamageMultiplier", "effectiveMultiplier" : 0.2 },
 		{ "stat" : "fujungleslowImmunity", "amount" : 1 },
-		{ "stat" : "jungleslowImmunity", "amount" : 1 },
 		{ "stat" : "bowDrawTimeBonus", "amount": 0.1 }
 	],
 	"diet" : "carnivore",

--- a/species/lamia.raceeffect
+++ b/species/lamia.raceeffect
@@ -41,7 +41,7 @@
 			"amount": 1
 		},
 		{
-			"stat": "jungleslowImmunity",
+			"stat": "fujungleslowImmunity",
 			"amount": 1
 		}
 	],

--- a/species/phox.raceeffect
+++ b/species/phox.raceeffect
@@ -37,7 +37,7 @@
 			"amount": -0.2
 		},
 		{
-			"stat": "jungleslowImmunity",
+			"stat": "fujungleslowImmunity",
 			"amount": 1
 		},
 		{

--- a/species/pony.raceeffect
+++ b/species/pony.raceeffect
@@ -14,7 +14,6 @@
 
 		{ "stat" : "fujungleslowImmunity", "amount" : 1 },
 		{ "stat" : "fumudslowImmunity", "amount" : 1 },
-		{ "stat" : "fuclayslowImmunity", "amount" : 1 },
 
 		{ "stat": "broadswordMastery", "amount": 0.2 },
 		{ "stat": "whipMastery", "amount": 0.1 },

--- a/species/pony.raceeffect
+++ b/species/pony.raceeffect
@@ -13,7 +13,6 @@
 		{ "stat": "poisonResistance", "amount": 0.15 },
 
 		{ "stat" : "fujungleslowImmunity", "amount" : 1 },
-		{ "stat" : "jungleslowImmunity", "amount" : 1 },
 		{ "stat" : "fumudslowImmunity", "amount" : 1 },
 		{ "stat" : "fuclayslowImmunity", "amount" : 1 },
 

--- a/species/pony.species.patch
+++ b/species/pony.species.patch
@@ -11,7 +11,7 @@
 
 ^orange;Perks^reset;:
   Health and Protection x^green;1.1^reset;. +^green;7^reset;% Movement & Jump Height
-  ^cyan;Immune^reset;: Mud, Jungle, Clay
+  ^cyan;Immune^reset;: Mud Slow, Jungle
   ^cyan;Racial Ability^reset;: Earth Pony Stomp
 
 ^orange;Environment^reset;:

--- a/species/pygs.raceeffect
+++ b/species/pygs.raceeffect
@@ -29,7 +29,7 @@
 			"amount": 1
 		},
 		{
-			"stat": "jungleslowImmunity",
+			"stat": "fujungleslowImmunity",
 			"amount": 1
 		}
 	],

--- a/species/satkyterran.raceeffect
+++ b/species/satkyterran.raceeffect
@@ -18,10 +18,6 @@
       "amount": -0.1
     },
     {
-      "stat": "jungleslowImmunity",
-      "amount": 1
-    },
-    {
       "stat": "fujungleslowImmunity",
       "amount": 1
     },

--- a/species/scyphojel.raceeffect
+++ b/species/scyphojel.raceeffect
@@ -10,7 +10,6 @@
 		{ "stat": "shadowResistance", 		"amount": -0.1 },
 
 //		Scyphojel are levitating, electric producing jellyfish, so most terrain and slow effects wouldn't make sense affecting them.
-		{ "stat": "mudslowImmunity", 		"amount": 1 },
 		{ "stat": "fumudslowImmunity", 		"amount": 1 },
 		{ "stat": "fuclayslowImmunity", 	"amount": 1 },
 		{ "stat": "fujungleslowImmunity", 	"amount": 1 },

--- a/species/scyphojel.raceeffect
+++ b/species/scyphojel.raceeffect
@@ -13,7 +13,7 @@
 		{ "stat": "mudslowImmunity", 		"amount": 1 },
 		{ "stat": "fumudslowImmunity", 		"amount": 1 },
 		{ "stat": "fuclayslowImmunity", 	"amount": 1 },
-		{ "stat": "jungleslowImmunity", 	"amount": 1 },
+		{ "stat": "fujungleslowImmunity", 	"amount": 1 },
 		{ "stat": "slushslowImmunity", 		"amount": 1 },
 		{ "stat": "snowslowImmunity", 		"amount": 1 },
 		{ "stat": "snowslipImmunity", 		"amount": 1 },

--- a/species/scyphojel.raceeffect
+++ b/species/scyphojel.raceeffect
@@ -11,7 +11,6 @@
 
 //		Scyphojel are levitating, electric producing jellyfish, so most terrain and slow effects wouldn't make sense affecting them.
 		{ "stat": "fumudslowImmunity", 		"amount": 1 },
-		{ "stat": "fuclayslowImmunity", 	"amount": 1 },
 		{ "stat": "fujungleslowImmunity", 	"amount": 1 },
 		{ "stat": "slushslowImmunity", 		"amount": 1 },
 		{ "stat": "snowslowImmunity", 		"amount": 1 },

--- a/species/spiritguardian.raceeffect
+++ b/species/spiritguardian.raceeffect
@@ -9,7 +9,6 @@
 
 		{ "stat": "fujungleslowImmunity", "amount": 1 },
 		{ "stat": "fumudslowImmunity", "amount": 1 },
-		{ "stat": "fuclayslowImmunity", "amount": 1 },
 
 		{ "stat": "iceResistance", "amount": 0.1 },
 		{ "stat": "shadowResistance", "amount": 0.2 },

--- a/species/spiritguardian.raceeffect
+++ b/species/spiritguardian.raceeffect
@@ -9,7 +9,6 @@
 
 		{ "stat": "fujungleslowImmunity", "amount": 1 },
 		{ "stat": "fumudslowImmunity", "amount": 1 },
-		{ "stat": "mudslowImmunity", "amount": 1 },
 		{ "stat": "fuclayslowImmunity", "amount": 1 },
 
 		{ "stat": "iceResistance", "amount": 0.1 },

--- a/species/spiritguardian.raceeffect
+++ b/species/spiritguardian.raceeffect
@@ -7,7 +7,7 @@
 		{ "stat": "foodDelta", "baseMultiplier": 0.9 },
 		{ "stat": "maxFood", "effectiveMultiplier": 0.8 },
 
-		{ "stat": "jungleslowImmunity", "amount": 1 },
+		{ "stat": "fujungleslowImmunity", "amount": 1 },
 		{ "stat": "fumudslowImmunity", "amount": 1 },
 		{ "stat": "mudslowImmunity", "amount": 1 },
 		{ "stat": "fuclayslowImmunity", "amount": 1 },

--- a/species/spiritguardian.species.patch
+++ b/species/spiritguardian.species.patch
@@ -10,7 +10,7 @@
 ^orange;Perks^reset;
   +^green;20^reset;% Speed, Jump. Energy x^green;1.3^reset;
   +^green;1^reset;% Health Regen, -^green;10^reset;% Hunger Drain
-  ^cyan;Immune^reset;: Jungle Slow, Mud Slow, Clay Slow, Fall Damage
+  ^cyan;Immune^reset;: Jungle Slow, Mud Slow, Fall Damage
   ^green;Resist^reset;: +^green;20^reset;% Shadow, Darkness, +^green;10% Ice^reset;
   Glows
 

--- a/species/spirittree.raceeffect
+++ b/species/spirittree.raceeffect
@@ -7,7 +7,7 @@
 		{ "stat": "poisonResistance", "amount": -0.3 },
 		{ "stat": "shadowResistance", "amount": 0.1 },
 		{ "stat": "cosmicResistance", "amount": 0.1 },
-		{ "stat": "jungleslowImmunity", "amount": 1 },
+		{ "stat": "fujungleslowImmunity", "amount": 1 },
 		{ "stat": "fumudslowImmunity", "amount": 1 },
 		{ "stat": "fallDamageMultiplier", "effectiveMultiplier": 0 }
 	],

--- a/species/squamaeft.raceeffect
+++ b/species/squamaeft.raceeffect
@@ -9,7 +9,7 @@
 		{ "stat" : "cosmicResistance", "amount" : 0.15 },
 		{ "stat" : "radioactiveResistance", "amount" : 0.15 },
 		{ "stat" : "poisonStatusImmunity", "amount" : 1 },
-		{ "stat": "jungleslowImmunity", "amount": 1 },
+		{ "stat": "fujungleslowImmunity", "amount": 1 },
 		{ "stat": "fumudslowImmunity", "amount": 1 },
 		{ "stat": "mudslowImmunity", "amount": 1 },
 		{ "stat": "fuclayslowImmunity", "amount": 1 },

--- a/species/squamaeft.raceeffect
+++ b/species/squamaeft.raceeffect
@@ -11,7 +11,6 @@
 		{ "stat" : "poisonStatusImmunity", "amount" : 1 },
 		{ "stat": "fujungleslowImmunity", "amount": 1 },
 		{ "stat": "fumudslowImmunity", "amount": 1 },
-		{ "stat": "fuclayslowImmunity", "amount": 1 },
 		{ "stat": "blacktarslowImmunity", "amount": 1 },
 		{ "stat": "slushslowImmunity", "amount": 1 }
 	],

--- a/species/squamaeft.raceeffect
+++ b/species/squamaeft.raceeffect
@@ -11,7 +11,6 @@
 		{ "stat" : "poisonStatusImmunity", "amount" : 1 },
 		{ "stat": "fujungleslowImmunity", "amount": 1 },
 		{ "stat": "fumudslowImmunity", "amount": 1 },
-		{ "stat": "mudslowImmunity", "amount": 1 },
 		{ "stat": "fuclayslowImmunity", "amount": 1 },
 		{ "stat": "blacktarslowImmunity", "amount": 1 },
 		{ "stat": "slushslowImmunity", "amount": 1 }

--- a/species/tauren.raceeffect
+++ b/species/tauren.raceeffect
@@ -49,7 +49,7 @@
 			"amount": 1
 		},
 		{
-			"stat": "jungleslowImmunity",
+			"stat": "fujungleslowImmunity",
 			"amount": 1
 		},
 		{

--- a/species/taurikin.raceeffect
+++ b/species/taurikin.raceeffect
@@ -8,7 +8,6 @@
 		{ "stat" : "fujungleslowImmunity", "amount" : 1 },
 		{ "stat" : "snowslowImmunity", "amount" : 1 },
 		{ "stat" : "slushslowImmunity", "amount" : 1 },
-		{ "stat" : "fuclayslowImmunity", "amount" : 1 },
 		{ "stat" : "foodDelta", "baseMultiplier" : 1.25 }
 	],
 	"diet" : "herbivore",

--- a/species/taurikin.raceeffect
+++ b/species/taurikin.raceeffect
@@ -5,7 +5,7 @@
 		{ "stat": "fallDamageMultiplier", "effectiveMultiplier": 0.9 },
 		{ "stat" : "protection", "effectiveMultiplier" : 0.9 },
 		{ "stat" : "fumudslowImmunity", "amount" : 1 },
-		{ "stat" : "jungleslowImmunity", "amount" : 1 },
+		{ "stat" : "fujungleslowImmunity", "amount" : 1 },
 		{ "stat" : "snowslowImmunity", "amount" : 1 },
 		{ "stat" : "slushslowImmunity", "amount" : 1 },
 		{ "stat" : "fuclayslowImmunity", "amount" : 1 },

--- a/species/veluu.raceeffect
+++ b/species/veluu.raceeffect
@@ -13,7 +13,6 @@
 
 		{ "stat": "fumudslowImmunity", "amount": 1 },
 		{ "stat": "fujungleslowImmunity", "amount": 1 },
-		{ "stat": "jungleslowImmunity", "amount": 1 },
 
 		{ "stat": "fistMastery", "amount": 0.20 },
 		{ "stat": "daggerMastery", "amount": 0.15 },

--- a/species/vulpes.raceeffect
+++ b/species/vulpes.raceeffect
@@ -21,7 +21,7 @@
 			"amount": -0.5
 		},
 		{
-			"stat": "jungleslowImmunity",
+			"stat": "fujungleslowImmunity",
 			"amount": 1
 		}
 	],

--- a/species/zoroark.raceeffect
+++ b/species/zoroark.raceeffect
@@ -37,7 +37,7 @@
 			"amount": 1
 		},
 		{
-			"stat": "jungleslowImmunity",
+			"stat": "fujungleslowImmunity",
 			"amount": 1
 		}
 	],

--- a/species/zoroark.raceeffect
+++ b/species/zoroark.raceeffect
@@ -29,7 +29,7 @@
 			"amount": 0.1
 		},
 		{
-			"stat": "mudslowImmunity",
+			"stat": "fumudslowImmunity",
 			"amount": 1
 		},
 		{

--- a/stats/__STAT_LIST.TXT
+++ b/stats/__STAT_LIST.TXT
@@ -44,7 +44,7 @@ IMMUNITIES
         mudslowImmunity             [amount] [Boolean]
         fumudslowImmunity           [amount] [Boolean]
         fuclayslowImmunity          [amount] [Boolean]
-        jungleslowImmunity          [amount] [Boolean]
+        fujungleslowImmunity        [amount] [Boolean]
 
         slushslowImmunity           [amount] [Boolean]
         snowslowImmunity            [amount] [Boolean]

--- a/stats/__STAT_LIST.TXT
+++ b/stats/__STAT_LIST.TXT
@@ -42,7 +42,6 @@ RESISTANCES: These use float values (0.5 is 50% Resistance)
 IMMUNITIES
     MOBILITY:
         fumudslowImmunity           [amount] [Boolean]
-        fuclayslowImmunity          [amount] [Boolean]
         fujungleslowImmunity        [amount] [Boolean]
 
         slushslowImmunity           [amount] [Boolean]

--- a/stats/__STAT_LIST.TXT
+++ b/stats/__STAT_LIST.TXT
@@ -41,7 +41,6 @@ RESISTANCES: These use float values (0.5 is 50% Resistance)
 
 IMMUNITIES
     MOBILITY:
-        mudslowImmunity             [amount] [Boolean]
         fumudslowImmunity           [amount] [Boolean]
         fuclayslowImmunity          [amount] [Boolean]
         fujungleslowImmunity        [amount] [Boolean]

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/darkdisguisesetbonuseffectkhe.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/darkdisguisesetbonuseffectkhe.lua
@@ -13,7 +13,7 @@ shellBonus={
 	{stat = "clayslowImmunity", amount = 1},
 	{stat = "blacktarImmunity", amount = 1},
 	{stat = "fumudslowImmunity", amount = 1},
-	{stat = "jungleslowImmunity", amount = 1},
+	{stat = "fujungleslowImmunity", amount = 1},
 	{stat = "quicksandImmunity", amount = 1},
 	{stat = "honeyslowImmunity", amount = 1},
 	{stat = "iceslipImmunity", amount = 1},

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/darkdisguisesetbonuseffectkhe.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/darkdisguisesetbonuseffectkhe.lua
@@ -10,7 +10,6 @@ shellBonus={
 
 	{stat = "snowslowImmunity", amount = 1},
 	{stat = "slushslowImmunity", amount = 1},
-	{stat = "clayslowImmunity", amount = 1},
 	{stat = "blacktarImmunity", amount = 1},
 	{stat = "fumudslowImmunity", amount = 1},
 	{stat = "fujungleslowImmunity", amount = 1},

--- a/stats/effects/fu_armoreffects/set_bonuses/tier7/phasesetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier7/phasesetbonuseffect.lua
@@ -9,7 +9,6 @@ armorBonus={
 	{stat ="critChance" , amount = 3 },
 	{stat = "snowslowImmunity", amount = 1},
 	{stat = "slushslowImmunity", amount = 1},
-	{stat = "clayslowImmunity", amount = 1},
 	{stat = "blacktarImmunity", amount = 1},
 	{stat = "fumudslowImmunity", amount = 1},
 	{stat = "fujungleslowImmunity", amount = 1},

--- a/stats/effects/fu_armoreffects/set_bonuses/tier7/phasesetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier7/phasesetbonuseffect.lua
@@ -12,7 +12,7 @@ armorBonus={
 	{stat = "clayslowImmunity", amount = 1},
 	{stat = "blacktarImmunity", amount = 1},
 	{stat = "fumudslowImmunity", amount = 1},
-	{stat = "jungleslowImmunity", amount = 1},
+	{stat = "fujungleslowImmunity", amount = 1},
 	{stat = "quicksandImmunity", amount = 1},
 	{stat = "honeyslowImmunity", amount = 1},
 	{stat = "iceslipImmunity", amount = 1},

--- a/stats/effects/fu_armoreffects/special_bonuses/movementprotection.lua
+++ b/stats/effects/fu_armoreffects/special_bonuses/movementprotection.lua
@@ -2,7 +2,6 @@ function init()
   effect.addStatModifierGroup({
     {stat = "snowslowImmunity", amount = 1},
     {stat = "slushslowImmunity", amount = 1},
-    {stat = "clayslowImmunity", amount = 1},
     {stat = "blacktarImmunity", amount = 1},
     {stat = "fumudslowImmunity", amount = 1},
     {stat = "fujungleslowImmunity", amount = 1},

--- a/stats/effects/fu_armoreffects/special_bonuses/movementprotection.lua
+++ b/stats/effects/fu_armoreffects/special_bonuses/movementprotection.lua
@@ -5,7 +5,7 @@ function init()
     {stat = "clayslowImmunity", amount = 1},
     {stat = "blacktarImmunity", amount = 1},
     {stat = "fumudslowImmunity", amount = 1},
-    {stat = "jungleslowImmunity", amount = 1},
+    {stat = "fujungleslowImmunity", amount = 1},
     {stat = "quicksandImmunity", amount = 1},
     {stat = "honeyslowImmunity", amount = 1},
     {stat = "iceslipImmunity", amount = 1},

--- a/stats/effects/fu_artifacts/apexartifact.statuseffect
+++ b/stats/effects/fu_artifacts/apexartifact.statuseffect
@@ -14,7 +14,7 @@
 
       { "stat": "fumudslowImmunity", "amount": 1 },
       { "stat": "iceslipImmunity", "amount": 1 },
-      { "stat": "jungleslowImmunity", "amount": 1 },
+      { "stat": "fujungleslowImmunity", "amount": 1 },
       { "stat": "slushslowImmunity", "amount": 1 },
       { "stat": "snowslowImmunity", "amount": 1 }
     ]

--- a/stats/effects/fu_immunityeffects/jungleslowimmunity.statuseffect
+++ b/stats/effects/fu_immunityeffects/jungleslowimmunity.statuseffect
@@ -2,7 +2,7 @@
 	"name": "jungleslowimmunity",
 	"effectConfig": {
 		"stats": [{
-			"stat": "jungleslowImmunity",
+			"stat": "fujungleslowImmunity",
 			"amount": 1
 		}]
 	},

--- a/stats/effects/fu_tileeffects/mobility_effects/jungleslow.statuseffect
+++ b/stats/effects/fu_tileeffects/mobility_effects/jungleslow.statuseffect
@@ -1,6 +1,6 @@
 {
   "name" : "jungleslow",
-  "blockingStat" : "jungleslowImmunity",
+  "blockingStat" : "fujungleslowImmunity",
   "effectConfig" : {
     "speedMod": "0.9"
   },

--- a/stats/effects/fu_weathereffects/new/tropical/jungleheatweather.statuseffect
+++ b/stats/effects/fu_weathereffects/new/tropical/jungleheatweather.statuseffect
@@ -7,7 +7,7 @@
 		},
 		"resistanceThreshold" : 0.2,
 		"immunityStats" : [
-			"jungleslowImmunity"
+			"fujungleslowImmunity"
 		],
 
 		"healthDrain" : 0.3,


### PR DESCRIPTION
- Fixed immunity to Jungle Slow not being applied by Monster Plate armor and some races.
- Replaced immunity to Clay Slow (not used anywhere) with immunity to Mud Slow (already protects against Clay tiles).