### PR TITLE
Fire rate throttle fix for rng full auto weapons

### DIFF
--- a/items/active/weapons/melee/abilities/katana/katanacombo.weaponability
+++ b/items/active/weapons/melee/abilities/katana/katanacombo.weaponability
@@ -131,7 +131,7 @@
           "allowFlip":false
         },
         "wait1":{
-          "duration":0.08,
+          "duration":0.1,
           "armRotation":-85,
           "weaponRotation":-5,
           "allowRotate":false,
@@ -170,7 +170,7 @@
           "allowFlip":false
           },
         "wait2":{
-          "duration":0.08,
+          "duration":0.1,
           "armRotation":-85,
           "weaponRotation":-5,
           "allowRotate":false,
@@ -229,7 +229,7 @@
           "allowFlip":true
         },
         "wait4":{
-          "duration":0.075,
+          "duration":0.1,
           "armRotation":-20,
           "weaponRotation":140,
           "twoHanded":false,
@@ -389,7 +389,7 @@
 		"twoHanded": false
           },
         "wait9":{
-          "duration":0.05,
+          "duration":0.1,
           "armRotation":-85,
           "weaponRotation":-5,
           "allowRotate":false,
@@ -427,7 +427,7 @@
              "allowFlip":true
            },
            "wait10":{
-             "duration":0.05,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,
@@ -457,7 +457,7 @@
              "allowFlip":true
            },
            "wait11":{
-             "duration":0.08,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,
@@ -486,7 +486,7 @@
              "allowFlip":true
            },
            "wait12":{
-             "duration":0.08,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,
@@ -516,7 +516,7 @@
              "allowFlip":true
            },
            "wait13":{
-             "duration":0.08,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,
@@ -545,7 +545,7 @@
              "allowFlip":true
            },
            "wait14":{
-             "duration":0.08,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,

--- a/items/active/weapons/melee/abilities/katana/katanacombo2h.weaponability
+++ b/items/active/weapons/melee/abilities/katana/katanacombo2h.weaponability
@@ -131,7 +131,7 @@
           "allowFlip":false
         },
         "wait1":{
-          "duration":0.08,
+          "duration":0.1,
           "armRotation":-85,
           "weaponRotation":-5,
           "allowRotate":false,
@@ -170,7 +170,7 @@
           "allowFlip":false
           },
         "wait2":{
-          "duration":0.08,
+          "duration":0.1,
           "armRotation":-85,
           "weaponRotation":-5,
           "allowRotate":false,
@@ -229,7 +229,7 @@
           "allowFlip":true
         },
         "wait4":{
-          "duration":0.075,
+          "duration":0.1,
           "armRotation":-20,
           "weaponRotation":140,
           "twoHanded":true,
@@ -392,7 +392,7 @@
 		"twoHanded": true
           },
         "wait9":{
-          "duration":0.05,
+          "duration":0.1,
           "armRotation":-85,
           "weaponRotation":-5,
           "allowRotate":false,
@@ -430,7 +430,7 @@
              "allowFlip":true
            },
            "wait10":{
-             "duration":0.05,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,
@@ -460,7 +460,7 @@
              "allowFlip":true
            },
            "wait11":{
-             "duration":0.08,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,
@@ -489,7 +489,7 @@
              "allowFlip":true
            },
            "wait12":{
-             "duration":0.08,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,
@@ -519,7 +519,7 @@
              "allowFlip":true
            },
            "wait13":{
-             "duration":0.08,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,
@@ -548,7 +548,7 @@
              "allowFlip":true
            },
            "wait14":{
-             "duration":0.08,
+             "duration":0.1,
              "armRotation":-85,
              "weaponRotation":-5,
              "allowRotate":false,

--- a/items/active/weapons/melee/longsword/densiniumlongsword.activeitem
+++ b/items/active/weapons/melee/longsword/densiniumlongsword.activeitem
@@ -36,7 +36,7 @@
     "baseDps" : 6.8,
     "damageConfig" : {
       "damageSourceKind": "electricshortsword",
-      "statusEffect": [ "electrified" ]
+      "statusEffects": [ "electrified" ]
     }
   },
 

--- a/items/active/weapons/ranged/assaultrifle/commonassaultrifle.activeitem.patch
+++ b/items/active/weapons/ranged/assaultrifle/commonassaultrifle.activeitem.patch
@@ -61,6 +61,46 @@
   },
   {
     "op": "add",
+    "path": "/primaryAbility/stances/idle/weaponOffset",
+    "value": [0, 0]
+  },
+  {
+    "op": "add",
+    "path": "/primaryAbility/stances/fire/weaponOffset",
+    "value": [-0.1, 0]
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/fire/allowRotate",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/fire/allowFlip",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/duration",
+    "value": 0.04
+  },
+  {
+    "op": "add",
+    "path": "/primaryAbility/stances/cooldown/weaponOffset",
+    "value": [-0.1, 0]
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/allowRotate",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/allowFlip",
+    "value": true
+  },
+  {
+    "op": "add",
     "path": "/fireSounds/0",
     "value": "/sfx/gun/mp1.ogg"
   },

--- a/items/active/weapons/ranged/assaultrifle/rareassaultrifle.activeitem.patch
+++ b/items/active/weapons/ranged/assaultrifle/rareassaultrifle.activeitem.patch
@@ -61,6 +61,46 @@
   },
   {
     "op": "add",
+    "path": "/primaryAbility/stances/idle/weaponOffset",
+    "value": [0, 0]
+  },
+  {
+    "op": "add",
+    "path": "/primaryAbility/stances/fire/weaponOffset",
+    "value": [-0.1, 0]
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/fire/allowRotate",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/fire/allowFlip",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/duration",
+    "value": 0.04
+  },
+  {
+    "op": "add",
+    "path": "/primaryAbility/stances/cooldown/weaponOffset",
+    "value": [-0.1, 0]
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/allowRotate",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/allowFlip",
+    "value": true
+  },
+  {
+    "op": "add",
     "path": "/builderConfig/0/elementalType/-",
     "value": "radioactive"
   },

--- a/items/active/weapons/ranged/assaultrifle/swtjc_ewg_commonbattlerifle.activeitem
+++ b/items/active/weapons/ranged/assaultrifle/swtjc_ewg_commonbattlerifle.activeitem
@@ -50,27 +50,30 @@
         "armRotation" : 0,
         "weaponRotation" : 0,
         "twoHanded" : true,
+        "weaponOffset" : [0, 0],
 
         "allowRotate" : true,
         "allowFlip" : true
       },
       "fire" : {
         "duration" : 0,
-        "armRotation" : 4,
-        "weaponRotation" : 4,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       },
       "cooldown" : {
-        "duration" : 0.16,
-        "armRotation" : 4,
-        "weaponRotation" : 4,
+        "duration" : 0.1,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       }
     }
   },

--- a/items/active/weapons/ranged/assaultrifle/swtjc_ewg_commonsaw.activeitem
+++ b/items/active/weapons/ranged/assaultrifle/swtjc_ewg_commonsaw.activeitem
@@ -52,27 +52,30 @@
         "armRotation" : 0,
         "weaponRotation" : 0,
         "twoHanded" : true,
+        "weaponOffset" : [0, 0],
 
         "allowRotate" : true,
         "allowFlip" : true
       },
       "fire" : {
         "duration" : 0,
-        "armRotation" : 5,
-        "weaponRotation" : 5,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       },
       "cooldown" : {
-        "duration" : 0.1,
-        "armRotation" : 2,
-        "weaponRotation" : 2,
+        "duration" : 0.04,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       }
     }
   },

--- a/items/active/weapons/ranged/assaultrifle/swtjc_ewg_rarebattlerifle.activeitem
+++ b/items/active/weapons/ranged/assaultrifle/swtjc_ewg_rarebattlerifle.activeitem
@@ -47,27 +47,30 @@
         "armRotation" : 0,
         "weaponRotation" : 0,
         "twoHanded" : true,
+        "weaponOffset" : [0, 0],
 
         "allowRotate" : true,
         "allowFlip" : true
       },
       "fire" : {
         "duration" : 0,
-        "armRotation" : 4,
-        "weaponRotation" : 4,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       },
       "cooldown" : {
-        "duration" : 0.16,
-        "armRotation" : 4,
-        "weaponRotation" : 4,
+        "duration" : 0.1,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       }
     }
   },

--- a/items/active/weapons/ranged/assaultrifle/swtjc_ewg_raresaw.activeitem
+++ b/items/active/weapons/ranged/assaultrifle/swtjc_ewg_raresaw.activeitem
@@ -49,27 +49,30 @@
         "armRotation" : 0,
         "weaponRotation" : 0,
         "twoHanded" : true,
+        "weaponOffset" : [0, 0],
 
         "allowRotate" : true,
         "allowFlip" : true
       },
       "fire" : {
         "duration" : 0,
-        "armRotation" : 5,
-        "weaponRotation" : 5,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       },
       "cooldown" : {
-        "duration" : 0.1,
-        "armRotation" : 2,
-        "weaponRotation" : 2,
+        "duration" : 0.04,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       }
     }
   },

--- a/items/active/weapons/ranged/assaultrifle/swtjc_ewg_uncommonbattlerifle.activeitem
+++ b/items/active/weapons/ranged/assaultrifle/swtjc_ewg_uncommonbattlerifle.activeitem
@@ -47,27 +47,30 @@
         "armRotation" : 0,
         "weaponRotation" : 0,
         "twoHanded" : true,
+        "weaponOffset" : [0, 0],
 
         "allowRotate" : true,
         "allowFlip" : true
       },
       "fire" : {
         "duration" : 0,
-        "armRotation" : 4,
-        "weaponRotation" : 4,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       },
       "cooldown" : {
-        "duration" : 0.16,
-        "armRotation" : 4,
-        "weaponRotation" : 4,
+        "duration" : 0.1,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       }
     }
   },

--- a/items/active/weapons/ranged/assaultrifle/swtjc_ewg_uncommonsaw.activeitem
+++ b/items/active/weapons/ranged/assaultrifle/swtjc_ewg_uncommonsaw.activeitem
@@ -49,27 +49,30 @@
         "armRotation" : 0,
         "weaponRotation" : 0,
         "twoHanded" : true,
+        "weaponOffset" : [0, 0],
 
         "allowRotate" : true,
         "allowFlip" : true
       },
       "fire" : {
         "duration" : 0,
-        "armRotation" : 5,
-        "weaponRotation" : 5,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       },
       "cooldown" : {
-        "duration" : 0.1,
-        "armRotation" : 2,
-        "weaponRotation" : 2,
+        "duration" : 0.04,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : true,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
-        "allowFlip" : false
+        "allowRotate" : true,
+        "allowFlip" : true
       }
     }
   },

--- a/items/active/weapons/ranged/assaultrifle/uncommonassaultrifle.activeitem.patch
+++ b/items/active/weapons/ranged/assaultrifle/uncommonassaultrifle.activeitem.patch
@@ -61,6 +61,46 @@
   },
   {
     "op": "add",
+    "path": "/primaryAbility/stances/idle/weaponOffset",
+    "value": [0, 0]
+  },
+  {
+    "op": "add",
+    "path": "/primaryAbility/stances/fire/weaponOffset",
+    "value": [-0.1, 0]
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/fire/allowRotate",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/fire/allowFlip",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/duration",
+    "value": 0.04
+  },
+  {
+    "op": "add",
+    "path": "/primaryAbility/stances/cooldown/weaponOffset",
+    "value": [-0.1, 0]
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/allowRotate",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/allowFlip",
+    "value": true
+  },
+  {
+    "op": "add",
     "path": "/builderConfig/0/elementalType/-",
     "value": "radioactive"
   },

--- a/items/active/weapons/ranged/machinepistol/commonmachinepistol.activeitem.patch
+++ b/items/active/weapons/ranged/machinepistol/commonmachinepistol.activeitem.patch
@@ -62,6 +62,21 @@
     "value": 0.12
   },
   {
+    "op": "replace",
+    "path": "/primaryAbility/stances/fire/allowRotate",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/duration",
+    "value": 0.02
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/allowRotate",
+    "value": true
+  },
+  {
     "op": "add",
     "path": "/fireSounds/-",
     "value": "/sfx/gun/uzi1.ogg"

--- a/items/active/weapons/ranged/machinepistol/raremachinepistol.activeitem.patch
+++ b/items/active/weapons/ranged/machinepistol/raremachinepistol.activeitem.patch
@@ -57,6 +57,21 @@
     "value": 0.04
   },
   {
+    "op": "replace",
+    "path": "/primaryAbility/stances/fire/allowRotate",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/duration",
+    "value": 0.02
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/allowRotate",
+    "value": true
+  },
+  {
     "op": "add",
     "path": "/builderConfig/0/elementalType/-",
     "value": "radioactive"

--- a/items/active/weapons/ranged/machinepistol/swtjc_ewg_commonsubmachinegun.activeitem
+++ b/items/active/weapons/ranged/machinepistol/swtjc_ewg_commonsubmachinegun.activeitem
@@ -24,9 +24,9 @@
     "class" : "GunFire",
 
     "fireTime" : [0.09, 0.15],
-    "baseDps" : [5.5, 7],
+    "baseDps" : [6.4, 7.5],
     "energyUsage" : [24, 27],
-    "inaccuracy" : 0.02,
+    "inaccuracy" : 0.06,
 
     "burstTime" : 0.075,
     "burstCount" : [2,4],
@@ -42,26 +42,29 @@
         "armRotation" : 0,
         "weaponRotation" : 0,
         "twoHanded" : false,
+        "weaponOffset" : [0, 0],
 
         "allowRotate" : true,
         "allowFlip" : true
       },
       "fire" : {
         "duration" : 0,
-        "armRotation" : 5,
-        "weaponRotation" : 5,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : false,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
+        "allowRotate" : true,
         "allowFlip" : true
       },
       "cooldown" : {
-        "duration" : 0.11,
-        "armRotation" : 5,
-        "weaponRotation" : 5,
+        "duration" : 0.05,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : false,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
+        "allowRotate" : true,
         "allowFlip" : true
       }
     }

--- a/items/active/weapons/ranged/machinepistol/swtjc_ewg_raresubmachinegun.activeitem
+++ b/items/active/weapons/ranged/machinepistol/swtjc_ewg_raresubmachinegun.activeitem
@@ -24,9 +24,9 @@
     "class" : "GunFire",
 
     "fireTime" : [0.08, 0.15],
-    "baseDps" : [5.7, 7.5],
+    "baseDps" : [6.4, 8.0],
     "energyUsage" : [25.5, 28.5],
-    "inaccuracy" : 0.02,
+    "inaccuracy" : 0.06,
 
     "burstTime" : 0.075,
     "burstCount" : [2,4],
@@ -41,26 +41,29 @@
         "armRotation" : 0,
         "weaponRotation" : 0,
         "twoHanded" : false,
+        "weaponOffset" : [0, 0],
 
         "allowRotate" : true,
         "allowFlip" : true
       },
       "fire" : {
         "duration" : 0,
-        "armRotation" : 5,
-        "weaponRotation" : 5,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : false,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
+        "allowRotate" : true,
         "allowFlip" : true
       },
       "cooldown" : {
-        "duration" : 0.11,
-        "armRotation" : 5,
-        "weaponRotation" : 5,
+        "duration" : 0.04,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : false,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
+        "allowRotate" : true,
         "allowFlip" : true
       }
     }

--- a/items/active/weapons/ranged/machinepistol/swtjc_ewg_uncommonsubmachinegun.activeitem
+++ b/items/active/weapons/ranged/machinepistol/swtjc_ewg_uncommonsubmachinegun.activeitem
@@ -24,9 +24,9 @@
     "class" : "GunFire",
 
     "fireTime" : [0.08, 0.15],
-    "baseDps" : [5.5, 7.2],
+    "baseDps" : [6.4, 8.0],
     "energyUsage" : [25.5, 28.5],
-    "inaccuracy" : 0.02,
+    "inaccuracy" : 0.06,
 
     "burstTime" : 0.075,
     "burstCount" : [2,4],
@@ -41,26 +41,29 @@
         "armRotation" : 0,
         "weaponRotation" : 0,
         "twoHanded" : false,
+        "weaponOffset" : [0, 0],
 
         "allowRotate" : true,
         "allowFlip" : true
       },
       "fire" : {
         "duration" : 0,
-        "armRotation" : 5,
-        "weaponRotation" : 5,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : false,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
+        "allowRotate" : true,
         "allowFlip" : true
       },
       "cooldown" : {
-        "duration" : 0.11,
-        "armRotation" : 5,
-        "weaponRotation" : 5,
+        "duration" : 0.04,
+        "armRotation" : 3,
+        "weaponRotation" : 3,
         "twoHanded" : false,
+        "weaponOffset" : [-0.1, 0],
 
-        "allowRotate" : false,
+        "allowRotate" : true,
         "allowFlip" : true
       }
     }

--- a/items/active/weapons/ranged/machinepistol/uncommonmachinepistol.activeitem.patch
+++ b/items/active/weapons/ranged/machinepistol/uncommonmachinepistol.activeitem.patch
@@ -62,6 +62,21 @@
     "value": 0.12
   },
   {
+    "op": "replace",
+    "path": "/primaryAbility/stances/fire/allowRotate",
+    "value": true
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/duration",
+    "value": 0.02
+  },
+  {
+    "op": "replace",
+    "path": "/primaryAbility/stances/cooldown/allowRotate",
+    "value": true
+  },
+  {
     "op": "add",
     "path": "/builderConfig/0/elementalType/-",
     "value": "radioactive"

--- a/items/active/weapons/ranged/shotgun/swtjc_ewg_commonautoshotgun.activeitem
+++ b/items/active/weapons/ranged/shotgun/swtjc_ewg_commonautoshotgun.activeitem
@@ -64,7 +64,7 @@
         "allowFlip" : false
       },
       "cooldown" : {
-        "duration" : 0.20,
+        "duration" : 0.1,
         "armRotation" : 5,
         "weaponRotation" : 5,
         "twoHanded" : true,

--- a/items/active/weapons/ranged/shotgun/swtjc_ewg_rareautoshotgun.activeitem
+++ b/items/active/weapons/ranged/shotgun/swtjc_ewg_rareautoshotgun.activeitem
@@ -60,7 +60,7 @@
         "allowFlip" : false
       },
       "cooldown" : {
-        "duration" : 0.2,
+        "duration" : 0.1,
         "armRotation" : 5,
         "weaponRotation" : 5,
         "twoHanded" : true,

--- a/items/active/weapons/ranged/shotgun/swtjc_ewg_uncommonautoshotgun.activeitem
+++ b/items/active/weapons/ranged/shotgun/swtjc_ewg_uncommonautoshotgun.activeitem
@@ -60,7 +60,7 @@
         "allowFlip" : false
       },
       "cooldown" : {
-        "duration" : 0.2,
+        "duration" : 0.1,
         "armRotation" : 5,
         "weaponRotation" : 5,
         "twoHanded" : true,


### PR DESCRIPTION
The long cooldown duration throttled the fire rate of fast firing guns. A smg with a fire rate of 12 actually only shot 7-8 times per second, greatly reducing it's intended dps.

Set allowRotate and allowFlip when firing to true, as there is no reason why it was on false. All it does is making the animation look weird when aiming up and down and preventing proper aiming with burst fire variants.

Sub Machine Guns: reduced accuracy, as their description says they are unprecise, while they used to be more accurate than ARs.
Slightly increased their dps to compensate for lost accuracy and to make them slightly stronger than the smaller machine pistols.

Katana Combo: increased the wait period of some combo steps so full combos require less button mashing. Barely any visual difference.