### PR TITLE
Fix some consumables giving less energy than their description says

### DIFF
--- a/items/generic/loot/fudeathstick.consumable
+++ b/items/generic/loot/fudeathstick.consumable
@@ -10,7 +10,7 @@
     "madnessgain",
     {"effect" : "booze2", "duration" : 220},
     {"effect" : "defenseboostneg20", "duration" : 220},
-    {"effect" : "maxenergyboost2", "duration" : 220}
+    {"effect" : "maxenergyboost3", "duration" : 220}
   ] ],
   "tooltipKind" : "food",
   "emitters" : [ "bandageuse" ],

--- a/items/generic/loot/fushroomspore.consumable
+++ b/items/generic/loot/fushroomspore.consumable
@@ -9,7 +9,7 @@
   "effects" : [ [
     "madnessgain2",
     {"effect" : "booze2", "duration" : 520},
-    {"effect" : "maxenergyboost2", "duration" : 520},
+    {"effect" : "maxenergyboost4", "duration" : 520},
     {"effect" : "insanity", "duration" : 520}
   ] ],
   "tooltipKind" : "food",


### PR DESCRIPTION
- Ghost-Spore and Telk Death-Stick now give +30/+20 Energy (was: +12)