### PR TITLE
Fix human bonus from Perfect Blocks, reword confusing/outdated text

### DIFF
--- a/codex/documents/networkguide.codex
+++ b/codex/documents/networkguide.codex
@@ -14,7 +14,7 @@
 
 	"Storage bridges work with more than just ordinary containers. Almost any object which can be interacted with that has item slots can be linked to a storage bridge. This includes some FrackinUniverse crafting stations and a few misc. objects that might already have power nodes (but no input/output nodes). If you find yourself uncertain about which nodes to use, remember that storage bridge nodes always function as ITN input/output nodes.",
 
-	"Point Sensor: Made in the nanofabricator. Detects object placement points, to allow for more precise placement of Storage Bridges. Bridges select a single container based on the distance between themselves and object placement points.",
+	"Object Data Sensor: Crafted in the tinkering table. Detects object placement points, to allow for more precise placement of Storage Bridges. Bridges select a single container based on the distance between themselves and object placement points.",
 
 	"Item Transference Devices (ITDs) are additional core components of the ITN system. While ITDs are capable of moving all items by default, you will need special token items to filter for currencies or items the ITD does not recognize. You can place them wherever you want as long as you can keep their wiring straight. Mastery of the ITD will bring mastery over the entire ITN system.",
 

--- a/objects/ship/fu_ftldrive/fu_ftldrivesmall.object
+++ b/objects/ship/fu_ftldrive/fu_ftldrivesmall.object
@@ -3,7 +3,7 @@
   "rarity" : "essential",
   "colonyTags" : [ "science" ],
   "category" : "furniture",
-  "description" : "An FTL drive for a space ship. Allows interstellar travel. ^orange;Ship Speed: +3, Ship Mass: +1^reset;. ^red;BYOS Only^reset;",
+  "description" : "An FTL drive for a space ship. Allows interstellar travel and STL travel. ^orange;Ship Speed: +3, Ship Mass: +1^reset;. ^red;BYOS Only^reset;",
   "shortdescription" : "^cyan;Small FTL Drive^reset;",
   "race" : "generic",
   "printable" : false,

--- a/quests/fu_questlines/tutorial/vinj/fuquest_powergeneration2.questtemplate
+++ b/quests/fu_questlines/tutorial/vinj/fuquest_powergeneration2.questtemplate
@@ -3,7 +3,7 @@
 	"prerequisites" : [ "fuquest_powergeneration1", "create_electronics" ],
 	"title" : "Sifters",
 	"text" : "A ^orange;Wooden Sifter^reset; requires power, but allows you to toss in ^orange;Sand^reset;, ^orange;Dirt^reset; and ^green;other loose materials^reset; and sift for hidden goodies. Very useful. Though the wood sifter is quite slow, one cannot complain about free resources. Try building a ^orange;Wooden Sifter^reset; now.",
-	"completionText" : "If you want to step up your game, try creating a ^orange;Item Transference Device^reset; and a ^orange;Storage Bridge^reset;, then link them to the ^green;Sifter^reset;! You'll be able to automatically transfer from a crafting station to a storage container!",
+	"completionText" : "If you want to step up your game, try creating a ^orange;Item Transference Device^reset; and a ^orange;Storage Bridge^reset;, then link them to the ^green;Sifter^reset;! It can automatically move the items from machines (such as a ^orange;Wooden Sifter^reset;) to a storage container, or vice versa!",
 	"rewards" : [ [ [ "fuscienceresource", 50 ] ] ],
 	"moneyRange" : [10, 10],
 

--- a/species/human.raceeffect
+++ b/species/human.raceeffect
@@ -32,7 +32,7 @@
 					{ "stat": "protection", "amount": 0 }
 				],
 				"statCombos": {
-					"powerMultiplier": {
+					"protection": {
 						"comboBase": 2,
 						"max": 16
 					}

--- a/species/novakid.species.patch
+++ b/species/novakid.species.patch
@@ -13,7 +13,7 @@
   ^cyan;Immune^reset;: Burning, Radiation Burn
 
 ^orange;Environment^reset;:
-  ^green;Radioactive^reset; biomes: gain Energy & Health x^green;1.15^reset;
+  ^green;Radioactive^reset; biomes: gain Health x^green;1.15^reset;
   Sunlight: ^green;Regenerate^reset; when fed, +^green;20^reset;% E. Regen.
   Night: Regen ^red;consumes food^reset;, Energy x^red;0.75^reset;
 


### PR DESCRIPTION
- Fixed humans not receiving Protection bonus from Perfect Blocks (now gives +2 Protection, stacks up to +16)
- Fixed outdated description of Novakid: they don't have increased energy on radioactive planets
- Updated tutorial codex that was mentioning Point Sensor (old name of Object Data Sensor)
- Reworded confusing completion text of Sifters tutorial quest
- In description of Small FTL Drive, mentioned that it can do STL travel too.