### PR TITLE
fix stupid people, I wish

### DIFF
--- a/items/active/weapons/weapon.lua
+++ b/items/active/weapons/weapon.lua
@@ -167,7 +167,8 @@ function Weapon:updateAim()
 	end
 
 	--activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation)
-	activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation, not self.stance.noAimCompensation)	 -- StardustLib edit; added allowRotate parameter
+	-- activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation, not self.stance.noAimCompensation)	 -- StardustLib edit; added allowRotate parameter
+	activeItem.setArmAngle(self.aimAngle + self.relativeArmRotation, self.stance.noAimCompensation==false) --khe note: fucking idiot. the above screws over other mods badly.
 
 	local isPrimary = activeItem.hand() == "primary"
 	if isPrimary then

--- a/radiomessages/fu_exploration.radiomessages
+++ b/radiomessages/fu_exploration.radiomessages
@@ -1,19 +1,19 @@
 {
   "researchBonus1" : {
     "unique" : false,
-    "text" : "You've gained a +^green;1^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
+    "text" : "You've gained a +^green;1^reset; passive ^orange;Research^reset; rate bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
   },
   "researchBonus2" : {
     "unique" : false,
-    "text" : "You've gained a +^green;2^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
+    "text" : "You've gained a +^green;2^reset; passive ^orange;Research^reset; rate bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
   },
   "researchBonus3" : {
     "unique" : false,
-    "text" : "You've gained a +^green;3^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
+    "text" : "You've gained a +^green;3^reset; passive ^orange;Research^reset; rate bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
   },
   "researchBonus4" : {
     "unique" : false,
-    "text" : "You've gained a +^green;4^reset; ^orange;Research^reset; bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
+    "text" : "You've gained a +^green;4^reset; passive ^orange;Research^reset; rate bonus based on your session playtime. ^red;This bonus will be disabled if you are AFK^reset;."
   },
   "upgrade_station" : {
     "type" : "quest",

--- a/species/vespoid.raceeffect
+++ b/species/vespoid.raceeffect
@@ -5,16 +5,20 @@
 			"effectiveMultiplier": 1.15
 		},
 		{
+			"stat": "maxEnergy",
+			"effectiveMultiplier": 1.05
+		},
+		{
 			"stat": "fallDamageMultiplier",
 			"effectiveMultiplier": 0.8
 		},
 		{
 			"stat": "fireResistance",
-			"amount": -0.5
+			"amount": -0.35
 		},
 		{
 			"stat": "iceResistance",
-			"amount": -0.3
+			"amount": -0.25
 		},
 		{
 			"stat": "poisonResistance",

--- a/species/vespoid.species.patch
+++ b/species/vespoid.species.patch
@@ -10,7 +10,7 @@
   ^orange;Diet^reset;: Herbivore, prefers sugary items.
 
 ^orange;Perks^reset;:
-  Health x^green;1.15^reset;, Fall Damage x^green;0.8^reset;, +^green;10^reset;% Speed
+  Health x^green;1.15^reset;, Energy x^green;1.05^reset;, Fall Damage x^green;0.8^reset;, +^green;10^reset;% Speed
   ^green;Resist^reset;: +^green;50^reset;% Poison
   ^cyan;Immune^reset;: Bee Stings, Honey
 
@@ -21,6 +21,6 @@
   Sniper Rifles/Machine Pistols: Damage x^green;1.15^reset;
 
 ^red;Weaknesses^reset;:
-  ^red;Resist^reset;: -^red;50^reset;% Fire, -^red;30^reset;% Ice"
+  ^red;Resist^reset;: -^red;35^reset;% Fire, -^red;25^reset;% Ice"
     }
 ]


### PR DESCRIPTION
fixed compatibility with modded flipslash abilities and other playermodel rotators. the weapon will now rotate with the player (usually.)

longform:
mod compatibility fix for a stardustlib import, sloppy code.  weapon.lua now explicitly checks for stance's noAimCompensation being false, rather than assuming that it is false if it isn't true. the result of the mistaken code was that any weaponability that rotated the player and didnt have this parameter in its stances (false or true) would rotate the player and not the weapon.