### PR TITLE
small fixes

### DIFF
--- a/items/liquids/arcana_liquid_arcaneWater.liqitem.patch
+++ b/items/liquids/arcana_liquid_arcaneWater.liqitem.patch
@@ -1,5 +1,0 @@
-{
-  "op": "replace",
-  "path": "/description",
-  "value": "A measure of water sprinkled with arcane magic. \n^yellow;Centrifugable^reset;."
-}

--- a/items/liquids/arcana_liquid_illuminatedWater.liqitem.patch
+++ b/items/liquids/arcana_liquid_illuminatedWater.liqitem.patch
@@ -1,5 +1,0 @@
-{
-  "op": "replace",
-  "path": "/description",
-  "value": "A pale colored liquid. \n^yellow;Centrifugable^reset;."
-}

--- a/items/liquids/arcana_liquid_neonWater.liqitem.patch
+++ b/items/liquids/arcana_liquid_neonWater.liqitem.patch
@@ -1,5 +1,0 @@
-{
-  "op": "replace",
-  "path": "/description",
-  "value": "A neon colored liquid. \n^yellow;Centrifugable^reset;."
-}

--- a/items/liquids/arcana_liquid_ruinousWater.liqitem.patch
+++ b/items/liquids/arcana_liquid_ruinousWater.liqitem.patch
@@ -1,5 +1,0 @@
-{
-  "op": "replace",
-  "path": "/description",
-  "value": "A mysterious dark liquid. \n^yellow;Centrifugable^reset;."
-}

--- a/items/liquids/arcana_liquid_viridescentAcid.liqitem.patch
+++ b/items/liquids/arcana_liquid_viridescentAcid.liqitem.patch
@@ -1,5 +1,0 @@
-{
-  "op": "replace",
-  "path": "/description",
-  "value": "A highly acidic liquid, found in Viridescent planets. \n^yellow;Centrifugable^reset;."
-}


### PR DESCRIPTION
removed arcana liqitem patches due to common complaints of crashing in the arcana server, caused by these patches. blame mod loading for unreliable behavior
this is something that should be handled by an external patch mod, not something that should be bundled into either base mod.