### PR TITLE
Liquid gun animation fix

### DIFF
--- a/items/active/weapons/ranged/unique/fu_liquidguns/healingliquidgun.activeitem
+++ b/items/active/weapons/ranged/unique/fu_liquidguns/healingliquidgun.activeitem
@@ -47,7 +47,7 @@
       "idle" : {
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : true,
         "allowFlip" : true
@@ -56,7 +56,7 @@
         "duration" : 0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false
@@ -65,7 +65,7 @@
         "duration" : 0.0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false

--- a/items/active/weapons/ranged/unique/fu_liquidguns/honeygun.activeitem
+++ b/items/active/weapons/ranged/unique/fu_liquidguns/honeygun.activeitem
@@ -47,7 +47,7 @@
       "idle" : {
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : true,
         "allowFlip" : true
@@ -56,7 +56,7 @@
         "duration" : 0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false
@@ -65,7 +65,7 @@
         "duration" : 0.0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false

--- a/items/active/weapons/ranged/unique/fu_liquidguns/liquidacidgun.activeitem
+++ b/items/active/weapons/ranged/unique/fu_liquidguns/liquidacidgun.activeitem
@@ -47,7 +47,7 @@
       "idle" : {
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : true,
         "allowFlip" : true
@@ -56,7 +56,7 @@
         "duration" : 0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false
@@ -65,7 +65,7 @@
         "duration" : 0.0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false

--- a/items/active/weapons/ranged/unique/fu_liquidguns/liquidpoisongun.activeitem
+++ b/items/active/weapons/ranged/unique/fu_liquidguns/liquidpoisongun.activeitem
@@ -47,7 +47,7 @@
       "idle" : {
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : true,
         "allowFlip" : true
@@ -56,7 +56,7 @@
         "duration" : 0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false
@@ -65,7 +65,7 @@
         "duration" : 0.0,
         "armRotation" : 0,
         "weaponRotation" : 0,
-        "twoHanded" : true,
+        "twoHanded" : false,
 
         "allowRotate" : false,
         "allowFlip" : false


### PR DESCRIPTION
The four one-handed liquid guns were set as two-handed under stances. While they still worked as one-handed, it caused other one-handed weapons to disappear when wielded together.