### PR TITLE
fixes

### DIFF
--- a/scripts/colonycorefu.lua
+++ b/scripts/colonycorefu.lua
@@ -51,7 +51,7 @@ function update(dt)
 		rentTimer = 0
 		if happy>0 then
 			world.containerPutItemsAt(entity.id(),{name=wellSlots[1].name,count=(10 * (wellsDrawing) * (happy/10))*(1+offlineTicks)},0)
-		elseif happy<0 then
+		elseif bonusHappiness<0 then
 			rentTimer=rentTimer-happy
 		end
 		offlineTicks=0

--- a/scripts/colonycorefu.lua
+++ b/scripts/colonycorefu.lua
@@ -47,9 +47,14 @@ function update(dt)
 	end
 	rentTimer = rentTimer + dt
 	if (rentTimer > rentTime) then
-		world.containerPutItemsAt(entity.id(),{name=wellSlots[1].name,count=(10 * (wellsDrawing) * (bonusHappiness/10))*(1+offlineTicks)},0)
-		offlineTicks=0
+		local happy=math.max(0,bonusHappiness)
 		rentTimer = 0
+		if happy>0 then
+			world.containerPutItemsAt(entity.id(),{name=wellSlots[1].name,count=(10 * (wellsDrawing) * (happy/10))*(1+offlineTicks)},0)
+		elseif happy<0 then
+			rentTimer=rentTimer-happy
+		end
+		offlineTicks=0
 		object.setConfigParameter("leftTime", os.time() )
 	end
 end

--- a/species/protogenrace1.raceeffect
+++ b/species/protogenrace1.raceeffect
@@ -3,7 +3,7 @@
 		// base stats
 		{ "stat": "maxEnergy", "effectiveMultiplier": 1.15 },
 		{ "stat": "maxHealth", "effectiveMultiplier": 0.85 },
-		{ "stat": "healingBonus", "amount": 1.2 },
+		{ "stat": "healingBonus", "amount": 0.2 },
 		// resists
 		{ "stat": "electricResistance", "amount": -0.25 },
 		{ "stat": "poisonResistance", "amount": 0.25 },


### PR DESCRIPTION
Corrected happiness underflow in colony core system. Additionally, negative happiness will now delay the timer.

Reverted unacceptable change to protogen species, +20% healing was buffed to +120% healing in another user's commit. This has been brought back down to +20%.