### PR TITLE
Put times in descriptions for two foods

### DIFF
--- a/items/generic/food/awfuloffalsmoothie.consumable
+++ b/items/generic/food/awfuloffalsmoothie.consumable
@@ -4,7 +4,7 @@
 	"price": 60,
 	"category": "preparedFood",
 	"inventoryIcon": "awfuloffalsmoothie.png",
-	"description": "Blended rotten food. The greatest invention of Dupont Dewpawnt. ^red;-^reset;5^red;% Health^reset; 15^red;s Poisoned^reset; ^blue;Madness Gain^reset; 3 ^red;Type: Raw Meat Dairy Dessert^reset;",
+	"description": "Blended rotten food. The greatest invention of Dupont Dewpawnt. 90^red;s -^reset;5^red;% Health^reset; 15^red;s Poisoned^reset; ^blue;Madness Gain^reset; 3 ^red;Type: Raw Meat Dairy Dessert^reset;",
 	"shortdescription": "Awful Offal Smoothie",
 	"effects": [
         ["madnessgain2", "meatr_dairy_dessert",

--- a/items/generic/food/bloodyboogerbread.consumable
+++ b/items/generic/food/bloodyboogerbread.consumable
@@ -4,7 +4,7 @@
 	"price": 35,
 	"category": "preparedFood",
 	"inventoryIcon": "bloodyboogerbread.png",
-	"description": "Whose twisted idea was this?! Revolting! \n^red;-^reset;15^red;% Health^reset; \n^blue;Madness Gain^reset; 2",
+	"description": "Whose twisted idea was this?! Revolting! \n60^red;s -^reset;15^red;% Health^reset; \n^blue;Madness Gain^reset; 2",
 	"shortdescription": "Bloody Boogerbread",
 	"effects": [
 		["madnessgain",


### PR DESCRIPTION
## What Does This PR Do

Alters the description in the items 'Awful Offal Smoothie' and 'Bloody Booger Bread', so that the negative maximum health debuff's time is shown to the player in said item descriptions

## Why It's Good For The Mod

Most of the other consumables with debuffs display how long the debuffs will occur for in their description.