### PR TITLE
[QOL] Remove "On/Off Switch" on batteries (major point of confusion)

### DIFF
--- a/monsters/pandorasboxmonsterscripts/pandorasboxsimplefarmablemonster.lua
+++ b/monsters/pandorasboxmonsterscripts/pandorasboxsimplefarmablemonster.lua
@@ -29,15 +29,20 @@ end
 
 function resolveStageDuration(dur)
 	if type(dur)=="table" then
-		return math.max(unpack(dur))
+		return math.max(table.unpack(dur))
 	else
 		return dur
 	end
 end
 
 function hasMonsterHarvest(args, board)
+	if (not storage.lastHarvest) or (not cacheHarvestTime) then
+		resetMonsterHarvest()
+		return false
+	end
+
 	local harvestMath=(world.time() - storage.lastHarvest)
-	if (not storage.lastHarvest) or ((not cacheHarvestTime) or (harvestMath<0) or (harvestMath>=(resolveStageDuration(cacheHarvestTime))*100)) then
+	if (harvestMath<0) or (harvestMath>=(resolveStageDuration(cacheHarvestTime))*100) then
 		resetMonsterHarvest()
 		return false
 	end

--- a/objects/generic/centrifuge_recipes.config
+++ b/objects/generic/centrifuge_recipes.config
@@ -1816,7 +1816,9 @@
  
   "itemMapFarm": {
     "milk": {
-      "cheese": ["common", 1]
+      "fubutter": ["common", 1],
+      "cheese": ["uncommon", 1],
+      "sugar": ["rare", 1]
     },
     "liquidwater": {
       "fu_hydrogen": ["normal", 2],

--- a/objects/power/isn_battery.lua
+++ b/objects/power/isn_battery.lua
@@ -66,7 +66,7 @@ function isn_makeBatteryDescription(desc, charge, onDeath)
 	-- append charge state to default description; ensure that it's on a line of its own
 	local str=string_split(desc,"^truncate;")
 	if str[1] then str=str[1] else str="" end
-	str=str..((onDeath and " ^red;Scan for Info^reset;") or "\n^blue;Upper Right Input^reset;: On/Off Switch\n^red;Battery Logic outputs:\nLeft^reset;: Has Power, ^red;Right^reset;: Is Full")
+	str=str..((onDeath and " ^red;Scan for Info^reset;") or "\n^red;Battery Logic outputs:\nLeft^reset;: Has Power, ^red;Right^reset;: Is Full")
 	str = str .. (desc ~= '' and "\n" or '') .. "Power Stored: ^yellow;"..util.round(power.getStoredEnergy(),1).."^reset;/^green;"..util.round(power.getMaxEnergy(),1).."^reset;J (^yellow;" .. charge .. '^reset;%)'
 	return str
 end
@@ -99,8 +99,7 @@ end
 
 function batteryUpdate(dt)
 	batteryUpdateThrottle=math.max(0,(batteryUpdateThrottle or batteryUpdateThrottleBase)-(dt or 0))
-	local on=(not object.isInputNodeConnected(1)) or object.getInputNodeLevel(1)
-	power.setPower(on and power.getStoredEnergy() or 0)
+	power.setPower(power.getStoredEnergy())
 	if batteryUpdateThrottle <= 0 then
 		local throttleMult=(math.sqrt(#(world.objectQuery(entity.position(),16,{callScript="isFuBattery"}))))
 		object.setConfigParameter('description', isn_makeBatteryDescription())

--- a/scripts/pandorasbox/objects/pandorasboxfarmableobject.lua
+++ b/scripts/pandorasbox/objects/pandorasboxfarmableobject.lua
@@ -22,7 +22,7 @@ end
 
 function resolveStageDuration(dur)
 	if type(dur)=="table" then
-		return math.max(unpack(dur))
+		return math.max(table.unpack(dur))
 	else
 		return dur
 	end
@@ -33,8 +33,8 @@ function update(dt)
 	if storage.lastHarvest then
 		if storage.stage and not storage.harvestable then
 			local harvestMath=(world.time() - storage.lastHarvest)
-			if (harvestMath<0) or (harvestMath>(resolveStageDuration(stages[stage].duration))*100) then
-				storage.harvestTime=util.randomInRange(stages[stage].duration)+world.time()
+			if (harvestMath<0) or (harvestMath>(resolveStageDuration(stages[storage.stage].duration))*100) then
+				storage.harvestTime=util.randomInRange(stages[storage.stage].duration)+world.time()
 			elseif harvestMath >= storage.harvestTime then
 				if checkForMoisture(true) then
 					grow()


### PR DESCRIPTION
- Removed On/Off Switch from batteries (it often caused players to accidentally disable the battery). Now both inputs can be used to transmit power, and the battery is never disabled.
- Milk now centrifuges into Butter, Cheese, Sugar (was: only Cheese).
- Fixed Cottonbops not growing/harvesting correctly.