### PR TITLE
Made Farmbeast Harvester Turret work on friendly Cottonbops

### DIFF
--- a/items/generic/desserts/fuchocolatechipcookie.consumable
+++ b/items/generic/desserts/fuchocolatechipcookie.consumable
@@ -4,7 +4,7 @@
   "price": 255,
   "category": "preparedFood",
   "inventoryIcon": "fuchocolatechipcookie.png",
-  "description": "Delicious chocolate chip cookies.\n^cyan;+^white;20% ^cyan;EP ^gray;(^white;150s^gray;), ^green;Heal ^white;1500 ^gray;(^white;150s^gray;)^reset; ^orange;Type: Grain + Dairy + Eggs + Sugar^reset;",
+  "description": "Delicious chocolate chip cookies.\n^cyan;+^white;20% ^cyan;EP ^gray;(^white;150s^gray;), ^green;Heal ^white;100 ^gray;(^white;150s^gray;)^reset; ^orange;Type: Grain + Dairy + Eggs + Sugar^reset;",
   "shortdescription": "Chocolate Honey Cookies",
   "effects": [
     [

--- a/monsters/pandorasboxmonsterscripts/pandorasboxsimplefarmablemonster.lua
+++ b/monsters/pandorasboxmonsterscripts/pandorasboxsimplefarmablemonster.lua
@@ -54,6 +54,10 @@ function hasMonsterHarvest(args, board)
 	end
 end
 
+function isMonsterHarvestable(args, board)
+	return hasMonsterHarvest(args, board)
+end
+
 function update(dt)
 	originalUpdate(dt)
 	if config.getParameter("wildHarvestable") or config.getParameter("ownerUuid") then


### PR DESCRIPTION
- Farmbeast Harvester Turret now works on friendly Cottonbops
- Fixed typo in description of Chocolate Honey Cookies (it heals 100 hitpoints, not 1500).