### PR TITLE
Fixed liquid interaction crash

### DIFF
--- a/tiles/materials/matterblock.material
+++ b/tiles/materials/matterblock.material
@@ -18,7 +18,7 @@
     "variants" : 5,
     "lightTransparent" : false,
     "occludesBelow" : true,
-    "multiColored" : false,
+    "multiColored" : true,
     "zLevel" : 1550
   }//,
  // "learnBlueprintsOnPickup" : [ "matteritem" ]

--- a/tiles/materials/redsand2.material
+++ b/tiles/materials/redsand2.material
@@ -18,7 +18,7 @@
     "variants" : 3,
     "lightTransparent" : false,
     "occludesBelow" : true,
-    "multiColored" : false,
+    "multiColored" : true,
     "zLevel" : 1830
   }
 }


### PR DESCRIPTION
- Creating Matter Blocks and Red Sand by mixing liquids with painted tiles no longer causes crashes.