### PR TITLE
Remove explicit null from Lua files | Fixes #3682

### DIFF
--- a/interface/scripted/statWindow/statWindow.lua
+++ b/interface/scripted/statWindow/statWindow.lua
@@ -73,7 +73,7 @@ function update()
 			if(priority==stuff.priority) then
 				local listItem = "immunitiesList.textList."..widget.addListItem("immunitiesList.textList")
 				widget.setText(listItem..".immunity", stuff.name)
-				bufferList[thing]=null
+				bufferList[thing] = nil
 			end
 		end
 	end

--- a/objects/crafting/clonelab/clonelab.lua
+++ b/objects/crafting/clonelab/clonelab.lua
@@ -15,7 +15,7 @@ end
 function containerCallback()
   local items = world.containerItems(entity.id())
 
-  if items[1]~=null and items[2]~=null and
+  if items[1] and items[2] and
      items[1].name == "sapling" and items[2].name == "sapling" then
 
     local leafsample = items[2]


### PR DESCRIPTION
Replaced instances of `null` with `nil` in Lua code to preserve compatibility with forks using the former as a keyword, such as xStarbound. This fixes the latter's broken tricorder (#3682).