### PR TITLE
Add missing Salt Water mixings, misc. improvements/fixes

### DIFF
--- a/interface/objectcrafting/fu_pethouse/fu_pethouse.config
+++ b/interface/objectcrafting/fu_pethouse/fu_pethouse.config
@@ -225,7 +225,7 @@
 	"buttonTimer" : 1,
 	"popupMessages" :	{
 		"noPod" : "This requires an empty capture pod in your inventory.",
-		"captureFail" : "Incompatible mod detected. Any mods that modifiy groundPet.lua can cause issues with catching ship pets.",
+		"captureFail" : "Incompatible mod detected. Any mods that modify groundPet.lua can cause issues with catching ship pets.",
 		"petMissing" : "Can't find ship pet.",
 		"invalidTechstation" : "This SAIL is missing the necessary script changes. This either means that it uses a custom script, another mod is overwriting the techstation script or you have Purchasable Pets installed."
 	},

--- a/interface/scripted/fu_craftinfo/fu_craftinfo.lua
+++ b/interface/scripted/fu_craftinfo/fu_craftinfo.lua
@@ -794,6 +794,10 @@ function addHeadingItem(item, list)
 end
 
 function canonicalise(file, directory)
+	if not file then
+		return '/objects/generic/perfectlygenericitem/perfectlygenericitem.png'
+	end
+
 	if string.sub(file, 1, 1) == '/' then return file end
 	return directory .. file
 end

--- a/items/active/weapons/ranged/pistol/swtjc_ewg_commonbeampistol.activeitem
+++ b/items/active/weapons/ranged/pistol/swtjc_ewg_commonbeampistol.activeitem
@@ -8,7 +8,7 @@
   "tooltipKind" : "gun",
   "category" : "swtjc_ewg_beamPistol",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","pistol","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","pistol","energy","upgradeableWeapon"],
   "level" : 1,
 
   "animation" : "/items/active/weapons/ranged/gun.animation",

--- a/items/active/weapons/ranged/pistol/swtjc_ewg_rarebeampistol.activeitem
+++ b/items/active/weapons/ranged/pistol/swtjc_ewg_rarebeampistol.activeitem
@@ -8,7 +8,7 @@
   "tooltipKind" : "gun",
   "category" : "swtjc_ewg_beamPistol",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","pistol","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","pistol","energy","upgradeableWeapon"],
   "level" : 1,
 
   "animation" : "/items/active/weapons/ranged/gun.animation",

--- a/items/active/weapons/ranged/pistol/swtjc_ewg_uncommonbeampistol.activeitem
+++ b/items/active/weapons/ranged/pistol/swtjc_ewg_uncommonbeampistol.activeitem
@@ -8,7 +8,7 @@
   "tooltipKind" : "gun",
   "category" : "swtjc_ewg_beamPistol",
   "twoHanded" : false,
-  "itemTags" : ["weapon","ranged","pistol","upgradeableWeapon"],
+  "itemTags" : ["weapon","ranged","pistol","energy","upgradeableWeapon"],
   "level" : 1,
 
   "animation" : "/items/active/weapons/ranged/gun.animation",

--- a/liquids/orangegravrain.liquid
+++ b/liquids/orangegravrain.liquid
@@ -54,6 +54,11 @@
     //irradium
       "liquid" : 47,
       "materialResult" : "retexaetherdust"
+    },
+    {
+    //salt water
+      "liquid" : 73,
+      "liquidResult" : 51
     }
   ],
   "texture" : "/liquids/honeytex.png",

--- a/liquids/organicsoup.liquid
+++ b/liquids/organicsoup.liquid
@@ -45,6 +45,11 @@
       //mercury
       "liquid" : 48,
       "liquidResult" : 46
+    },
+    {
+      //salt water
+      "liquid" : 73,
+      "liquidResult" : 3
     }
   ],
   "texture" : "/liquids/watertex.png",

--- a/liquids/pus.liquid
+++ b/liquids/pus.liquid
@@ -38,6 +38,11 @@
     //acid
      "liquid" : 46,
      "liquidResult" : 46
+    },
+    {
+    //salt water
+     "liquid" : 73,
+     "liquidResult" : 58
     }
   ],
   "texture" : "/liquids/pustex.png",

--- a/liquids/slimeliquid.liquid.patch
+++ b/liquids/slimeliquid.liquid.patch
@@ -3,6 +3,7 @@
     "op" : "add",
     "path" : "/interactions/-",
     "value" : {
+      // liquid iron
       "liquid" : 52,
       "liquidResult" : 2
     }
@@ -11,6 +12,7 @@
     "op" : "add",
     "path" : "/interactions/-",
     "value" : {
+      // water
       "liquid" : 1,
       "liquidResult" : 3
     }
@@ -19,8 +21,18 @@
     "op" : "add",
     "path" : "/interactions/-",
     "value" : {
+      // poison
       "liquid" : 3,
       "liquidResult" : 41
+    }
+  },
+  {
+    "op" : "add",
+    "path" : "/interactions/-",
+    "value" : {
+      // salt water
+      "liquid" : 73,
+      "liquidResult" : 3
     }
   }
 ]

--- a/objects/power/fu_liquidcondenser/fu_liquidcondenser.object
+++ b/objects/power/fu_liquidcondenser/fu_liquidcondenser.object
@@ -2,7 +2,7 @@
 	"objectName": "fu_liquidcondenser",
 	"rarity": "rare",
 	"colonyTags": ["science", "wired", "lab"],
-	"description": "Condenses liquid from biome atmosphere. ^cyan;Requires ^orange;15J^cyan; per action^reset;. ^red;Slower production when stacked^reset;. Scan for Info.",
+	"description": "Condenses liquid from biome atmosphere. ^cyan;Requires ^orange;15W^cyan; of power^reset;. ^red;Slower production when stacked^reset;. Scan for Info.",
 	"shortdescription": "^cyan;Liquid Collector^reset;",
 	"race": "generic",
 	"category": "wire",

--- a/objects/power/fu_liquidmixer/fu_liquidmixer_recipes.config
+++ b/objects/power/fu_liquidmixer/fu_liquidmixer_recipes.config
@@ -10,6 +10,10 @@
 	{"inputs":{"fusaltwater":1,"fu_liquidhoney":1},"outputs":{"honeycombmaterial":1}},
 	{"inputs":{"fusaltwater":10,"corruptionore":1},"outputs":{"liquiddarkwater":5}},
 	{"inputs":{"fusaltwater":1,"liquidwater":1},"outputs":{"fusaltwater":2}},
+	{"inputs":{"fusaltwater":1,"liquidorangegravrain":1},"outputs":{"liquidgravrain":2}},
+	{"inputs":{"fusaltwater":1,"liquidorganicsoup":1},"outputs":{"liquidpoison":2}},
+	{"inputs":{"fusaltwater":1,"liquidpus":1},"outputs":{"liquidwastewater":2}},
+	{"inputs":{"fusaltwater":1,"liquidslime":1},"outputs":{"liquidpoison":2}},
 
 	{"inputs":{"liquidwater":1,"liquidpoison":1},"outputs":{"liquidpoison":2}},
 	{"inputs":{"liquidwater":1,"swampwater":1},"outputs":{"swampwater":2}},

--- a/recipes/chemlab/liquids/fusaltwater.recipe
+++ b/recipes/chemlab/liquids/fusaltwater.recipe
@@ -1,12 +1,12 @@
 {
   "input" : [
-    { "item" : "fusaltwater", "count" : 10 },
-    { "item" : "corefragmentore", "count" : 1 }
+    { "item" : "liquidwater", "count" : 1 },
+    { "item" : "fu_salt", "count" : 1 }
   ],
   "output" : {
-    "item" : "liquidwater",
-    "count" : 10
+    "item" : "fusaltwater",
+    "count" : 2
   },
-  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
-  "duration" : 0.2
+  "groups" : [ "chemlab","chemlab1", "liquids", "all","nouncrafting","norecycling" ],
+  "duration" : 0.25
 }

--- a/recipes/chemlab/liquids/liquidwater.recipe
+++ b/recipes/chemlab/liquids/liquidwater.recipe
@@ -1,12 +1,12 @@
 {
   "input" : [
-    { "item" : "liquidwater", "count" : 1 },
-    { "item" : "fu_salt", "count" : 1 }
+    { "item" : "fusaltwater", "count" : 10 },
+    { "item" : "corefragmentore", "count" : 1 }
   ],
   "output" : {
-    "item" : "fusaltwater",
-    "count" : 2
+    "item" : "liquidwater",
+    "count" : 10
   },
-  "groups" : [ "chemlab","chemlab1", "liquids", "all","nouncrafting","norecycling" ],
-  "duration" : 0.25
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
+  "duration" : 0.2
 }

--- a/recipes/chemlab/liquids/liquidwater.recipe
+++ b/recipes/chemlab/liquids/liquidwater.recipe
@@ -7,6 +7,6 @@
     "item" : "liquidwater",
     "count" : 10
   },
-  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling", "excludeFromQuests" ],
   "duration" : 0.2
 }

--- a/recipes/chemlab/liquids/purewater.recipe
+++ b/recipes/chemlab/liquids/purewater.recipe
@@ -8,6 +8,6 @@
     "item" : "liquidwater",
     "count" : 5
   },
-  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling" ],
+  "groups" : [ "chemlab1", "liquids", "all","nouncrafting","norecycling", "excludeFromQuests" ],
   "duration" : 0.25
 }

--- a/species/novakid.species.patch
+++ b/species/novakid.species.patch
@@ -8,6 +8,7 @@
   ^orange;Diet^reset;: Any
 
 ^orange;Perks^reset;:
+  Glow in the dark
   Energy x^green;1.1^reset;
   ^green;Resist^reset;: +^cyan;35^reset;% Radiation, +^cyan;20^reset;% Fire
   ^cyan;Immune^reset;: Burning, Radiation Burn

--- a/stats/effects/regeneration/lightregen.lua
+++ b/stats/effects/regeneration/lightregen.lua
@@ -4,33 +4,20 @@ require "/scripts/interp.lua"
 require "/stats/effects/fu_statusUtil.lua"
 
 function init()
-	self.healingRate = 1.01 / config.getParameter("healTime", 320)
 	script.setUpdateDelta(5)
 	self.healTime=config.getParameter("healTime", 140)
 	bonusHandler=effect.addStatModifierGroup({})
 end
 
 function update(dt)
-	local daytime = daytimeCheck()
-	local underground = undergroundCheck()
 	local lightLevel = getLight()
+	local healingRate = 0.0
 
-	if daytime then
-		if underground and lightLevel < 40 then
-			self.healingRate = 1.0009 / self.healTime
-		elseif underground and lightLevel > 40 then
-			self.healingRate = 1.001 / self.healTime
-		else
-		    if lightLevel > 25 then
-				self.healingRate=((((lightLevel-25.0)/37.5)+1.0)/self.healTime)
-			else
-				self.healingRate=0.0
-			end
-		end
-	else
-		self.healingRate=0.0
+	if lightLevel > 25 then
+		healingRate = ((((lightLevel-25.0)/37.5)+1.0)/self.healTime)
 	end
-	effect.setStatModifierGroup(bonusHandler,{{stat="healthRegen",amount=status.resourceMax("health")*self.healingRate*math.max(0,1+status.stat("healingBonus"))}})
+
+	effect.setStatModifierGroup(bonusHandler,{{stat="healthRegen",amount=status.resourceMax("health")*healingRate*math.max(0,1+status.stat("healingBonus"))}})
 end
 
 function uninit()

--- a/terrestrial_worlds.config.patch
+++ b/terrestrial_worlds.config.patch
@@ -4634,7 +4634,7 @@
 				},
 				"surface": {
 					"primaryRegion": ["irradiated"],
-					"secondaryRegions": ["biowastes", "wartfield", "wastelandmini", "aliendesert", "goreforest", "crystaldesert", "crystalswamp", "supermatterzone", "ffhive", "corruptedforest", "birchforest", "alienforest", "cellfield", "reddesert", "swamp", "bloodgulch", "hellhive", "elder", "icewaste", "snow", "protoworld", "irradiated", "precursorsurface"],
+					"secondaryRegions": ["biowastes", "wartfield", "wastelandmini", "aliendesert", "goreforest", "crystaldesert", "crystalswamp", "supermatterzone", "ffhive", "corruptedforest", "birchforest", "alienforest", "cellfield", "reddesert", "swamp", "bloodgulch", "hellhive", "elder", "icewaste", "snow", "protoworld", "precursorsurface"],
 
 					"dungeons": [
 						[0.5, "fuwreck"],

--- a/tests/travis/.eslintrc.js
+++ b/tests/travis/.eslintrc.js
@@ -3,20 +3,20 @@
 module.exports = {
 	env: {
 		node: true,
-		es2021: true
+		es2022: true
 	},
 	extends: [
 		'wikimedia',
 		'wikimedia/node',
-		'wikimedia/language/es2021'
+		'wikimedia/language/es2022'
 	],
-	parserOptions: {
-		ecmaVersion: 12
-	},
 	rules: {
 		// Necessary to skip: both console.log() and process.exit() are used in tests.
 		'no-console': 'off',
-		'no-process-exit': 'off',
+		'n/no-process-exit': 'off',
+
+		// Unavoidable when loading assets.
+		'security/detect-non-literal-fs-filename': 'off',
 
 		// Very annoying with the current codestyle ("for ( var [ a, b ] of ..." loops, etc.).
 		'prefer-const': 'off',

--- a/tests/travis/check_json_assets.js
+++ b/tests/travis/check_json_assets.js
@@ -911,9 +911,9 @@ class JsonAssetsTest {
 		var lines = [];
 		filenames.forEach( ( filename ) => {
 			var moreLines = fs.readFileSync( __dirname + '/' + filename ).toString().split( /[\r\n]+/ )
-				.filter( function ( x ) {
-					return x !== '' && !x.startsWith( '#' ) && !x.startsWith( '//' );
-				} );
+				.filter( ( x ) => (
+					x !== '' && !x.startsWith( '#' ) && !x.startsWith( '//' )
+				) );
 			lines.push( ...moreLines );
 		} );
 		return lines;

--- a/tests/travis/package.json
+++ b/tests/travis/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "dependencies": {
-    "fast-glob": "^3.2.4",
+    "fast-glob": "^3.3.3",
     "fs": "^0.0.2",
     "strip-json-comments": "^3.1.1"
   },
   "devDependencies": {
-    "eslint-config-wikimedia": "^0.21.0"
+    "eslint-config-wikimedia": "^0.28.0"
   },
   "scripts": {
     "test": "node check_json_assets.js"

--- a/zb/newSail/fu_customFunctions.lua
+++ b/zb/newSail/fu_customFunctions.lua
@@ -27,8 +27,8 @@ function fu_configureShipPet()
 	local petConfigPane = root.assetJson("/interface/objectcrafting/fu_pethouse/fu_pethouse.config")
 	if petConfigPane and petConfigPane.gui then
 		petConfigPane.gui.itemGrid = nil
-		petConfigPane.gui.changeObjectPet.disabled = true
-		petConfigPane.gui.addObjectPetToList.disabled = true
+		petConfigPane.gui.changeObjectPet = nil
+		petConfigPane.gui.addObjectPetToList = nil
 		petConfigPane.containerId = pane.sourceEntity()
 		player.interact("ScriptPane", petConfigPane)
 	end


### PR DESCRIPTION
- Novakid species description now tells that they glow in the dark.
- Salt Water can now be mixed with Organic Soup, Slime, Pus, Orange Grav-Liquid (result is the same as when mixing them with Water).
- Fixed Irradiated planet having its main biome as a possible subbiome.
- Removed unused buttons (Change Object Pet, Add Pet To List) from Pet Configuration in SAIL.
- Beam Pistols now benefit from bonuses to energy weapons.
- Fixed incorrect description of Liquid Condenser (it uses 15W, not 15J per action).
- Tenant quests no longer ask player to craft Water from Salt Water or Contaminated Water.
- Fixed unexpected behavior of Gurn Onion consumable (Heal in Light buff). Now it always heals if light>0.25 (even at night) and never heals if light<=0.25.
- Fixed Lab Directory not working if some item from another mod doesn't have an inventory item.