### PR TITLE
Added Piercing to Cloudburst and Flaregunflare projectiles

### DIFF
--- a/projectiles/activeitems/staff/cloudburst/cutecloud.projectile
+++ b/projectiles/activeitems/staff/cloudburst/cutecloud.projectile
@@ -9,6 +9,7 @@
   "damagePoly" : [ ],
   "orientationLocked" : true,
   "bounces" : -1,
+  "piercing" : true,
   "scripts" : ["/projectiles/activeitems/staff/staffprojectile.lua"],
   "scriptDelta" : 1,
   "timedActions" : [

--- a/projectiles/activeitems/staff/cloudburst/darkcloud.projectile
+++ b/projectiles/activeitems/staff/cloudburst/darkcloud.projectile
@@ -9,6 +9,7 @@
   "damagePoly" : [ ],
   "orientationLocked" : true,
   "bounces" : -1,
+  "piercing" : true,
   "scripts" : ["/projectiles/activeitems/staff/staffprojectile.lua"],
   "scriptDelta" : 1,
   "timedActions" : [

--- a/projectiles/activeitems/staff/cloudburst/miasma.projectile
+++ b/projectiles/activeitems/staff/cloudburst/miasma.projectile
@@ -9,6 +9,7 @@
   "damagePoly" : [ ],
   "orientationLocked" : true,
   "bounces" : -1,
+  "piercing" : true,
   "scripts" : ["/projectiles/activeitems/staff/staffprojectile.lua"],
   "scriptDelta" : 1,
   "timedActions" : [

--- a/projectiles/flaregunflare/flaregunflare.projectile
+++ b/projectiles/flaregunflare/flaregunflare.projectile
@@ -2,6 +2,7 @@
   "projectileName" : "flaregunflare",
   "physics" : "grenadenobounce",
   "bounces" : -1,
+  "piercing" : true,
   "timeToLive" : 60,
   "image" : "flaregunflare.png",
   "animationCycle" : 0.25,


### PR DESCRIPTION
Cloudburst staff abilities (e.g. Effigium Staff) are canceled when an enemy moves through the center of the cloud, same with the Flaregun projectile when stepped on.
Adding piercing fixes this.