### PR TITLE
Misc. fixes: rain watering crops, Getting Started quest, Blade Tree Dart

### DIFF
--- a/biomes/surface/strangeseafloor.biome
+++ b/biomes/surface/strangeseafloor.biome
@@ -5,16 +5,6 @@
   "spawnProfile" : {
     "groups" : [
       {
-        "select" : 3,
-        "pool" : [
-          [ 0.1, "eyeslime" ],
-          [ 0.4, "eyeslimeking" ],
-          [ 0.1, "eyejelly" ],
-          [ 0.4, "eyejellyking" ],
-          [ 0.4, "anglure6" ],
-          [ 1, "garflipp" ]
-        ]
-      },{
         "select" : 5,
         "pool" : [
           [ 0.18, "smallFishOcean1" ],

--- a/items/generic/loot/fuancientkey.item
+++ b/items/generic/loot/fuancientkey.item
@@ -5,7 +5,7 @@
   "price" : 100,
   "itemTags" :[ "artifactBasic" ],
   "inventoryIcon" : "fuancientkey.png",
-  "description" : "A strange device made by the Ancients.",
+  "description" : "^red;This item is no longer needed, it's safe to sell it.^reset;\nA strange device made by the Ancients.",
   "shortdescription" : "Ancient Device",
   "maxStack" : 1
 }

--- a/items/throwables/ise3/bladetreeblade.thrownitem
+++ b/items/throwables/ise3/bladetreeblade.thrownitem
@@ -10,7 +10,6 @@
   "edgeTrigger" : true,
   "windupTime" : 0.0,
   "cooldown" : 0.4,
-  "timeToLive" : 1.2,
 
   "category" : "throwableItem",
   "projectileType" : "bladetreedart",

--- a/npcs/merchantpools.config.patch
+++ b/npcs/merchantpools.config.patch
@@ -14,7 +14,6 @@
 				{"item": {"name": "ancienttemplemap"}, "prerequisiteQuest": "outpostclue"},
 				{"item": {"name": "mecharmmissilerack-recipe"}, "prerequisiteQuest": "mechupgrade1"},
 				{"item": {"name": "mecharmsinrack-recipe"}, "prerequisiteQuest": "mechupgrade1"},
-				{"item": {"name": "fuancientkey"}, "prerequisiteQuest": "create_matterassembler"},
 				{"item": {"name": "fuorangebag"}, "prerequisiteQuest": "create_clothingfabricator3c"},
 				{"item": {"name": "alien_trophy", "parameters": {"genomeInspected": true, "category": "artifactResearched"}}, "prerequisiteQuest": "evernight.gearup"},
 				{"item": {"name": "temple_trophy", "parameters": {"genomeInspected": true, "category": "artifactResearched"}}, "prerequisiteQuest": "ancienttemple.gearup"},

--- a/quests/scripts/story/gaterepair.lua
+++ b/quests/scripts/story/gaterepair.lua
@@ -104,7 +104,6 @@ end
 
 
 function checkGate()
-	--if player.hasItem({name = "fuancientkey", count = 1}) then
 	if player.hasCompletedQuest("create_matterassembler") then
 		self.gateUid = "ancientgate2"
 	else
@@ -197,7 +196,6 @@ function repairGate()
 		else
 			storage.stage = 3
 			quest.setObjectiveList({{self.descriptions.makeTable, false}})
-			player.radioMessage("fu_start_needstricorder")
 			self.state:set(self.stages[storage.stage])
 		end
 

--- a/quests/scripts/tutorial/fu_start.lua
+++ b/quests/scripts/tutorial/fu_start.lua
@@ -48,7 +48,6 @@ function setStage(newStage)
 			player.radioMessage("fu_start_Complete1a", 1)
 			player.radioMessage("fu_start_Complete1b", 1)
 			player.radioMessage("fu_start_Complete1c", 1)
-			player.giveItem("fuancientkey")
 		end
 		storage.missionStage = newStage
 	end

--- a/radiomessages/fu_quests.radiomessages
+++ b/radiomessages/fu_quests.radiomessages
@@ -107,7 +107,7 @@
     "type" : "quest",
     "senderName" : "Vinalisj",
     "portraitImage": "/interface/chatbubbles/fuvintalk.png:<frame>",
-    "text" : "In order to access the cave, you're going to need this ^orange;key^reset; that I interestingly found in the ^green;old, ruined house^reset; on the surface. It seems to react with the cavern, allowing entrance. ^red;Keep it with you, or you won't be able to enter^reset;!",
+    "text" : "The cave was previously locked, but I just opened it with a ^orange;key^reset; that I interestingly found in the ^green;old, ruined house^reset; on the surface. You should be able to enter now.",
     "portraitFrames" : 9,
     "portraitSpeed" : 3,
     "persistTime" : 20.0
@@ -147,26 +147,6 @@
     "type" : "tutorial",
     "unique": true,
     "text" : "The ^orange;Personal Tricorder^reset; is ^red;EXTREMELY^reset; important. Do not throw it out. Ever! Should you lose it, you can always create a new ^orange;Personal Tricorder^reset; in your ^green;Tinkering Table^reset;.",
-    "persistTime" : 20.0
-  },
-
-  "fu_start_needstricorder" : {
-    "type" : "quest",
-    "senderName" : "Vinalisj",
-    "portraitImage": "/interface/chatbubbles/fuvintalk.png:<frame>",
-    "text" : "The ^orange;Ancient Device^reset; will probably allow you to interface with the ^orange;power source^reset;! I've heard they react to the technology of their creators.",
-    "portraitFrames" : 9,
-    "portraitSpeed" : 3,
-    "persistTime" : 20.0
-  },
-
-  "fu_start_needstricorder2" : {
-    "type" : "quest",
-    "senderName" : "Vinalisj",
-    "portraitImage": "/interface/chatbubbles/fuvintalk.png:<frame>",
-    "text" : "Without a ^orange;Tricorder^reset; we won't be able to proceed. It needs to interface with this machine to properly enable the power.",
-    "portraitFrames" : 9,
-    "portraitSpeed" : 3,
     "persistTime" : 20.0
   },
 

--- a/tech/items/combatmaneuvering1.item
+++ b/tech/items/combatmaneuvering1.item
@@ -4,7 +4,7 @@
   "price" : 100,
   "category" : "Tech",
   "inventoryIcon" : "/tech/dashcombat.png",
-  "description" : "Short-ranged double-tap dodge. Increases Shield Bash chance and Protection.",
+  "description" : "Short-ranged double-tap dodge. Increases Shield Bash chance and Protection.\n^green;It's safe to sell this item, you won't lose the tech.^reset;\n^yellow;In multiplayer:^reset; giving this item to another player will teach them this tech.",
   "shortdescription" : "^#77acc3;Dodge^reset;",
   "consumeOnPickup" : false,
   "itemTags" : [ "trophy" ],

--- a/tech/items/fudistortionsphere.item
+++ b/tech/items/fudistortionsphere.item
@@ -4,7 +4,7 @@
   "price" : 100,
   "category" : "Tech",
   "inventoryIcon" : "/tech/distortionsphere.png",
-  "description" : "Transform into a ball! ^green;Press [F]^reset;",
+  "description" : "Transform into a ball! ^green;Press [F]^reset;\n^green;It's safe to sell this item, you won't lose the tech.^reset;\n^yellow;In multiplayer:^reset; giving this item to another player will teach them this tech.",
   "shortdescription" : "^#77acc3;Distortion Sphere^reset;",
   "consumeOnPickup" : false,
   "itemTags" : [ "trophy" ],

--- a/tech/items/longjump0.item
+++ b/tech/items/longjump0.item
@@ -4,7 +4,7 @@
   "price" : 100,
   "category" : "Tech",
   "inventoryIcon" : "/tech/boostedjump.png",
-  "description" : "Increased jump ability.",
+  "description" : "Increased jump ability.\n^green;It's safe to sell this item, you won't lose the tech.^reset;\n^yellow;In multiplayer:^reset; giving this item to another player will teach them this tech.",
   "shortdescription" : "^#77acc3;Boosted Jump^reset;",
 //  "learnBlueprintsOnPickup" : [ "longjump_tech" ],
   "consumeOnPickup" : false,

--- a/weather/bog/bograin.weather
+++ b/weather/bog/bograin.weather
@@ -67,6 +67,17 @@
       "spawnAboveRegion" : 30,
       "spawnHorizontalPad" : 30,
       "windAffectAmount" : 1.0
+    },
+    {
+      "projectile" : "lightwater",
+      "parameters" : {
+        "power" : 0
+      },
+      "velocity" : [0, -100],
+      "ratePerX" : 0.1,
+      "spawnAboveRegion" : 30,
+      "spawnHorizontalPad" : 10,
+      "windAffectAmount" : 1
     }
   ],
 

--- a/weather/rain/bloodrain.weather
+++ b/weather/rain/bloodrain.weather
@@ -67,6 +67,17 @@
       "spawnAboveRegion" : 30,
       "spawnHorizontalPad" : 30,
       "windAffectAmount" : 1.0
+    },
+    {
+      "projectile" : "lightwater",
+      "parameters" : {
+        "power" : 0
+      },
+      "velocity" : [0, -100],
+      "ratePerX" : 0.1,
+      "spawnAboveRegion" : 30,
+      "spawnHorizontalPad" : 10,
+      "windAffectAmount" : 1
     }
   ],
 

--- a/weather/rain/fububblerain.weather
+++ b/weather/rain/fububblerain.weather
@@ -30,6 +30,17 @@
       "spawnAboveRegion" : 30,
       "spawnHorizontalPad" : 30,
       "windAffectAmount" : 0.0
+    },
+    {
+      "projectile" : "lightwater",
+      "parameters" : {
+        "power" : 0
+      },
+      "velocity" : [0, -100],
+      "ratePerX" : 0.1,
+      "spawnAboveRegion" : 30,
+      "spawnHorizontalPad" : 10,
+      "windAffectAmount" : 1
     }
   ],
 

--- a/weather/rain/mistyrain.weather
+++ b/weather/rain/mistyrain.weather
@@ -72,6 +72,17 @@
       "spawnAboveRegion" : 30,
       "spawnHorizontalPad" : 30,
       "windAffectAmount" : 1.0
+    },
+    {
+      "projectile" : "lightwater",
+      "parameters" : {
+        "power" : 0
+      },
+      "velocity" : [0, -100],
+      "ratePerX" : 0.1,
+      "spawnAboveRegion" : 30,
+      "spawnHorizontalPad" : 10,
+      "windAffectAmount" : 1
     }
   ],
 


### PR DESCRIPTION
- The following rain-like weathers can water crops now: Bubble Rain, Misty Rain, Bog Rain, Blood Rain.
- Fixed stacks of Blade Tree Dart despawning if dropped (Q) onto the ground.
- Vinalisj no longer tells the player to carry an Ancient Device (was: key to the Dark Cavern), instead he says that he already opened the cave, and you can enter it.
- Vinalisj will no longer start talking about "power source" if player finds 20 Core Fragments outside of the Dark Cavern (when player doesn't know yet what he is talking about).
- Description of tech items from Dark Cavern (e.g. Distortion Sphere) now tells that they are safe to sell (player won't lose the tech), and how they can be used in multiplayer.
- Removed surface-only monsters (which can't spawn underwater) from underwater biome Strange Sea Floor.