### PR TITLE
Khe Lantern quest changes

### DIFF
--- a/items/active/flashlights/lanterror/lanterror.activeitem
+++ b/items/active/flashlights/lanterror/lanterror.activeitem
@@ -19,5 +19,7 @@
   "animationCustom" : { },
 
   "scripts" : ["lanterror.lua"],
-  "fireOffset" : [0, 0]
+  "fireOffset" : [0, 0],
+
+  "pickupQuestTemplates" : ["khe_lantern"]
 }

--- a/npcs/scienceoutpost/lostandfoundnpc.npctype
+++ b/npcs/scienceoutpost/lostandfoundnpc.npctype
@@ -26,7 +26,7 @@
 
 	"scriptConfig": {
 		"offeredQuests" : [
-			"khe_fabric","khe_lantern","mastermanipulator2"//,
+			"khe_fabric","mastermanipulator2"//,
 			//"fu_t10_initial"//disabled. quest will reward a beacon which is used to access the arena. each quest will reward ONE beacon to the next arena. more can be bought.
 		],
 		"turnInQuests": [

--- a/quests/fu_questlines/outpost/khe_stuff/khe_lantern.questtemplate
+++ b/quests/fu_questlines/outpost/khe_stuff/khe_lantern.questtemplate
@@ -1,8 +1,8 @@
 {
 	"id": "khe_lantern",
-	"prerequisites": ["khe_fabric"],
+	"prerequisites" : [ ],
 	"title": "Cat Toys",
-	"text": "Mew lantern broke. Sad, sad mew. Find mew another one? Also, mew wants an accordion.",
+	"text": "Hey, you. Mew lantern broke. Sad, sad mew. You found another for mew?",
 	"completionText": "Yay! Happy kitty! You can keep the old lantern. I got lots of those.",
 	"moneyRange": [1, 2],
 	"rewards": [[ [ "lanterrortreasuretrollking", 1 ] ]],
@@ -20,11 +20,10 @@
 
 		"requireTurnIn": true,
 
-		"turnInDescription": "Bring ^cyan;Khe^reset; the ingredients.",
+		"turnInDescription": "Bring the Ghost Lantern to ^cyan;Khe^reset; at the Science Outpost.",
 
 		"conditions": [
-			{"type": "gatherItem","itemName": "lanterror","count": 1,"consume": true},
-			{"type": "gatherItem","itemName": "accordion","count": 1,"consume": true}
+			{"type": "gatherItem","itemName": "lanterror","count": 1,"consume": true}
 		]
 	}
 }


### PR DESCRIPTION
- The quest 'Cat Toys' no longer requires an accordion, and is now obtained by finding a Ghost Lantern. To update this quest, abandon it and pick up a Ghost Lantern.