### PR TITLE
small

### DIFF
--- a/interface/scripted/fu_upgradetable/fu_upgradetable.lua
+++ b/interface/scripted/fu_upgradetable/fu_upgradetable.lua
@@ -83,7 +83,7 @@ end
 
 function upgradeCost(itemConfig,type,targetLvl)
 	local costValue=0
-	local itemLvl = math.floor((itemConfig.parameters.level or itemConfig.config.level) or 1)
+	local itemLvl = math.floor(tonumber(itemConfig.parameters.level or itemConfig.config.level or 1))
 	if not targetLvl then
 		targetLvl = itemLvl
 	end
@@ -218,14 +218,14 @@ function populateItemList(forceRepop)
 		for i, item in pairs(self.upgradableItems) do
 			local config = root.itemConfig(item.itemData)
 			local entryLevelMax=maxLvl(config,item.itemType)
-			if (self.isCrucible and not self.isUpgradeKit) or (config.parameters.level or config.config.level or 1) < entryLevelMax then
+			if (self.isCrucible and not self.isUpgradeKit) or tonumber(config.parameters.level or config.config.level or 1) < entryLevelMax then
 				local listItem = string.format("%s.%s", self.itemList, widget.addListItem(self.itemList))
 				local name = config.parameters.shortdescription or config.config.shortdescription
 
 				widget.setText(string.format("%s.itemName", listItem), name)
 				widget.setItemSlotItem(string.format("%s.itemIcon", listItem), item.itemData)
 
-				local price = upgradeCost(config,item.itemType,math.min(item.itemLevel+1, entryLevelMax))
+				local price = upgradeCost(config,item.itemType,math.min(tonumber(item.itemLevel)+1, entryLevelMax))
 				widget.setData(listItem, { index = i,itemType = item.itemType,itemLevel = item.itemLevel })
 				if self.isUpgradeKit or not self.isCrucible then
 					widget.setVisible(string.format("%s.unavailableoverlay", listItem), getCurrency(item.itemType)<price)
@@ -255,7 +255,7 @@ function showItem(item,price,itemType)
 		widget.setText("essenceCost", string.format("0 / --"))
 	end
 	local downgrade=""
-	if item and item.parameters.level and (item.parameters.level > maxLvl(item, itemType)) then
+	if item and item.parameters.level and (tonumber(item.parameters.level) > maxLvl(item, itemType)) then
 		downgrade="Warning: Item will be downgraded"
 	end
 	widget.setText("warningLabel",isWorn and "Error: "..isWorn or downgrade)
@@ -307,7 +307,7 @@ function fixTargetText(changed, item, itemType)
 		self.upgradeTargetLevel=nil
 	else
 		item=root.itemConfig(item)
-		local itemLevel=math.floor(item.parameters.level or item.config.level or 1)
+		local itemLevel=math.floor(tonumber(item.parameters.level or item.config.level or 1))
 		if self.isUpgradeKit or not self.isCrucible then
 			num=math.max(itemLevel+1,num)
 		else
@@ -449,7 +449,7 @@ function upgradeWeapon(upgradeItem,target)
 				local maxLvl=maxLvl(itemConfig, "weapon")
 				local defaultLvl=(itemConfig.config.level or 1)
 				--mergeBuffer.level = math.min((itemConfig.parameters.level or itemConfig.config.level or 1)+1,maxLvl)
-				mergeBuffer.level = math.min((itemConfig.parameters.level or itemConfig.config.level or 1),maxLvl)
+				mergeBuffer.level = math.min(tonumber(itemConfig.parameters.level or itemConfig.config.level or 1),maxLvl)
 				if target then
 					mergeBuffer.level=math.min(math.max(mergeBuffer.level,target),maxLvl)
 				end
@@ -534,7 +534,7 @@ function upgradeTool(upgradeItem, target)
 				--set level
 				local maxLvl=maxLvl(itemConfig, "tool")
 				--mergeBuffer.level = math.min((itemConfig.parameters.level or itemConfig.config.level or 1)+1,maxLvl)
-				mergeBuffer.level = math.min((itemConfig.parameters.level or itemConfig.config.level or 1),maxLvl)
+				mergeBuffer.level = math.min(tonumber(itemConfig.parameters.level or itemConfig.config.level or 1),maxLvl)
 				if target then
 					mergeBuffer.level=math.min(math.max(mergeBuffer.level,target),maxLvl)
 				end

--- a/monsters/walkers/adultpoptopish/adultshadowtop/adultshadowtop.monstertype
+++ b/monsters/walkers/adultpoptopish/adultshadowtop/adultshadowtop.monstertype
@@ -1,296 +1,297 @@
 {
-  "type" : "adultshadowtop",
-  "shortdescription" : "Adult Shadowtop",
-  "description" : "It's huge...",
+	"type" : "adultshadowtop",
+	"shortdescription" : "Adult Shadowtop",
+	"description" : "It's huge...",
 
-  "categories" : [ "adultshadowtop" ],
-  "parts" : [ "body", "bodyfullbright" ],
+	"categories" : [ "adultshadowtop" ],
+	"parts" : [ "body", "bodyfullbright" ],
 
-  "animation" : "adultshadowtop.animation",
+	"animation" : "adultshadowtop.animation",
 
-  "dropPools" : [
-    {
-    "default" : "adultpoptopTreasure",
-    "bow" : "ashgolemLoot",
-    "firebow" : "ashgolemLoot",
-    "icebow" : "ashgolemLoot",
-    "poisonbow" : "ashgolemLoot",
-    "electricbow" : "ashgolemLoot",
-    "cosmicbow" : "ashgolemLoot",
-    "radioactivebow" : "ashgolemLoot",
-    "shadowbow" : "ashgolemLoot"
-    }
-  ],
+	"dropPools" : [
+		{
+		"default" : "adultpoptopTreasure",
+		"bow" : "ashgolemLoot",
+		"firebow" : "ashgolemLoot",
+		"icebow" : "ashgolemLoot",
+		"poisonbow" : "ashgolemLoot",
+		"electricbow" : "ashgolemLoot",
+		"cosmicbow" : "ashgolemLoot",
+		"radioactivebow" : "ashgolemLoot",
+		"shadowbow" : "ashgolemLoot"
+		}
+	],
 
-  "baseParameters" : {
-    "scripts" : [
-      "/monsters/monster.lua",
-      "/stats/monstereffects/monsterstatus_camouflage_unified.lua"
-    ],
+	"baseParameters" : {
+		"scripts" : [
+			"/monsters/monster.lua",
+			"/stats/monstereffects/monsterstatus_camouflage_unified.lua"
+		],
+		"camoEffectToApply":"camouflage55",
 
-    "renderLayer" : "Monster+10",
+		"renderLayer" : "Monster+10",
 
-    "behavior" : "monster",
+		"behavior" : "monster",
 
-    "behaviorConfig" : {
-      "damageOnTouch" : true,
+		"behaviorConfig" : {
+			"damageOnTouch" : true,
 
-      "targetQueryRange" : 50,
-      "targetOnDamage" : true,
-      "keepTargetInSight" : true,
-      "keepTargetInRange" : 100,
-      "targetOutOfSightTime" : 20.5,
-      "hurtWaitForGround": false,
+			"targetQueryRange" : 50,
+			"targetOnDamage" : true,
+			"keepTargetInSight" : true,
+			"keepTargetInRange" : 100,
+			"targetOutOfSightTime" : 20.5,
+			"hurtWaitForGround": false,
 
-      "foundTargetActions" : [
-        {
-          "name" : "action-animate",
-          "cooldown" : 15,
-          "parameters" : {
-            "stateType" : "body",
-            "state" : "roar",
-            "animationTime" : 0.53
-          }
-        }
-      ],
+			"foundTargetActions" : [
+				{
+					"name" : "action-animate",
+					"cooldown" : 15,
+					"parameters" : {
+						"stateType" : "body",
+						"state" : "roar",
+						"animationTime" : 0.53
+					}
+				}
+			],
 
-      "fleeActions" : [],
+			"fleeActions" : [],
 
-      "hostileActions" : [
-        {
-          "name" : "action-animate",
-          "cooldown" : 15,
-          "parameters" : {
-            "stateType" : "body",
-            "state" : "roar",
-            "animationTime" : 0.53
-          }
-        },
-        {
-          "name" : "action-fire",
-          "cooldown" : 6,
-          "parameters" : {
-            "maximumRange" : 30,
-            "minimumRange" : 12,
-            "windupState" : "blink",
-            "windupTime" : 0.5,
+			"hostileActions" : [
+				{
+					"name" : "action-animate",
+					"cooldown" : 15,
+					"parameters" : {
+						"stateType" : "body",
+						"state" : "roar",
+						"animationTime" : 0.53
+					}
+				},
+				{
+					"name" : "action-fire",
+					"cooldown" : 6,
+					"parameters" : {
+						"maximumRange" : 30,
+						"minimumRange" : 12,
+						"windupState" : "blink",
+						"windupTime" : 0.5,
 
-            "projectileType" : "futarball",
-            "fireOffset" : [0.875, 0.625],
+						"projectileType" : "futarball",
+						"fireOffset" : [0.875, 0.625],
 
-            "aimAtTarget" : true,
-            "projectileCount" : 4,
-            "projectileInterval" : 0.08,
-            "inaccuracy" : 0.3,
-            "aimDirection" : [0,1],
-            "power" : 8,
-            "fireDelay" : 0.2,
-            "fireArc" : true,
-            "gravityMultiplier" : 0.25,
-            "fireSound" : "fire",
-            "fireState" : "fire",
+						"aimAtTarget" : true,
+						"projectileCount" : 4,
+						"projectileInterval" : 0.08,
+						"inaccuracy" : 0.3,
+						"aimDirection" : [0,1],
+						"power" : 8,
+						"fireDelay" : 0.2,
+						"fireArc" : true,
+						"gravityMultiplier" : 0.25,
+						"fireSound" : "fire",
+						"fireState" : "fire",
 
 
-            "winddownState" : ""
-          }
-        },
-        {
-          "name" : "action-charge",
-          "cooldown" : 7.0,
-          "parameters" : {
-            "maximumRange" : 20,
-            "windupState" : "chargewindup",
-            "windupTime" : 0.3,
+						"winddownState" : ""
+					}
+				},
+				{
+					"name" : "action-charge",
+					"cooldown" : 7.0,
+					"parameters" : {
+						"maximumRange" : 20,
+						"windupState" : "chargewindup",
+						"windupTime" : 0.3,
 
-            "chargeTime" : 0.2,
-            "chargeSpeed" : 60,
-            "chargeControlForce" : 1000,
-            "chargeState" : "charge",
-            "wallCrashSound" : "",
-            "wallCrashEmitter" : "",
+						"chargeTime" : 0.2,
+						"chargeSpeed" : 60,
+						"chargeControlForce" : 1000,
+						"chargeState" : "charge",
+						"wallCrashSound" : "",
+						"wallCrashEmitter" : "",
 
-            "winddownTime" : 0.05,
-            "winddownStopForce" : 1000,
-            "winddownState" : "chargewinddown"
-          }
-        }
-      ],
+						"winddownTime" : 0.05,
+						"winddownStopForce" : 1000,
+						"winddownState" : "chargewinddown"
+					}
+				}
+			],
 
-      "periodicActions" : [],
+			"periodicActions" : [],
 
-      "approachActions" : [
-        {
-          "name" : "approach-walk",
-          "parameters" : {
-            "canJump" : true,
-            "maxJumps" : 5,
-            "jumpXVelocity" : 12,
-            "jumpYVelocity" : 30,
-            "jumpXControlForce" : 50,
-            "minXRange" : 10
-          }
-        }
-      ],
+			"approachActions" : [
+				{
+					"name" : "approach-walk",
+					"parameters" : {
+						"canJump" : true,
+						"maxJumps" : 5,
+						"jumpXVelocity" : 12,
+						"jumpYVelocity" : 30,
+						"jumpXControlForce" : 50,
+						"minXRange" : 10
+					}
+				}
+			],
 
-      "followActions" : [
-        {
-          "name" : "approach-teleport",
-          "parameters" : {
-          }
-        },
-        {
-          "name" : "approach-walk",
-          "parameters" : {
-            "canJump" : true,
-            "maxJumps" : 5,
-            "jumpXVelocity" : 12,
-            "jumpYVelocity" : 30,
-            "jumpXControlForce" : 50,
-            "minXRange" : 10
-          }
-        }
-      ],
-      "damageTakenActions" : [
-        {
-          "name" : "action-charge",
-          "cooldown" : 1.0,
-          "parameters" : {
-            "maximumRange" : 15,
-            "windupState" : "chargewindup",
-            "windupTime" : 0.3,
+			"followActions" : [
+				{
+					"name" : "approach-teleport",
+					"parameters" : {
+					}
+				},
+				{
+					"name" : "approach-walk",
+					"parameters" : {
+						"canJump" : true,
+						"maxJumps" : 5,
+						"jumpXVelocity" : 12,
+						"jumpYVelocity" : 30,
+						"jumpXControlForce" : 50,
+						"minXRange" : 10
+					}
+				}
+			],
+			"damageTakenActions" : [
+				{
+					"name" : "action-charge",
+					"cooldown" : 1.0,
+					"parameters" : {
+						"maximumRange" : 15,
+						"windupState" : "chargewindup",
+						"windupTime" : 0.3,
 
-            "chargeTime" : 0.4,
-            "chargeSpeed" : 50,
-            "chargeControlForce" : 1000,
-            "chargeState" : "charge",
-            "wallCrashSound" : "",
-            "wallCrashEmitter" : "",
+						"chargeTime" : 0.4,
+						"chargeSpeed" : 50,
+						"chargeControlForce" : 1000,
+						"chargeState" : "charge",
+						"wallCrashSound" : "",
+						"wallCrashEmitter" : "",
 
-            "winddownTime" : 0.05,
-            "winddownStopForce" : 1200,
-            "winddownState" : "chargewinddown"
-          }
-        }
-      ],
-      "wanderActions" : [
-        {
-          "name" : "wander-walk",
-          "cooldown" : 6.0,
-          "parameters" : {
-            "wanderTime" : [5, 15]
-          }
-        }
-      ]
-    },
+						"winddownTime" : 0.05,
+						"winddownStopForce" : 1200,
+						"winddownState" : "chargewinddown"
+					}
+				}
+			],
+			"wanderActions" : [
+				{
+					"name" : "wander-walk",
+					"cooldown" : 6.0,
+					"parameters" : {
+						"wanderTime" : [5, 15]
+					}
+				}
+			]
+		},
 
-    "damageParts" : {
-      "body" : {
-        "damage" : 13,
+		"damageParts" : {
+			"body" : {
+				"damage" : 13,
 
-        "teamType" : "enemy",
-        "damageSourceKind" : "slash",
-        "knockback" : 20,
-        "statusEffects" : [ ]
-      }
-    },
+				"teamType" : "enemy",
+				"damageSourceKind" : "slash",
+				"knockback" : 20,
+				"statusEffects" : [ ]
+			}
+		},
 
-    "touchDamage" : {
-      "poly" : [ [1.75, 2.55], [2.25, 2.05],  [2.75, -3.55], [2.25, -3.95],  [-2.25, -3.95], [-2.75, -3.55],  [-2.25, 2.05], [-1.75, 2.55] ],
-      "damage" : 13,
+		"touchDamage" : {
+			"poly" : [ [1.75, 2.55], [2.25, 2.05],	[2.75, -3.55], [2.25, -3.95],	[-2.25, -3.95], [-2.75, -3.55],	[-2.25, 2.05], [-1.75, 2.55] ],
+			"damage" : 13,
 
-      "teamType" : "enemy",
-      "damageSourceKind" : "slash",
-      "knockback" : 20,
-      "statusEffects" : [ ]
-    },
+			"teamType" : "enemy",
+			"damageSourceKind" : "slash",
+			"knockback" : 20,
+			"statusEffects" : [ ]
+		},
 
-    "metaBoundBox" : [-4, -4, 4, 4],
-    "scale" : 1.0,
+		"metaBoundBox" : [-4, -4, 4, 4],
+		"scale" : 1.0,
 
-    "movementSettings" : {
-      "collisionPoly" : [ [1.75, 2.55], [2.25, 2.05],  [2.75, -3.55], [2.25, -3.95],  [-2.25, -3.95], [-2.75, -3.55],  [-2.25, 2.05], [-1.75, 2.55] ],
+		"movementSettings" : {
+			"collisionPoly" : [ [1.75, 2.55], [2.25, 2.05],	[2.75, -3.55], [2.25, -3.95],	[-2.25, -3.95], [-2.75, -3.55],	[-2.25, 2.05], [-1.75, 2.55] ],
 
-      "mass" : 2.5,
-      "walkSpeed" : 8,
-      "runSpeed" : 9,
+			"mass" : 2.5,
+			"walkSpeed" : 8,
+			"runSpeed" : 9,
 
-      "airFriction" : 0,
+			"airFriction" : 0,
 
-      "airJumpProfile" : {
-        "jumpSpeed" : 35.0,
-        "jumpInitialPercentage" : 1.0,
-        "jumpHoldTime" : 0.0
-      }
-    },
+			"airJumpProfile" : {
+				"jumpSpeed" : 35.0,
+				"jumpInitialPercentage" : 1.0,
+				"jumpHoldTime" : 0.0
+			}
+		},
 
-    "bodyMaterialKind" : "organic",
+		"bodyMaterialKind" : "organic",
 
-    "knockoutTime" : 0.3,
-    "knockoutAnimationStates" : {
-      "damage" : "stunned"
-    },
-    "deathParticles" : "deathPoof",
-    "knockoutEffect" : "",
+		"knockoutTime" : 0.3,
+		"knockoutAnimationStates" : {
+			"damage" : "stunned"
+		},
+		"deathParticles" : "deathPoof",
+		"knockoutEffect" : "",
 
-    "statusSettings" : {
-      "statusProperties" : {
-        "targetMaterialKind" : "organic"
-      },
+		"statusSettings" : {
+			"statusProperties" : {
+				"targetMaterialKind" : "organic"
+			},
 
-      "appliesEnvironmentStatusEffects" : false,
-      "appliesWeatherStatusEffects" : true,
-      "minimumLiquidStatusEffectPercentage" : 0.1,
+			"appliesEnvironmentStatusEffects" : false,
+			"appliesWeatherStatusEffects" : true,
+			"minimumLiquidStatusEffectPercentage" : 0.1,
 
-      "primaryScriptSources" : [
-        "/stats/monster_primary.lua"
-      ],
-      "primaryScriptDelta" : 5,
+			"primaryScriptSources" : [
+				"/stats/monster_primary.lua"
+			],
+			"primaryScriptDelta" : 5,
 
-      "stats" : {
-        "knockbackStunTime" : {
-          "baseValue" : 0.25
-        },
-        "knockbackThreshold" : {
-          "baseValue" : 9
-        },
-        "maxHealth" : {
-          "baseValue" : 180
-        },
-        "protection" : {
-          "baseValue" : 0.0
-        },
-        "healthRegen" : {
-          "baseValue" : 0.0
-        },
-        "powerMultiplier" : {
-          "baseValue" : 1.0
-        },
-        "poisonResistance" : { "baseValue" : 0 },
-        "fireResistance" : { "baseValue" : 0 },
-        "iceResistance" : { "baseValue" : 0 },
-        "electricResistance" : { "baseValue" : 0 },
-        "physicalResistance" : { "baseValue" : 0 },
-        "shadowResistance" : { "baseValue" : 0.5 }
-      },
+			"stats" : {
+				"knockbackStunTime" : {
+					"baseValue" : 0.25
+				},
+				"knockbackThreshold" : {
+					"baseValue" : 9
+				},
+				"maxHealth" : {
+					"baseValue" : 180
+				},
+				"protection" : {
+					"baseValue" : 0.0
+				},
+				"healthRegen" : {
+					"baseValue" : 0.0
+				},
+				"powerMultiplier" : {
+					"baseValue" : 1.0
+				},
+				"poisonResistance" : { "baseValue" : 0 },
+				"fireResistance" : { "baseValue" : 0 },
+				"iceResistance" : { "baseValue" : 0 },
+				"electricResistance" : { "baseValue" : 0 },
+				"physicalResistance" : { "baseValue" : 0 },
+				"shadowResistance" : { "baseValue" : 0.5 }
+			},
 
-      "resources" : {
-        "stunned" : {
-          "deltaValue" : -1.0,
-          "initialValue" : 0.0
-        },
-        "health" : {
-          "maxStat" : "maxHealth",
-          "deltaStat" : "healthRegen",
-          "defaultPercentage" : 100
-        }
-      }
-    },
+			"resources" : {
+				"stunned" : {
+					"deltaValue" : -1.0,
+					"initialValue" : 0.0
+				},
+				"health" : {
+					"maxStat" : "maxHealth",
+					"deltaStat" : "healthRegen",
+					"defaultPercentage" : 100
+				}
+			}
+		},
 
-    "mouthOffset" : [0, 0],
-    "feetOffset" : [0, -8],
-    "capturable" : true,
-    "captureHealthFraction" : 0.5,
-    "nametagColor" : [64, 200, 255]//,
-    //"captureCollectables" : { "fu_monster" : "adultshadowtop" }
-  }
+		"mouthOffset" : [0, 0],
+		"feetOffset" : [0, -8],
+		"capturable" : true,
+		"captureHealthFraction" : 0.5,
+		"nametagColor" : [64, 200, 255]//,
+		//"captureCollectables" : { "fu_monster" : "adultshadowtop" }
+	}
 }

--- a/monsters/walkers/poptopish/shadowtop/shadowtop.monstertype
+++ b/monsters/walkers/poptopish/shadowtop/shadowtop.monstertype
@@ -28,10 +28,10 @@
 			"/stats/monstereffects/monsterstatus_camouflage_unified.lua",
 			"/scripts/golemancer/gol_monstermain.lua"
 		],
-	"camoEffectToApply":"camouflage55",
-	"tickEvoTime" : 5,
-	"agingEvoTime" : 500,
-	"evolutions" : [ "/scripts/golemancer/evolutions/adultshadowtop.evo" ],
+		"camoEffectToApply":"camouflage55",
+		"tickEvoTime" : 5,
+		"agingEvoTime" : 500,
+		"evolutions" : [ "/scripts/golemancer/evolutions/adultshadowtop.evo" ],
 
 		"behavior" : "monster",
 

--- a/scripts/kheAA/liquidLib.lua
+++ b/scripts/kheAA/liquidLib.lua
@@ -2,6 +2,14 @@ liquidLib = {}
 
 function liquidLib.init()
 	storage.liquids = storage.liquids or {}
+	local buffer={}
+	for id,amount in pairs(storage.liquids) do
+		local id2=tonumber(id)
+		if not buffer[id2] then buffer[id2] = 0 end
+		buffer[id2]=buffer[id2]+amount
+	end
+	storage.liquids=buffer
+
 	self.liquidOuts = self.liquidOuts or {}
 	liquidLib.vars={}
 	liquidLib.vars.inLiquidNode=config.getParameter("kheAA_inLiquidNode")--doesn't actually do anything, doesn't matter at this point.

--- a/stats/effects/fu_armoreffects/set_bonuses/tier1/trollkingsetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier1/trollkingsetbonuseffect.lua
@@ -56,7 +56,7 @@ function checkWeapons()
 
 	if weaponSword["both"] then
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle2,weaponBonus2)
-		status.addEphemeralEffect("ghostburst",1)
+		status.addEphemeralEffect("ghostburst_armorset",1)
 	else
 		effect.setStatModifierGroup(effectHandlerList.weaponBonusHandle2,{})
 	end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier4/infernosetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier4/infernosetbonuseffect.lua
@@ -21,11 +21,11 @@ end
 
 function update(dt)
 	if not checkSetWorn(self.setBonusCheck) then
-		status.removeEphemeralEffect("fireburst")
+		status.removeEphemeralEffect("fireburst_armorsetbonus")
 		effect.expire()
 	else
 
-		status.addEphemeralEffect("fireburst")
+		status.addEphemeralEffect("fireburst_armorsetbonus")
 		checkWeapons()
 	end
 end

--- a/stats/effects/fu_armoreffects/set_bonuses/tier5/hellfiresetbonuseffect.lua
+++ b/stats/effects/fu_armoreffects/set_bonuses/tier5/hellfiresetbonuseffect.lua
@@ -22,14 +22,14 @@ end
 
 function update(dt)
 	if not checkSetWorn(self.setBonusCheck) then
-		status.removeEphemeralEffect("fireburst")
+		status.removeEphemeralEffect("fireburst_armorsetbonus")
 		status.removeEphemeralEffect("gloworange")
 		effect.expire()
 	else
 
 		checkWeapons()
 		status.addEphemeralEffect("gloworange")
-		status.addEphemeralEffect("fireburst")
+		status.addEphemeralEffect("fireburst_armorsetbonus")
 	end
 end
 

--- a/stats/effects/thorns/fireburst_armorsetbonus.statuseffect
+++ b/stats/effects/thorns/fireburst_armorsetbonus.statuseffect
@@ -1,0 +1,26 @@
+{
+  "name" : "fireburst_armorsetbonus",
+  "effectConfig" : {
+    "minRange" : 0.5,
+    "visualProjectileCount" : 8,
+    "visualProjectileType" : "armornova",
+    "visualProjectileSpeed" : 6.66,
+    "visualProjectileTime" : 0.75,
+    "visualDuration" : 0,
+    "border" : "1;FF550099;00000000",
+    "damageMultiplier" : 1.0,
+    "damageProjectileType" : "novadamage",
+    "cooldown" : 1,
+    "minTriggerDamage" : 1,
+    "removeInWater" : false
+  },
+
+  "defaultDuration" : 60,
+
+  "scripts" : [
+    "thorns.lua"
+  ],
+
+  "label" : "Flame",
+  "icon" : "/interface/statuses/nova.png"
+}

--- a/stats/effects/thorns/ghostburst_armorset.statuseffect
+++ b/stats/effects/thorns/ghostburst_armorset.statuseffect
@@ -1,0 +1,28 @@
+{
+	"name": "ghostburst_armorset",
+	"effectConfig": {
+		"minRange": 0.5,
+		"visualProjectileCount": 8,
+		"visualProjectileType": "gasburst",
+		"visualProjectileSpeed": 8,
+		"visualProjectileTime": 0.55,
+		"visualDuration": 0,
+		//"border" : "1;0055FF99;00000000",
+		"damageMultiplier": 0.15,
+		"damageProjectileType": "gasburst",
+		"cooldown": 1,
+		"minTriggerDamage": 1,
+		"removeInWater": false
+	},
+
+	"defaultDuration": 60,
+
+	"scripts": [
+		"ghostthorns.lua"
+	],
+
+	"animationConfig": "ghostlymiasma.animation",
+
+	"label": "Ghostly Miasma",
+	"icon": "/interface/statuses/thorns.png"
+}


### PR DESCRIPTION
liquid lib serialization fix - stops compressed liquids being lost.
fixed adult shadowtop missing camo effect due to missed changes
forced typecasting in upgrade UI on level parameter, to adjust for stupid people putting level as a string.
hellfire, inferno, and troll king sets use 'thorns' like status effects specific to them, now, which are not removed in water and have a minimum damage taken to trigger of 1.