### PR TITLE
Add rarities filter to Armory

### DIFF
--- a/interface/windowconfig/armory.config
+++ b/interface/windowconfig/armory.config
@@ -315,6 +315,38 @@
       "type" : "radioGroup",
       "toggleMode" : true,
       "buttons" : [
+        {
+          "position" : [8, 60],
+          "baseImage" : "/interface/crafting/sortcommon.png",
+          "baseImageChecked" : "/interface/crafting/sortcommonselected.png",
+          "data" : {
+            "rarity" : [ "common" ]
+          }
+        },
+        {
+          "position" : [14, 60],
+          "baseImage" : "/interface/crafting/sortuncommon.png",
+          "baseImageChecked" : "/interface/crafting/sortuncommonselected.png",
+          "data" : {
+            "rarity" : [ "uncommon" ]
+          }
+        },
+        {
+          "position" : [20, 60],
+          "baseImage" : "/interface/crafting/sortrare.png",
+          "baseImageChecked" : "/interface/crafting/sortrareselected.png",
+          "data" : {
+            "rarity" : [ "rare" ]
+          }
+        },
+        {
+          "position" : [26, 60],
+          "baseImage" : "/interface/crafting/sortlegendary.png",
+          "baseImageChecked" : "/interface/crafting/sortlegendaryselected.png",
+          "data" : {
+            "rarity" : [ "legendary" ]
+          }
+        }
       ]
     }
   }


### PR DESCRIPTION
Adds a way to filter armors and weapons by tier, since in FU the rarity directly linked to the tier of the item. This will help players pick a weapon/armor more easily.