### PR TITLE
Fix typo that prevented 8 blocks from being painted

### DIFF
--- a/tiles/materials/bamboo.material
+++ b/tiles/materials/bamboo.material
@@ -20,7 +20,7 @@
     "variants" : 5,
     "lightTransparent" : false,
     "occludesBelow" : true,
-    "multicolored" : true,
+    "multiColored" : true,
     "zLevel" : 0
   }
 }

--- a/tiles/materials/brittlemetal.material
+++ b/tiles/materials/brittlemetal.material
@@ -17,7 +17,7 @@
 	  "variants" : 3,
     "lightTransparent" : false,
     "occludesBelow" : true,
-	  "multicolored" : true,
+	  "multiColored" : true,
     "zLevel" : 0
   },
   "liquidInteractions" : [

--- a/tiles/materials/ff_diamondblock.material
+++ b/tiles/materials/ff_diamondblock.material
@@ -5,7 +5,6 @@
   "itemDrop" : "diamondblockmaterial",
   "description" : "A solid block of diamond alloy.",
   "shortdescription" : "Diamond block",
-  "multicolored" : false,
   "footstepSound" : "/sfx/blocks/footstep_metallic.ogg",
   "tillableMod" : 31,
   "soil" : true,

--- a/tiles/materials/fusteelgirdir.material
+++ b/tiles/materials/fusteelgirdir.material
@@ -5,7 +5,6 @@
   "itemDrop" : "fusteelgirdirmaterial",
   "description" : "A solid steel girder",
   "shortdescription" : "Steel Girder",
-  "multicolored" : false,
   "footstepSound" : "/sfx/blocks/footstep_girder.ogg",
   "health" : 20,
   "category": "materials",

--- a/tiles/materials/honey/frozenwaxblock.material
+++ b/tiles/materials/honey/frozenwaxblock.material
@@ -6,7 +6,6 @@
   "description" : "A block of frozen wax.",
   "shortdescription" : "Frozen Wax Block",
   "category": "material",
-  "multicolored" : false,
   "footstepSound" : "/sfx/blocks/footstep_ice.ogg",
   "health" : 3,
   "renderTemplate" : "/tiles/classicmaterialtemplate.config",

--- a/tiles/materials/honey/frozenwaxplatform.material
+++ b/tiles/materials/honey/frozenwaxplatform.material
@@ -16,7 +16,7 @@
     "variants" : 1,
     "lightTransparent" : true,
     "occludesBelow" : false,
-    "multicolored" : true,
+    "multiColored" : true,
     "zLevel" : 0,
     "platform" : true
   }

--- a/tiles/materials/honey/fu_honeycombblock.material
+++ b/tiles/materials/honey/fu_honeycombblock.material
@@ -5,7 +5,6 @@
   "itemDrop" : "fu_honeycombblock",
   "description" : "A block of honeycombs! Yum!",
   "shortdescription" : "Honeycomb Block",
-  "multicolored" : true,
   "category": "material",
   "footstepSound" : "/sfx/blocks/footstep_gravel.ogg",
   "health" : 5,

--- a/tiles/materials/honey/fu_redhoneycombblock.material
+++ b/tiles/materials/honey/fu_redhoneycombblock.material
@@ -5,7 +5,6 @@
   "itemDrop" : "fu_redhoneycombblock",
   "description" : "A block of red honeycombs! Yum!",
   "shortdescription" : "Red Honeycomb Block",
-  "multicolored" : true,
   "category": "material",
   "footstepSound" : "/sfx/blocks/footstep_ice.ogg",
   "health" : 5,

--- a/tiles/materials/honey/goldenglass/goldenglass.material
+++ b/tiles/materials/honey/goldenglass/goldenglass.material
@@ -9,7 +9,6 @@
   "shortdescription" : "Golden Glass Block",
   "glitchDescription" : "Statement. Glass.",
   "floranDescription" : "Floran look pretty in glasssss.",
-  "multicolored" : false,
   "footstepSound" : "/sfx/blocks/footstep_glass.ogg",
   "health" : 3,
   "renderTemplate" : "/tiles/fuclassicnopaint.config",

--- a/tiles/materials/honey/redwaxblock.material
+++ b/tiles/materials/honey/redwaxblock.material
@@ -5,7 +5,6 @@
   "itemDrop" : "redwaxblock",
   "description" : "A red block of wax.",
   "shortdescription" : "Red Wax Block",
-  "multicolored" : true,
   "category": "material",
   "footstepSound" : "/sfx/blocks/footstep_ice.ogg",
   "health" : 3,

--- a/tiles/materials/honey/redwaxplatform.material
+++ b/tiles/materials/honey/redwaxplatform.material
@@ -16,7 +16,7 @@
     "variants" : 1,
     "lightTransparent" : true,
     "occludesBelow" : false,
-    "multicolored" : true,
+    "multiColored" : true,
     "zLevel" : 0,
     "platform" : true
   }

--- a/tiles/materials/honey/waxblock1.material
+++ b/tiles/materials/honey/waxblock1.material
@@ -5,7 +5,6 @@
   "itemDrop" : "waxblock1",
   "description" : "A block of wax.",
   "shortdescription" : "Wax Block",
-  "multicolored" : true,
   "category": "material",
   "footstepSound" : "/sfx/blocks/footstep_ice.ogg",
   "health" : 3,

--- a/tiles/materials/honey/whitewaxblock.material
+++ b/tiles/materials/honey/whitewaxblock.material
@@ -6,7 +6,6 @@
   "description" : "A block of white wax.",
   "shortdescription" : "White Wax Block",
   "category": "material",
-  "multicolored" : true,
   "footstepSound" : "/sfx/blocks/footstep_ice.ogg",
   "health" : 3,
   "renderTemplate" : "/tiles/classicmaterialtemplate.config",

--- a/tiles/materials/penumbriteblock.material
+++ b/tiles/materials/penumbriteblock.material
@@ -5,7 +5,6 @@
   "itemDrop" : "penumbriteblockmaterial",
   "description" : "A solid block of penumbrite alloy.",
   "shortdescription" : "Penumbrite block",
-  "multicolored" : false,
   "footstepSound" : "/sfx/blocks/footstep_metallic.ogg",
   "health" : 44,
   "category": "materials",

--- a/tiles/materials/pixelgoods/fujellyblock2.material
+++ b/tiles/materials/pixelgoods/fujellyblock2.material
@@ -16,7 +16,7 @@
     "variants" : 5,
     "lightTransparent" : false,
     "occludesBelow" : true,
-    "multicolored" : true,
+    "multiColored" : true,
     "zLevel" : 0
   }
 }

--- a/tiles/materials/pixelgoods/fuokeagrass.material
+++ b/tiles/materials/pixelgoods/fuokeagrass.material
@@ -16,7 +16,7 @@
     "variants" : 5,
     "lightTransparent" : false,
     "occludesBelow" : true,
-    "multicolored" : true,
+    "multiColored" : true,
     "zLevel" : 0
   }
 }

--- a/tiles/materials/pixelgoods/fuokeahitechwall1.material
+++ b/tiles/materials/pixelgoods/fuokeahitechwall1.material
@@ -15,7 +15,7 @@
     "variants" : 15,
     "lightTransparent" : false,
     "occludesBelow" : true,
-    "multicolored" : true,
+    "multiColored" : true,
     "zLevel" : 0
   }
 }

--- a/tiles/materials/pixelgoods/fuokeahitechwall2.material
+++ b/tiles/materials/pixelgoods/fuokeahitechwall2.material
@@ -5,7 +5,6 @@
   "itemDrop" : "fuokeahitechwall2",
   "description" : "Plasteel is pretty awesome.",
   "shortdescription" : "Plasteel Tile",
-  "multicolored" : true,
   "footstepSound" : "/sfx/blocks/footstep_metallic.ogg",
   "health" : 20,
   "category": "materials",
@@ -16,7 +15,7 @@
     "variants" : 1,
     "lightTransparent" : false,
     "occludesBelow" : true,
-    "multicolored" : true,
+    "multiColored" : true,
     "zLevel" : 0
   }
 }

--- a/tiles/materials/pixelgoods/fuokeamagmabrick.material
+++ b/tiles/materials/pixelgoods/fuokeamagmabrick.material
@@ -3,7 +3,6 @@
   "materialName" : "fuokeamagmabrick",
   "particleColor" : [80, 80, 80, 255],
   "itemDrop" : "fuokeamagmabrick",
-  "multicolored" : true,
   "description" : "Bricks made out of magmastone and hellfire.",
   "shortdescription" : "Hellfire Bricks",
   "footstepSound" : "/sfx/blocks/footstep_stone3.ogg",
@@ -16,7 +15,7 @@
     "variants" : 10,
     "lightTransparent" : false,
     "occludesBelow" : true,
-    "multicolored" : true,
+    "multiColored" : true,
     "zLevel" : 0
   }
 }

--- a/tiles/materials/pixelgoods/fuokeamagmastone.material
+++ b/tiles/materials/pixelgoods/fuokeamagmastone.material
@@ -5,7 +5,6 @@
   "itemDrop" : "fuokeamagmastone",
   "description" : "Stone made out of magmastone and hellfire.",
   "shortdescription" : "Hellfire Stone",
-  "multicolored" : true,
   "footstepSound" : "/sfx/blocks/footstep_stone3.ogg",
   "health" : 30,
   "category": "materials",
@@ -16,7 +15,7 @@
     "variants" : 5,
     "lightTransparent" : false,
     "occludesBelow" : true,
-    "multicolored" : true,
+    "multiColored" : true,
     "zLevel" : 0
   }
 }

--- a/tiles/materials/protoblock.material
+++ b/tiles/materials/protoblock.material
@@ -5,7 +5,6 @@
   "itemDrop" : "protoblockmaterial",
   "description" : "A solid block of protocite.",
   "shortdescription" : "Protocite block",
-  "multicolored" : false,
   "footstepSound" : "/sfx/blocks/footstep_metallic.ogg",
   "health" : 24,
   "category": "materials",


### PR DESCRIPTION
* The following blocks can now be painted: Bamboo, Brittle Metal, Frozen Wax Platform, Hellfire Bricks, Hellfire Stone, Plasteel Tile, Plasteel Wall, Red Wax Platform.